### PR TITLE
Update Dockerfile base image to debian:testing

### DIFF
--- a/.jules/Dockerfile
+++ b/.jules/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/debian:trixie
+FROM debian:testing
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
This commit updates the base image in `.jules/Dockerfile` from `public.ecr.aws/docker/library/debian:trixie` to `debian:testing`. This makes it use the standard Docker Hub repository for the Debian testing branch instead of the AWS ECR mirror for trixie. All other contents remain the same.

---
*PR created automatically by Jules for task [17379992892960777639](https://jules.google.com/task/17379992892960777639) started by @arran4*