### PR TITLE
Improve Queue Error Handling and Display

### DIFF
--- a/src/BookDatabase.cpp
+++ b/src/BookDatabase.cpp
@@ -1228,11 +1228,13 @@ bool BookDatabase::updateQueueProcessingId(int id, int processingId) {
 
 bool BookDatabase::updateQueueError(int id, const QString& error) {
     if (!m_isOpen) return false;
-    const char* sql = "UPDATE queue SET last_error = ?, processing_id = 0 WHERE id = ?;";
+    const char* sql = "UPDATE queue SET last_error = ?, processing_id = 0, state = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
     if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
     sqlite3_bind_text(stmt, 1, error.toUtf8().constData(), -1, SQLITE_TRANSIENT);
-    sqlite3_bind_int(stmt, 2, id);
+    QString state = error.isEmpty() ? "pending" : "error";
+    sqlite3_bind_text(stmt, 2, state.toUtf8().constData(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 3, id);
     int rc = sqlite3_step(stmt);
     sqlite3_finalize(stmt);
     return rc == SQLITE_DONE;

--- a/src/QueueWindow.cpp
+++ b/src/QueueWindow.cpp
@@ -132,6 +132,10 @@ void QueueWindow::refresh() {
                            .arg(mi.item.prompt.left(100).replace("\n", " ").trimmed() + "...")
                            .arg(mi.item.model);
 
+        if (statusStr == "ERROR" && !mi.item.lastError.isEmpty()) {
+            text += QString(" - Error: %1").arg(mi.item.lastError);
+        }
+
         QListWidgetItem* listItem = new QListWidgetItem(text, m_queueList);
         listItem->setData(Qt::UserRole, QVariant::fromValue(mi.item.id));
         listItem->setData(Qt::UserRole + 1, mi.db->filepath());


### PR DESCRIPTION
Updates the database and queue window so that when tasks encounter errors, the error state is fully persisted and the specific error message is visible in the UI instead of the item appearing stuck in processing.

---
*PR created automatically by Jules for task [12779827910173284259](https://jules.google.com/task/12779827910173284259) started by @arran4*