### PR TITLE
Remove action after generation prompt from AIOperationsDialog

### DIFF
--- a/src/AIOperationsDialog.cpp
+++ b/src/AIOperationsDialog.cpp
@@ -24,16 +24,6 @@ AIOperationsDialog::AIOperationsDialog(const QString& defaultPrompt, QWidget* pa
     opLayout->addWidget(m_operationCombo, 1);
     layout->addLayout(opLayout);
 
-    // Target Action
-    QHBoxLayout* targetActionLayout = new QHBoxLayout();
-    targetActionLayout->addWidget(new QLabel(tr("Action after generation:")));
-    m_targetActionCombo = new QComboBox(this);
-    m_targetActionCombo->addItem(tr("Review & Replace Original"), "replace");
-    m_targetActionCombo->addItem(tr("Review & Append to Original"), "append");
-    m_targetActionCombo->addItem(tr("Review & Create New Document"), "fork");
-    targetActionLayout->addWidget(m_targetActionCombo, 1);
-    layout->addLayout(targetActionLayout);
-
     // Prompt
     layout->addWidget(new QLabel(tr("Prompt Instructions:")));
     m_promptEdit = new QTextEdit(this);
@@ -88,15 +78,10 @@ QString AIOperationsDialog::getOperation() const { return m_operationCombo->curr
 
 QString AIOperationsDialog::getPrompt() const { return m_promptEdit->toPlainText(); }
 
-QString AIOperationsDialog::getTargetAction() const { return m_targetActionCombo->currentData().toString(); }
-
 void AIOperationsDialog::setForkOnlyMode(bool enabled) {
     if (enabled) {
         m_operationCombo->setEnabled(false);
-        m_targetActionCombo->setCurrentIndex(m_targetActionCombo->findData("fork"));
-        m_targetActionCombo->setEnabled(false);
     } else {
         m_operationCombo->setEnabled(true);
-        m_targetActionCombo->setEnabled(true);
     }
 }

--- a/src/AIOperationsDialog.h
+++ b/src/AIOperationsDialog.h
@@ -15,13 +15,11 @@ class AIOperationsDialog : public QDialog {
 
     QString getOperation() const;
     QString getPrompt() const;
-    QString getTargetAction() const;
 
     void setForkOnlyMode(bool enabled);
 
    private:
     QComboBox* m_operationCombo;
-    QComboBox* m_targetActionCombo;
     QTextEdit* m_promptEdit;
 };
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -4234,9 +4234,7 @@ void MainWindow::onDocumentAIOperations() {
             model = m_availableModels.first();
         }
 
-        QString targetAction = dialog.getTargetAction();
-
-        QueueManager::instance().enqueuePrompt(currentDocumentId, model, prompt, 0, "document", 0, targetAction);
+        QueueManager::instance().enqueuePrompt(currentDocumentId, model, prompt, 0, "document", 0, "");
         statusBar->showMessage(tr("AI document task queued."), 3000);
     }
 }


### PR DESCRIPTION
This PR removes the redundant "action after generation" dropdown from the `AIOperationsDialog`. The choice is handled after generation completes, making the initial prompt unnecessary.

---
*PR created automatically by Jules for task [12083104210003164128](https://jules.google.com/task/12083104210003164128) started by @arran4*