### PR TITLE
Implement Ollama /api/chat endpoint for full conversation context

### DIFF
--- a/src/OllamaClient.cpp
+++ b/src/OllamaClient.cpp
@@ -204,3 +204,107 @@ void OllamaClient::generate(const QString& model, const QString& prompt, std::fu
         reply->deleteLater();
     });
 }
+
+/**
+ * @brief Opens a POST stream sequence to the Ollama chat endpoint.
+ *
+ * @param model The target model hash or tag.
+ * @param messages The complete chat history in the format required by Ollama API.
+ * @param onChunk Fired per JSON line received.
+ * @param onComplete Fired when the JSON EOF boolean is detected.
+ * @param onError Fired on socket or HTTP error conditions.
+ */
+void OllamaClient::generateChat(const QString& model, const QJsonArray& messages,
+                                std::function<void(const QString&)> onChunk,
+                                std::function<void(const QString&)> onComplete,
+                                std::function<void(const QString&)> onError) {
+    QUrl url(m_baseUrl + "/api/chat");
+    QNetworkRequest request(url);
+    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+    if (!m_authKey.isEmpty()) {
+        request.setRawHeader("Authorization", ("Bearer " + m_authKey).toUtf8());
+    }
+
+    QJsonObject json;
+    json["model"] = model;
+    json["messages"] = messages;
+    json["stream"] = true;
+
+    if (!m_systemPrompt.isEmpty()) {
+        // According to Ollama API documentation, system prompt can be passed either
+        // as a top level parameter in chat or injected as a system role message.
+        // We will stick to top-level `system` property if they support it, but
+        // it is safer to inject it as the first message with role="system".
+        QJsonObject sysMsg;
+        sysMsg["role"] = "system";
+        sysMsg["content"] = m_systemPrompt;
+
+        QJsonArray newMessages;
+        newMessages.append(sysMsg);
+        for (const auto& msg : messages) {
+            newMessages.append(msg);
+        }
+        json["messages"] = newMessages;
+    }
+
+    QJsonDocument doc(json);
+    QByteArray data = doc.toJson();
+
+    // Re-use requestSent with stringified prompt to maintain compatibility with GlobalSpy
+    QJsonDocument debugDoc(json["messages"].toArray());
+    emit requestSent(model, m_systemPrompt, QString(debugDoc.toJson(QJsonDocument::Compact)));
+
+    QNetworkReply* reply = m_networkManager->post(request, data);
+
+    auto fullResponse = std::make_shared<QString>();
+    auto buffer = std::make_shared<QByteArray>();
+
+    connect(reply, &QNetworkReply::readyRead, this, [this, reply, onChunk, fullResponse, buffer]() {
+        buffer->append(reply->readAll());
+
+        while (true) {
+            int newlineIndex = buffer->indexOf('\n');
+            if (newlineIndex == -1) break;
+
+            QByteArray line = buffer->left(newlineIndex);
+            buffer->remove(0, newlineIndex + 1);
+
+            if (line.trimmed().isEmpty()) continue;
+
+            QJsonParseError error;
+            QJsonDocument doc = QJsonDocument::fromJson(line, &error);
+            if (error.error == QJsonParseError::NoError && doc.isObject()) {
+                QJsonObject obj = doc.object();
+
+                // For /api/chat, the actual response string is nested inside "message" object
+                QString responsePart;
+                if (obj.contains("message") && obj.value("message").isObject()) {
+                    responsePart = obj.value("message").toObject().value("content").toString();
+                }
+
+                if (!responsePart.isEmpty()) {
+                    fullResponse->append(responsePart);
+                    onChunk(responsePart);
+                }
+
+                if (obj.value("done").toBool()) {
+                    double evalCount = obj.value("eval_count").toDouble();
+                    double evalDuration = obj.value("eval_duration").toDouble();
+                    if (evalDuration > 0 && evalCount > 0) {
+                        double tokensPerSecond = (evalCount / evalDuration) * 1e9;
+                        emit generationMetrics(tokensPerSecond);
+                    }
+                }
+            }
+        }
+    });
+
+    connect(reply, &QNetworkReply::finished, this, [reply, onComplete, onError, fullResponse]() {
+        if (reply->error() != QNetworkReply::NoError) {
+            onError(reply->errorString());
+        } else {
+            onComplete(*fullResponse);
+        }
+        reply->deleteLater();
+    });
+}

--- a/src/OllamaClient.h
+++ b/src/OllamaClient.h
@@ -26,6 +26,9 @@ class OllamaClient : public QObject {
     void generate(const QString& model, const QString& prompt, std::function<void(const QString&)> onChunk,
                   std::function<void(const QString&)> onComplete, std::function<void(const QString&)> onError);
 
+    void generateChat(const QString& model, const QJsonArray& messages, std::function<void(const QString&)> onChunk,
+                      std::function<void(const QString&)> onComplete, std::function<void(const QString&)> onError);
+
    signals:
     void connectionStatusChanged(bool isOk);
     void modelListUpdated(const QStringList& models);

--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -2,6 +2,8 @@
 
 #include <QCoreApplication>
 #include <QDebug>
+#include <QJsonArray>
+#include <QJsonObject>
 #include <QRegularExpression>
 #include <QTimer>
 
@@ -254,9 +256,57 @@ void QueueManager::processNext() {
     }
     m_client->setSystemPrompt(sysPrompt);
 
-    m_client->generate(
-        m_currentItem.model, m_currentItem.prompt, [this](const QString& chunk) { onChunk(chunk); },
-        [this](const QString& response) { onComplete(response); }, [this](const QString& error) { onError(error); });
+    if (m_currentItem.targetType == "message") {
+        QJsonArray messagesArray;
+        QList<MessageNode> allMessages = m_currentDb->getMessages();
+
+        // Tracing back from the target ai message's parent (which is the user message) to the root
+        QList<MessageNode> path;
+        int currentId = 0;
+
+        // Find the AI message first to get its parent
+        for (const auto& msg : allMessages) {
+            if (msg.id == m_currentItem.messageId) {
+                currentId = msg.parentId;
+                break;
+            }
+        }
+
+        while (currentId != 0) {
+            bool found = false;
+            for (const auto& msg : allMessages) {
+                if (msg.id == currentId) {
+                    path.prepend(msg);
+                    currentId = msg.parentId;
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) break;  // Break if tree is broken
+        }
+
+        for (int i = 0; i < path.size(); ++i) {
+            QJsonObject msgObj;
+            msgObj["role"] = path[i].role;
+            // For the last user message, we use the potentially updated prompt from the queue
+            if (i == path.size() - 1 && path[i].role == "user") {
+                msgObj["content"] = m_currentItem.prompt;
+            } else {
+                msgObj["content"] = path[i].content;
+            }
+            messagesArray.append(msgObj);
+        }
+
+        m_client->generateChat(
+            m_currentItem.model, messagesArray, [this](const QString& chunk) { onChunk(chunk); },
+            [this](const QString& response) { onComplete(response); },
+            [this](const QString& error) { onError(error); });
+    } else {
+        m_client->generate(
+            m_currentItem.model, m_currentItem.prompt, [this](const QString& chunk) { onChunk(chunk); },
+            [this](const QString& response) { onComplete(response); },
+            [this](const QString& error) { onError(error); });
+    }
 }
 
 /**


### PR DESCRIPTION
This change addresses the issue where the model was replying without the context of previous messages. 

It implements the `/api/chat` endpoint in `OllamaClient` via a new `generateChat` function and updates `QueueManager` to trace the history and build the array of objects (`{role: '...', content: '...'}`). This makes the model aware of the full conversation context.

---
*PR created automatically by Jules for task [3979298509983998456](https://jules.google.com/task/3979298509983998456) started by @arran4*