### PR TITLE
Fix model download status UI

### DIFF
--- a/src/ModelExplorer.cpp
+++ b/src/ModelExplorer.cpp
@@ -87,6 +87,10 @@ void ModelExplorer::setupDownloadingTab() {
 
     layout->addWidget(m_downloadingTable);
 
+    QPushButton* clearButton = new QPushButton("Clear Finished", this);
+    layout->addWidget(clearButton);
+    connect(clearButton, &QPushButton::clicked, this, &ModelExplorer::onClearFinishedDownloadsClicked);
+
     m_tabWidget->addTab(tab, "Downloading");
 }
 
@@ -177,14 +181,31 @@ void ModelExplorer::onPullProgressUpdated(const QString& modelName, int percent,
     }
 }
 
-void ModelExplorer::onPullFinished(const QString& modelName) {
+void ModelExplorer::onPullFinished(const QString& modelName, bool success, const QString& errorString) {
     for (int row = 0; row < m_downloadingTable->rowCount(); ++row) {
         if (m_downloadingTable->item(row, 0)->text() == modelName) {
-            m_downloadingTable->removeRow(row);
+            if (success) {
+                m_downloadingTable->item(row, 1)->setText("Completed");
+                QProgressBar* progressBar = qobject_cast<QProgressBar*>(m_downloadingTable->cellWidget(row, 2));
+                if (progressBar) {
+                    progressBar->setValue(100);
+                }
+            } else {
+                m_downloadingTable->item(row, 1)->setText("Error: " + errorString);
+            }
             break;
         }
     }
     m_client->fetchModels();  // Refresh installed list
+}
+
+void ModelExplorer::onClearFinishedDownloadsClicked() {
+    for (int row = m_downloadingTable->rowCount() - 1; row >= 0; --row) {
+        QString status = m_downloadingTable->item(row, 1)->text();
+        if (status == "Completed" || status.startsWith("Error:")) {
+            m_downloadingTable->removeRow(row);
+        }
+    }
 }
 
 void ModelExplorer::showInstalledContextMenu(const QPoint& pos) {

--- a/src/ModelExplorer.h
+++ b/src/ModelExplorer.h
@@ -25,8 +25,9 @@ class ModelExplorer : public QDialog {
     void onDownloadModelClicked();
     void updateModelList(const QStringList& models);
     void onPullProgressUpdated(const QString& modelName, int percent, const QString& status);
-    void onPullFinished(const QString& modelName);
+    void onPullFinished(const QString& modelName, bool success, const QString& errorString);
     void showInstalledContextMenu(const QPoint& pos);
+    void onClearFinishedDownloadsClicked();
 
    private:
     OllamaClient* m_client;

--- a/src/OllamaClient.cpp
+++ b/src/OllamaClient.cpp
@@ -81,7 +81,11 @@ void OllamaClient::pullModel(const QString& modelName) {
     m_activePulls[reply] = modelName;
     m_pullBuffers[reply] = QByteArray();
 
-    connect(reply, &QNetworkReply::readyRead, this, [this, reply, modelName]() {
+    // We'll track if there was an error in the streaming JSON
+    auto hasError = std::make_shared<bool>(false);
+    auto errorMsg = std::make_shared<QString>("");
+
+    connect(reply, &QNetworkReply::readyRead, this, [this, reply, modelName, hasError, errorMsg]() {
         m_pullBuffers[reply].append(reply->readAll());
         QByteArray& buffer = m_pullBuffers[reply];
 
@@ -98,6 +102,14 @@ void OllamaClient::pullModel(const QString& modelName) {
             QJsonDocument doc = QJsonDocument::fromJson(line, &error);
             if (error.error == QJsonParseError::NoError && doc.isObject()) {
                 QJsonObject obj = doc.object();
+
+                if (obj.contains("error")) {
+                    *hasError = true;
+                    *errorMsg = obj.value("error").toString();
+                    emit pullProgressUpdated(modelName, 0, "Error: " + *errorMsg);
+                    return;
+                }
+
                 QString status = obj.value("status").toString();
                 qint64 total = obj.value("total").toDouble();
                 qint64 completed = obj.value("completed").toDouble();
@@ -112,10 +124,18 @@ void OllamaClient::pullModel(const QString& modelName) {
         }
     });
 
-    connect(reply, &QNetworkReply::finished, this, [this, reply, modelName]() {
+    connect(reply, &QNetworkReply::finished, this, [this, reply, modelName, hasError, errorMsg]() {
         m_activePulls.remove(reply);
         m_pullBuffers.remove(reply);
-        emit pullFinished(modelName);
+
+        if (reply->error() != QNetworkReply::NoError) {
+            emit pullFinished(modelName, false, reply->errorString());
+        } else if (*hasError) {
+            emit pullFinished(modelName, false, *errorMsg);
+        } else {
+            emit pullFinished(modelName, true);
+        }
+
         fetchModels();
         reply->deleteLater();
     });

--- a/src/OllamaClient.h
+++ b/src/OllamaClient.h
@@ -30,7 +30,7 @@ class OllamaClient : public QObject {
     void connectionStatusChanged(bool isOk);
     void modelListUpdated(const QStringList& models);
     void pullProgressUpdated(const QString& modelName, int percent, const QString& status);
-    void pullFinished(const QString& modelName);
+    void pullFinished(const QString& modelName, bool success, const QString& errorString = "");
     void generationMetrics(double tokensPerSecond);
     void requestSent(const QString& model, const QString& systemPrompt, const QString& prompt);
 


### PR DESCRIPTION
Updated `OllamaClient` and `ModelExplorer` to handle successful downloads and pull errors explicitly, instead of just making the download silently disappear.

1. `OllamaClient::pullModel` checks for `error` fields in the JSON chunks.
2. `OllamaClient` emits `pullFinished` with a `success` flag and `errorString`.
3. `ModelExplorer` updates the download row to show "Completed" or "Error: [msg]" rather than automatically removing the row upon completion.
4. Added a "Clear Finished" button in `ModelExplorer` downloading tab to clean up the finished states manually.

---
*PR created automatically by Jules for task [2103570374463741848](https://jules.google.com/task/2103570374463741848) started by @arran4*