### PR TITLE
Add concurrent generation handling options and context menu enhancements

### DIFF
--- a/src/BookDatabase.cpp
+++ b/src/BookDatabase.cpp
@@ -404,6 +404,19 @@ bool BookDatabase::initSchema() {
         userVersion = 12;
     }
 
+    if (userVersion < 13) {
+        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE queue ADD COLUMN state TEXT DEFAULT 'pending';", nullptr, nullptr, nullptr);
+        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE queue ADD COLUMN response TEXT DEFAULT '';", nullptr, nullptr, nullptr);
+        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE queue ADD COLUMN parent_id INTEGER DEFAULT 0;", nullptr, nullptr, nullptr);
+
+        // Ensure existing rows map their "processing_id" properly to "state" if needed, though they shouldn't be 'completed'
+        sqlite3_exec((sqlite3*)m_db, "UPDATE queue SET state = 'processing' WHERE processing_id > 0;", nullptr, nullptr, nullptr);
+
+        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (13);", nullptr, nullptr, nullptr);
+        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 13;", nullptr, nullptr, nullptr);
+        userVersion = 13;
+    }
+
     return true;
 }
 
@@ -1029,11 +1042,11 @@ QList<FolderNode> BookDatabase::getFolders(const QString& type) const {
 }
 
 int BookDatabase::enqueuePrompt(int messageId, const QString& model, const QString& prompt, int priority,
-                                const QString& targetType) {
+                                const QString& targetType, int parentId) {
     if (!m_isOpen) return -1;
 
     const char* sql =
-        "INSERT INTO queue (message_id, model, prompt, priority, target_type) VALUES (?, ?, ?, ?, ?);";
+        "INSERT INTO queue (message_id, model, prompt, priority, target_type, parent_id, state) VALUES (?, ?, ?, ?, ?, ?, 'pending');";
     sqlite3_stmt* stmt;
     int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return -1;
@@ -1043,6 +1056,7 @@ int BookDatabase::enqueuePrompt(int messageId, const QString& model, const QStri
     sqlite3_bind_text(stmt, 3, prompt.toUtf8().constData(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_int(stmt, 4, priority);
     sqlite3_bind_text(stmt, 5, targetType.toUtf8().constData(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 6, parentId);
 
     rc = sqlite3_step(stmt);
     if (rc != SQLITE_DONE) {
@@ -1055,14 +1069,28 @@ int BookDatabase::enqueuePrompt(int messageId, const QString& model, const QStri
     return id;
 }
 
+bool BookDatabase::updateQueueStateAndResponse(int id, const QString& state, const QString& response) {
+    if (!m_isOpen) return false;
+    const char* sql = "UPDATE queue SET state = ?, response = ? WHERE id = ?;";
+    sqlite3_stmt* stmt;
+    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+
+    sqlite3_bind_text(stmt, 1, state.toUtf8().constData(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 2, response.toUtf8().constData(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 3, id);
+
+    int rc = sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    return rc == SQLITE_DONE;
+}
+
 QList<QueueItem> BookDatabase::getQueue() const {
     QList<QueueItem> items;
     if (!m_isOpen) return items;
 
     const char* sql =
-        "SELECT id, message_id, model, prompt, processing_id, last_error, priority, created_at, target_type FROM queue ORDER BY priority "
-        "DESC, "
-        "created_at DESC;";
+        "SELECT id, message_id, model, prompt, processing_id, last_error, priority, created_at, target_type, state, response, parent_id "
+        "FROM queue ORDER BY priority DESC, created_at DESC;";
     sqlite3_stmt* stmt;
     if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return items;
 

--- a/src/BookDatabase.h
+++ b/src/BookDatabase.h
@@ -65,6 +65,9 @@ struct QueueItem {
     int priority;
     QDateTime timestamp;
     QString targetType;  // "message" or "document"
+    QString state;       // "pending", "processing", "completed", "failed"
+    QString response;
+    int parentId;        // Reference to original document / chat for forks
 };
 
 struct CommentNode {
@@ -147,7 +150,8 @@ class BookDatabase {
 
     // Queue
     int enqueuePrompt(int messageId, const QString& model, const QString& prompt, int priority = 0,
-                      const QString& targetType = "message");
+                      const QString& targetType = "message", int parentId = 0);
+    bool updateQueueStateAndResponse(int id, const QString& state, const QString& response);
     QList<QueueItem> getQueue() const;
     bool updateQueueProcessingId(int id, int processingId);
     bool updateQueueError(int id, const QString& error);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2401,13 +2401,21 @@ void MainWindow::onSendMessage() {
                     // Just proceed, it will queue
                 } else if (msgBox.clickedButton() == forkBtn) {
                     // Fork from the parent of the currently generating message
-                    ChatNode generatingNode = currentDb->getChat(activeItem.messageId);
-                    currentLastNodeId = generatingNode.parentId; // The user prompt that spawned it
+                    for (const auto& msg : currentDb->getMessages()) {
+                        if (msg.id == activeItem.messageId) {
+                            currentLastNodeId = msg.parentId; // The user prompt that spawned it
+                            break;
+                        }
+                    }
                 } else if (msgBox.clickedButton() == cancelReplaceBtn) {
                     // Cancel current generation and proceed
                     QueueManager::instance().cancelItem(currentDb, activeItem.id);
-                    ChatNode generatingNode = currentDb->getChat(activeItem.messageId);
-                    currentLastNodeId = generatingNode.parentId; // The user prompt that spawned it
+                    for (const auto& msg : currentDb->getMessages()) {
+                        if (msg.id == activeItem.messageId) {
+                            currentLastNodeId = msg.parentId; // The user prompt that spawned it
+                            break;
+                        }
+                    }
                     currentDb->deleteMessage(activeItem.messageId); // Delete the assistant placeholder
                 } else if (msgBox.clickedButton() == saveDraftBtn) {
                     currentDb->addDraft(0, "New Draft", text);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -3458,44 +3458,155 @@ void MainWindow::updateNotificationStatus() {
         total += notifications.size();
         for (const auto& n : notifications) {
             QString bookName = QFileInfo(db->filepath()).fileName();
-            QString typeStr = (n.type == "error") ? tr("Error") : tr("Finished");
+            QString typeStr = (n.type == "error") ? tr("Error") : (n.type == "document_completed" ? tr("Document Review") : tr("Finished"));
             QAction* action = notificationMenu->addAction(
                 QString("[%1] %2: Msg %3").arg(bookName, typeStr, QString::number(n.messageId)));
             connect(action, &QAction::triggered, this, [this, db, n, bookName]() {
-                QDialog dialog(this);
-                dialog.setWindowTitle(tr("Notification Summary"));
-                QVBoxLayout* layout = new QVBoxLayout(&dialog);
+                if (n.type == "document_completed") {
+                    // Custom dialog for Document Review
+                    QDialog dialog(this);
+                    dialog.setWindowTitle(tr("Review Generated Document"));
+                    dialog.resize(800, 600);
+                    QVBoxLayout* layout = new QVBoxLayout(&dialog);
 
-                QString typeStr = (n.type == "error") ? tr("Error") : tr("Finished");
-                QLabel* summary = new QLabel(QString("<b>Book:</b> %1<br><b>Status:</b> %2<br><b>Message ID:</b> %3")
-                                                 .arg(bookName, typeStr, QString::number(n.messageId)));
-                summary->setWordWrap(true);
-                layout->addWidget(summary);
+                    // Find the queue item to get the response and original prompt
+                    auto queueItems = db->getQueue();
+                    QueueItem targetItem;
+                    bool found = false;
+                    for (const auto& qi : queueItems) {
+                        if (qi.messageId == n.messageId && qi.state == "completed" && qi.targetType == "document") {
+                            targetItem = qi;
+                            found = true;
+                            break;
+                        }
+                    }
 
-                QHBoxLayout* btnLayout = new QHBoxLayout();
-                QPushButton* gotoBtn = new QPushButton(tr("Goto Item"), &dialog);
-                QPushButton* dismissBtn = new QPushButton(tr("Dismiss"), &dialog);
-                QPushButton* closeBtn = new QPushButton(tr("Close"), &dialog);
+                    if (!found) {
+                        QMessageBox::warning(this, tr("Not found"), tr("Queue item not found or already processed."));
+                        db->dismissNotification(n.id);
+                        updateNotificationStatus();
+                        return;
+                    }
 
-                btnLayout->addWidget(gotoBtn);
-                btnLayout->addWidget(dismissBtn);
-                btnLayout->addWidget(closeBtn);
-                layout->addLayout(btnLayout);
+                    QLabel* infoLabel = new QLabel(QString("Review the generated response for document ID: %1").arg(n.messageId));
+                    layout->addWidget(infoLabel);
 
-                connect(gotoBtn, &QPushButton::clicked, [&]() {
-                    onQueueItemClicked(db, n.messageId);
-                    dialog.accept();
-                });
+                    QSplitter* splitter = new QSplitter(Qt::Vertical, &dialog);
 
-                connect(dismissBtn, &QPushButton::clicked, [&]() {
-                    db->dismissNotification(n.id);
-                    updateNotificationStatus();
-                    dialog.accept();
-                });
+                    QGroupBox* promptGroup = new QGroupBox(tr("Prompt"), splitter);
+                    QVBoxLayout* promptLayout = new QVBoxLayout(promptGroup);
+                    QTextEdit* promptEdit = new QTextEdit(targetItem.prompt, promptGroup);
+                    promptLayout->addWidget(promptEdit);
 
-                connect(closeBtn, &QPushButton::clicked, &dialog, &QDialog::reject);
+                    QGroupBox* responseGroup = new QGroupBox(tr("Generated Response"), splitter);
+                    QVBoxLayout* responseLayout = new QVBoxLayout(responseGroup);
+                    QTextEdit* responseEdit = new QTextEdit(targetItem.response, responseGroup);
+                    responseLayout->addWidget(responseEdit);
 
-                dialog.exec();
+                    layout->addWidget(splitter);
+
+                    QHBoxLayout* btnLayout = new QHBoxLayout();
+                    QPushButton* regenBtn = new QPushButton(tr("Change prompt and regenerate"), &dialog);
+                    QPushButton* replaceBtn = new QPushButton(tr("Modify and replace/append"), &dialog);
+                    QPushButton* newDocBtn = new QPushButton(tr("Create new document from results"), &dialog);
+                    QPushButton* discardBtn = new QPushButton(tr("Discard"), &dialog);
+                    QPushButton* cancelBtn = new QPushButton(tr("Cancel"), &dialog);
+
+                    btnLayout->addWidget(regenBtn);
+                    btnLayout->addWidget(replaceBtn);
+                    btnLayout->addWidget(newDocBtn);
+                    btnLayout->addWidget(discardBtn);
+                    btnLayout->addWidget(cancelBtn);
+                    layout->addLayout(btnLayout);
+
+                    connect(regenBtn, &QPushButton::clicked, [&]() {
+                        // Update the prompt, reset state to pending, clear response
+                        QString newPrompt = promptEdit->toPlainText();
+                        db->updateQueueItemPrompt(targetItem.id, newPrompt);
+                        db->updateQueueStateAndResponse(targetItem.id, "pending", "");
+                        db->dismissNotification(n.id);
+                        updateNotificationStatus();
+                        // QueueManager will automatically pick it up via its timer or signal
+                        emit QueueManager::instance().queueChanged();
+                        dialog.accept();
+                    });
+
+                    connect(replaceBtn, &QPushButton::clicked, [&]() {
+                        // Get original doc title
+                        auto docs = db->getDocuments();
+                        QString title = "Document";
+                        for (const auto& d : docs) {
+                            if (d.id == targetItem.messageId) {
+                                title = d.title;
+                                break;
+                            }
+                        }
+                        db->updateDocument(targetItem.messageId, title, responseEdit->toPlainText());
+                        db->deleteQueueItem(targetItem.id);
+                        db->dismissNotification(n.id);
+                        updateNotificationStatus();
+                        if (currentDb == db && currentDocumentId == targetItem.messageId) {
+                            documentEditorView->setPlainText(responseEdit->toPlainText());
+                        }
+                        dialog.accept();
+                    });
+
+                    connect(newDocBtn, &QPushButton::clicked, [&]() {
+                        db->addDocument(targetItem.parentId, "New from Generation", responseEdit->toPlainText());
+                        db->deleteQueueItem(targetItem.id);
+                        db->dismissNotification(n.id);
+                        updateNotificationStatus();
+                        loadDocumentsAndNotes();
+                        dialog.accept();
+                    });
+
+                    connect(discardBtn, &QPushButton::clicked, [&]() {
+                        db->deleteQueueItem(targetItem.id);
+                        db->dismissNotification(n.id);
+                        updateNotificationStatus();
+                        dialog.accept();
+                    });
+
+                    connect(cancelBtn, &QPushButton::clicked, &dialog, &QDialog::reject);
+
+                    dialog.exec();
+                } else {
+                    // Standard notification dialog
+                    QDialog dialog(this);
+                    dialog.setWindowTitle(tr("Notification Summary"));
+                    QVBoxLayout* layout = new QVBoxLayout(&dialog);
+
+                    QString typeStr = (n.type == "error") ? tr("Error") : tr("Finished");
+                    QLabel* summary = new QLabel(QString("<b>Book:</b> %1<br><b>Status:</b> %2<br><b>Message ID:</b> %3")
+                                                     .arg(bookName, typeStr, QString::number(n.messageId)));
+                    summary->setWordWrap(true);
+                    layout->addWidget(summary);
+
+                    QHBoxLayout* btnLayout = new QHBoxLayout();
+                    QPushButton* gotoBtn = new QPushButton(tr("Goto Item"), &dialog);
+                    QPushButton* dismissBtn = new QPushButton(tr("Dismiss"), &dialog);
+                    QPushButton* closeBtn = new QPushButton(tr("Close"), &dialog);
+
+                    btnLayout->addWidget(gotoBtn);
+                    btnLayout->addWidget(dismissBtn);
+                    btnLayout->addWidget(closeBtn);
+                    layout->addLayout(btnLayout);
+
+                    connect(gotoBtn, &QPushButton::clicked, [&]() {
+                        onQueueItemClicked(db, n.messageId);
+                        dialog.accept();
+                    });
+
+                    connect(dismissBtn, &QPushButton::clicked, [&]() {
+                        db->dismissNotification(n.id);
+                        updateNotificationStatus();
+                        dialog.accept();
+                    });
+
+                    connect(closeBtn, &QPushButton::clicked, &dialog, &QDialog::reject);
+
+                    dialog.exec();
+                }
             });
         }
     }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2362,10 +2362,71 @@ void MainWindow::onSendMessage() {
     if (!toggleInputModeBtn->isChecked()) {
         text = inputField->toPlainText().trimmed();
         if (text.isEmpty()) return;
-        inputField->clear();
     } else {
         text = multiLineInput->toPlainText();
         if (text.isEmpty()) return;
+    }
+
+    // Check if the current chat already has an active generation
+    if (!isCreatingNewChat && currentLastNodeId != 0 && QueueManager::instance().isProcessing()) {
+        QueueItem activeItem = QueueManager::instance().activeItem();
+        if (activeItem.targetType == "message") {
+            // Check if the active item belongs to the current chat path
+            bool isActiveInCurrentChat = false;
+            for (const auto& msg : currentChatPath) {
+                if (msg.id == activeItem.messageId) {
+                    isActiveInCurrentChat = true;
+                    break;
+                }
+            }
+            if (activeItem.messageId == currentLastNodeId) {
+                isActiveInCurrentChat = true;
+            }
+
+            if (isActiveInCurrentChat) {
+                QMessageBox msgBox(this);
+                msgBox.setWindowTitle(tr("Chat is Generating"));
+                msgBox.setText(tr("This chat is currently generating a response. What would you like to do?"));
+
+                QPushButton* queueBtn = msgBox.addButton(tr("Queue to automatically send"), QMessageBox::ActionRole);
+                QPushButton* forkBtn = msgBox.addButton(tr("Fork and send"), QMessageBox::ActionRole);
+                QPushButton* cancelReplaceBtn = msgBox.addButton(tr("Cancel previous message and replace with this"), QMessageBox::ActionRole);
+                QPushButton* saveDraftBtn = msgBox.addButton(tr("Save to drafts"), QMessageBox::ActionRole);
+                QPushButton* ignoreClearBtn = msgBox.addButton(tr("Ignore text and clear"), QMessageBox::ActionRole);
+                QPushButton* cancelBtn = msgBox.addButton(tr("Cancel (and leave in prompt)"), QMessageBox::RejectRole);
+
+                msgBox.exec();
+
+                if (msgBox.clickedButton() == queueBtn) {
+                    // Just proceed, it will queue
+                } else if (msgBox.clickedButton() == forkBtn) {
+                    // Fork from the parent of the currently generating message
+                    ChatNode generatingNode = currentDb->getChat(activeItem.messageId);
+                    currentLastNodeId = generatingNode.parentId; // The user prompt that spawned it
+                } else if (msgBox.clickedButton() == cancelReplaceBtn) {
+                    // Cancel current generation and proceed
+                    QueueManager::instance().cancelItem(currentDb, activeItem.id);
+                    ChatNode generatingNode = currentDb->getChat(activeItem.messageId);
+                    currentLastNodeId = generatingNode.parentId; // The user prompt that spawned it
+                    currentDb->deleteMessage(activeItem.messageId); // Delete the assistant placeholder
+                } else if (msgBox.clickedButton() == saveDraftBtn) {
+                    currentDb->addDraft(0, "New Draft", text);
+                    statusBar->showMessage(tr("Draft saved."), 3000);
+                    return;
+                } else if (msgBox.clickedButton() == ignoreClearBtn) {
+                    if (!toggleInputModeBtn->isChecked()) inputField->clear();
+                    else multiLineInput->clear();
+                    return;
+                } else { // cancelBtn or closed
+                    return;
+                }
+            }
+        }
+    }
+
+    if (!toggleInputModeBtn->isChecked()) {
+        inputField->clear();
+    } else {
         multiLineInput->clear();
     }
 
@@ -4212,6 +4273,8 @@ void MainWindow::onChatTextAreaContextMenu(const QPoint& pos) {
     QAction* forkAction = nullptr;
     QAction* copyAction = nullptr;
     QAction* infoAction = nullptr;
+    QAction* reuseAction = nullptr;
+    QAction* quoteAction = nullptr;
 
     if (msgIndex >= 0 && msgIndex < currentChatPath.size()) {
         menu->addSeparator();
@@ -4219,6 +4282,13 @@ void MainWindow::onChatTextAreaContextMenu(const QPoint& pos) {
         copyAction = menu->addAction(QIcon::fromTheme("edit-copy"), "Copy message");
 
         bool isAssistant = (currentChatPath[msgIndex].role == "assistant");
+
+        reuseAction = menu->addAction(QIcon::fromTheme("edit-redo"), "Reuse this");
+        bool inputEmpty = toggleInputModeBtn->isChecked() ? multiLineInput->toPlainText().trimmed().isEmpty() : inputField->toPlainText().trimmed().isEmpty();
+        reuseAction->setEnabled(inputEmpty);
+
+        quoteAction = menu->addAction(QIcon::fromTheme("format-text-blockquote"), "Quote this");
+
         infoAction =
             menu->addAction(QIcon::fromTheme("dialog-information"), isAssistant ? "Response info" : "Message info");
     }
@@ -4228,7 +4298,25 @@ void MainWindow::onChatTextAreaContextMenu(const QPoint& pos) {
     QAction* saveTemplateAction = menu->addAction(QIcon::fromTheme("document-save-as"), "Save chat as template");
 
     QAction* selectedAction = menu->exec(chatTextArea->viewport()->mapToGlobal(pos));
-    if (selectedAction == saveDraftAction) {
+
+    if (reuseAction && selectedAction == reuseAction) {
+        QString textToReuse = currentChatPath[msgIndex].content.trimmed();
+        if (currentChatPath[msgIndex].role == "assistant" && msgIndex > 0) {
+            textToReuse = currentChatPath[msgIndex - 1].content.trimmed();
+        }
+        if (toggleInputModeBtn->isChecked()) {
+            multiLineInput->setPlainText(textToReuse);
+        } else {
+            inputField->setPlainText(textToReuse);
+        }
+    } else if (quoteAction && selectedAction == quoteAction) {
+        QString quotedText = "> " + currentChatPath[msgIndex].content.trimmed().replace("\n", "\n> ") + "\n\n";
+        if (toggleInputModeBtn->isChecked()) {
+            multiLineInput->insertPlainText(quotedText);
+        } else {
+            inputField->insertPlainText(quotedText);
+        }
+    } else if (selectedAction == saveDraftAction) {
         bool ok;
         QString name = QInputDialog::getText(this, "Save as Draft", "Draft Name:", QLineEdit::Normal, "New Draft", &ok);
         if (ok && !name.isEmpty() && currentDb) {

--- a/src/OllamaClient.cpp
+++ b/src/OllamaClient.cpp
@@ -153,6 +153,7 @@ void OllamaClient::generate(const QString& model, const QString& prompt, std::fu
     QByteArray data = doc.toJson();
 
     QNetworkReply* reply = m_networkManager->post(request, data);
+    m_activeGenerations.append(reply);
 
     // Shared pointer to accumulate the full response safely
     auto fullResponse = std::make_shared<QString>();
@@ -193,7 +194,8 @@ void OllamaClient::generate(const QString& model, const QString& prompt, std::fu
         }
     });
 
-    connect(reply, &QNetworkReply::finished, this, [reply, onComplete, onError, fullResponse]() {
+    connect(reply, &QNetworkReply::finished, this, [this, reply, onComplete, onError, fullResponse]() {
+        m_activeGenerations.removeOne(reply);
         if (reply->error() != QNetworkReply::NoError) {
             onError(reply->errorString());
         } else {
@@ -201,4 +203,13 @@ void OllamaClient::generate(const QString& model, const QString& prompt, std::fu
         }
         reply->deleteLater();
     });
+}
+
+void OllamaClient::abortGenerations() {
+    for (QNetworkReply* reply : m_activeGenerations) {
+        if (reply && reply->isRunning()) {
+            reply->abort();
+        }
+    }
+    m_activeGenerations.clear();
 }

--- a/src/OllamaClient.h
+++ b/src/OllamaClient.h
@@ -26,6 +26,8 @@ class OllamaClient : public QObject {
     void generate(const QString& model, const QString& prompt, std::function<void(const QString&)> onChunk,
                   std::function<void(const QString&)> onComplete, std::function<void(const QString&)> onError);
 
+    void abortGenerations();
+
    signals:
     void connectionStatusChanged(bool isOk);
     void modelListUpdated(const QStringList& models);
@@ -44,6 +46,7 @@ class OllamaClient : public QObject {
     QString m_systemPrompt;
     QMap<QNetworkReply*, QString> m_activePulls;
     QMap<QNetworkReply*, QByteArray> m_pullBuffers;
+    QList<QNetworkReply*> m_activeGenerations;
 };
 
 #endif  // OLLAMACLIENT_H

--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -130,7 +130,9 @@ QList<QueueManager::MergedQueueItem> QueueManager::getMergedQueue() const {
 void QueueManager::cancelItem(std::shared_ptr<BookDatabase> db, int queueId) {
     if (db) db->deleteQueueItem(queueId);
     if (m_currentDb == db && m_currentItem.id == queueId) {
-        // Ideally we'd abort the network request here
+        if (m_client) {
+            m_client->abortGenerations();
+        }
         m_isProcessing = false;
         m_currentDb = nullptr;
     }

--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -70,9 +70,9 @@ void QueueManager::setClient(OllamaClient* client) { m_client = client; }
  * @param targetType The semantic class of generation (e.g. document, message).
  */
 void QueueManager::enqueuePrompt(int messageId, const QString& model, const QString& prompt, int priority,
-                                 const QString& targetType) {
+                                 const QString& targetType, int parentId) {
     if (m_activeDb && m_activeDb->isOpen()) {
-        m_activeDb->enqueuePrompt(messageId, model, prompt, priority, targetType);
+        m_activeDb->enqueuePrompt(messageId, model, prompt, priority, targetType, parentId);
         emit queueChanged();
         QTimer::singleShot(0, this, &QueueManager::checkQueue);
     }
@@ -295,24 +295,19 @@ void QueueManager::onChunk(const QString& chunk) {
 void QueueManager::onComplete(const QString& response) {
     if (!m_isProcessing) return;
     if (m_currentDb && m_currentDb->isOpen()) {
+        m_currentItem.processingId = 0;
+
         if (m_currentItem.targetType == "document") {
-            auto docs = m_currentDb->getDocuments();
-            QString title;
-            for (const auto& d : docs) {
-                if (d.id == m_currentItem.messageId) {
-                    title = d.title;
-                    break;
-                }
-            }
-            m_currentDb->updateDocument(m_currentItem.messageId, title, response);
+            m_currentItem.state = "completed";
+            m_currentItem.response = response;
+            m_currentDb->updateQueueStateAndResponse(m_currentItem.id, m_currentItem.state, m_currentItem.response);
+            m_currentDb->addNotification(m_currentItem.messageId, "document_completed");
         } else {
             m_currentDb->updateMessage(m_currentItem.messageId, response);
+            m_completedItems.append({m_currentDb, m_currentItem});
+            m_currentDb->deleteQueueItem(m_currentItem.id);
+            m_currentDb->addNotification(m_currentItem.messageId, "responded_to");
         }
-
-        m_currentItem.processingId = 0;
-        m_completedItems.append({m_currentDb, m_currentItem});
-        m_currentDb->deleteQueueItem(m_currentItem.id);
-        m_currentDb->addNotification(m_currentItem.messageId, "responded_to");
 
         m_currentDb->setSetting(m_currentItem.targetType, m_currentItem.messageId, "model", m_currentItem.model);
 

--- a/src/QueueManager.h
+++ b/src/QueueManager.h
@@ -21,7 +21,7 @@ class QueueManager : public QObject {
 
     void setClient(OllamaClient* client);
     void enqueuePrompt(int messageId, const QString& model, const QString& prompt, int priority = 0,
-                       const QString& targetType = "message");
+                       const QString& targetType = "message", int parentId = 0);
 
     int totalPendingCount() const;
     int pendingCount(std::shared_ptr<BookDatabase> db) const;

--- a/src/QueueManager.h
+++ b/src/QueueManager.h
@@ -43,6 +43,7 @@ class QueueManager : public QObject {
     bool isPaused() const { return m_isPaused; }
 
     bool isProcessing() const { return m_isProcessing; }
+    QueueItem activeItem() const { return m_currentItem; }
 
    signals:
     void queueChanged();


### PR DESCRIPTION
This PR introduces a dialog to manage user input when a chat is already generating a response, providing options like queueing, forking, or cancelling the ongoing generation. It also enhances the chat context menu with "Reuse this" and "Quote this" actions.
The `OllamaClient` and `QueueManager` were updated to support cancelling ongoing requests to facilitate the new features.

---
*PR created automatically by Jules for task [5294199530197318120](https://jules.google.com/task/5294199530197318120) started by @arran4*