### PR TITLE
Fix compilation error caused by incomplete KToolBar type

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -34,6 +34,7 @@
 #include <QScreen>
 #include <QScrollArea>
 #include <QSettings>
+#include <KToolBar>
 #include <QSpinBox>
 #include <QStandardPaths>
 #include <QStyle>
@@ -701,7 +702,7 @@ void MainWindow::setupUi() {
 
     setupGUI(Default, ":/kllamabooksui.rc");
 
-    QToolBar* mainToolBar = toolBar("mainToolBar");
+    KToolBar* mainToolBar = toolBar("mainToolBar");
     if (mainToolBar) {
         // Endpoints in toolbar
         QWidget* spacer = new QWidget(this);


### PR DESCRIPTION
Fix compilation error caused by incomplete KToolBar type

Included `<KToolBar>` in `MainWindow.cpp` and explicitly used the `KToolBar*` type when retrieving the main toolbar via `toolBar("mainToolBar")`.
This resolves a compilation error where `KToolBar*` could not be converted to `QToolBar*` due to `KToolBar` only being forward-declared in KDE framework headers.

---
*PR created automatically by Jules for task [8277339040333591505](https://jules.google.com/task/8277339040333591505) started by @arran4*