### PR TITLE
feat: display detailed model columns in selection dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(kllamabooks
     src/main.cpp
     src/OllamaClient.cpp
     src/OllamaClient.h
+    src/OllamaModelInfo.h
     src/ModelExplorer.cpp
     src/ModelExplorer.h
     src/ModelSelectionDialog.cpp

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -685,8 +685,12 @@ void MainWindow::setupUi() {
         }
     });
 
+    connect(&ollamaClient, &OllamaClient::modelInfoUpdated, this, [this](const QList<OllamaModelInfo>& infos) {
+        m_availableModelInfos = infos;
+    });
+
     connect(modelSelectButton, &QPushButton::clicked, this, [this]() {
-        ModelSelectionDialog dlg(m_availableModels, this);
+        ModelSelectionDialog dlg(m_availableModelInfos, m_availableModels, this);
         if (dlg.exec() == QDialog::Accepted) {
             QString selected = dlg.selectedModel();
             if (!selected.isEmpty()) {

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -38,6 +38,7 @@
 #include "ModelExplorer.h"
 #include "OllamaClient.h"
 #include "SettingsDialog.h"
+#include "OllamaModelInfo.h"
 
 class CustomItemModel : public QStandardItemModel {
     Q_OBJECT
@@ -194,6 +195,7 @@ class MainWindow : public KXmlGuiWindow {
     QPushButton* dismissDraftBtn;
     QPushButton* modelSelectButton;
     QStringList m_availableModels;
+    QList<OllamaModelInfo> m_availableModelInfos;
     QString m_selectedModel;
     QToolButton* inputSettingsButton;
     QComboBox* modelComboBox;

--- a/src/ModelExplorer.cpp
+++ b/src/ModelExplorer.cpp
@@ -22,7 +22,7 @@ ModelExplorer::ModelExplorer(OllamaClient* client, QWidget* parent) : QDialog(pa
 
     mainLayout->addWidget(m_tabWidget);
 
-    connect(m_client, &OllamaClient::modelListUpdated, this, &ModelExplorer::updateModelList);
+    connect(m_client, &OllamaClient::modelInfoUpdated, this, &ModelExplorer::updateModelList);
     connect(m_client, &OllamaClient::pullProgressUpdated, this, &ModelExplorer::onPullProgressUpdated);
     connect(m_client, &OllamaClient::pullFinished, this, &ModelExplorer::onPullFinished);
 
@@ -43,10 +43,16 @@ void ModelExplorer::setupInstalledTab() {
     searchLayout->addWidget(searchButton);
     layout->addLayout(searchLayout);
 
-    m_installedList = new QListWidget(this);
-    m_installedList->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(m_installedList, &QWidget::customContextMenuRequested, this, &ModelExplorer::showInstalledContextMenu);
-    layout->addWidget(m_installedList);
+    m_installedTable = new QTableWidget(0, 5, this);
+    m_installedTable->setHorizontalHeaderLabels({"Name", "Size", "Family", "Parameters", "Quantization"});
+    m_installedTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_installedTable->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_installedTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_installedTable->horizontalHeader()->setStretchLastSection(true);
+    m_installedTable->verticalHeader()->setVisible(false);
+    m_installedTable->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(m_installedTable, &QWidget::customContextMenuRequested, this, &ModelExplorer::showInstalledContextMenu);
+    layout->addWidget(m_installedTable);
 
     connect(searchButton, &QPushButton::clicked, this, &ModelExplorer::onSearchInstalledClicked);
     connect(m_installedSearchField, &QLineEdit::returnPressed, this, &ModelExplorer::onSearchInstalledClicked);
@@ -102,12 +108,12 @@ void ModelExplorer::saveFavorites() {
 
 void ModelExplorer::onSearchInstalledClicked() {
     QString query = m_installedSearchField->text().toLower();
-    for (int i = 0; i < m_installedList->count(); ++i) {
-        QListWidgetItem* item = m_installedList->item(i);
-        QString text = item->text();
-        // Remove favorite star when checking
-        if (text.startsWith("⭐ ")) text = text.mid(2);
-        item->setHidden(!text.toLower().contains(query));
+    for (int i = 0; i < m_installedTable->rowCount(); ++i) {
+        QTableWidgetItem* item = m_installedTable->item(i, 0);
+        if (item) {
+            QString itemName = item->data(Qt::UserRole).toString();
+            m_installedTable->setRowHidden(i, !itemName.toLower().contains(query));
+        }
     }
 }
 
@@ -142,26 +148,40 @@ void ModelExplorer::onDownloadModelClicked() {
     m_tabWidget->setCurrentIndex(2);  // Switch to downloading tab
 }
 
-void ModelExplorer::updateModelList(const QStringList& models) {
-    m_installedList->clear();
+void ModelExplorer::updateModelList(const QList<OllamaModelInfo>& models) {
+    m_installedTable->setRowCount(0);
 
     // Add favorites first
-    for (const QString& model : models) {
-        if (m_favorites.contains(model)) {
-            QListWidgetItem* item = new QListWidgetItem("⭐ " + model);
-            item->setData(Qt::UserRole, model);
-            m_installedList->addItem(item);
+    int row = 0;
+    for (const OllamaModelInfo& info : models) {
+        if (m_favorites.contains(info.name)) {
+            m_installedTable->insertRow(row);
+            QTableWidgetItem* nameItem = new QTableWidgetItem("⭐ " + info.name);
+            nameItem->setData(Qt::UserRole, info.name);
+            m_installedTable->setItem(row, 0, nameItem);
+            m_installedTable->setItem(row, 1, new QTableWidgetItem(info.size));
+            m_installedTable->setItem(row, 2, new QTableWidgetItem(info.family));
+            m_installedTable->setItem(row, 3, new QTableWidgetItem(info.parameterSize));
+            m_installedTable->setItem(row, 4, new QTableWidgetItem(info.quantizationLevel));
+            row++;
         }
     }
 
     // Add the rest
-    for (const QString& model : models) {
-        if (!m_favorites.contains(model)) {
-            QListWidgetItem* item = new QListWidgetItem(model);
-            item->setData(Qt::UserRole, model);
-            m_installedList->addItem(item);
+    for (const OllamaModelInfo& info : models) {
+        if (!m_favorites.contains(info.name)) {
+            m_installedTable->insertRow(row);
+            QTableWidgetItem* nameItem = new QTableWidgetItem(info.name);
+            nameItem->setData(Qt::UserRole, info.name);
+            m_installedTable->setItem(row, 0, nameItem);
+            m_installedTable->setItem(row, 1, new QTableWidgetItem(info.size));
+            m_installedTable->setItem(row, 2, new QTableWidgetItem(info.family));
+            m_installedTable->setItem(row, 3, new QTableWidgetItem(info.parameterSize));
+            m_installedTable->setItem(row, 4, new QTableWidgetItem(info.quantizationLevel));
+            row++;
         }
     }
+    m_installedTable->resizeColumnsToContents();
 }
 
 void ModelExplorer::onPullProgressUpdated(const QString& modelName, int percent, const QString& status) {
@@ -188,16 +208,20 @@ void ModelExplorer::onPullFinished(const QString& modelName) {
 }
 
 void ModelExplorer::showInstalledContextMenu(const QPoint& pos) {
-    QListWidgetItem* item = m_installedList->itemAt(pos);
+    QTableWidgetItem* item = m_installedTable->itemAt(pos);
     if (!item) return;
 
-    QString modelName = item->data(Qt::UserRole).toString();
+    int row = item->row();
+    QTableWidgetItem* nameItem = m_installedTable->item(row, 0);
+    if (!nameItem) return;
+
+    QString modelName = nameItem->data(Qt::UserRole).toString();
     bool isFavorite = m_favorites.contains(modelName);
 
     QMenu menu(this);
     QAction* favoriteAction = menu.addAction(isFavorite ? "Unfavorite" : "Favorite");
 
-    QAction* selectedAction = menu.exec(m_installedList->viewport()->mapToGlobal(pos));
+    QAction* selectedAction = menu.exec(m_installedTable->viewport()->mapToGlobal(pos));
     if (selectedAction == favoriteAction) {
         if (isFavorite) {
             m_favorites.removeAll(modelName);

--- a/src/ModelExplorer.h
+++ b/src/ModelExplorer.h
@@ -13,6 +13,7 @@
 #include <QVBoxLayout>
 
 #include "OllamaClient.h"
+#include "OllamaModelInfo.h"
 
 class ModelExplorer : public QDialog {
     Q_OBJECT
@@ -23,7 +24,7 @@ class ModelExplorer : public QDialog {
    private slots:
     void onSearchInstalledClicked();
     void onDownloadModelClicked();
-    void updateModelList(const QStringList& models);
+    void updateModelList(const QList<OllamaModelInfo>& models);
     void onPullProgressUpdated(const QString& modelName, int percent, const QString& status);
     void onPullFinished(const QString& modelName);
     void showInstalledContextMenu(const QPoint& pos);
@@ -35,7 +36,7 @@ class ModelExplorer : public QDialog {
 
     // Installed Tab
     QLineEdit* m_installedSearchField;
-    QListWidget* m_installedList;
+    QTableWidget* m_installedTable;
 
     // Download Tab
     QLineEdit* m_downloadNameField;

--- a/src/ModelSelectionDialog.cpp
+++ b/src/ModelSelectionDialog.cpp
@@ -1,13 +1,14 @@
 #include "ModelSelectionDialog.h"
 
+#include <QHeaderView>
 #include <QIcon>
 #include <QSettings>
 #include <QVBoxLayout>
 
-ModelSelectionDialog::ModelSelectionDialog(const QStringList& models, QWidget* parent)
-    : QDialog(parent), m_allModels(models) {
+ModelSelectionDialog::ModelSelectionDialog(const QList<OllamaModelInfo>& modelInfos, const QStringList& fallbackModels, QWidget* parent)
+    : QDialog(parent), m_modelInfos(modelInfos), m_fallbackModels(fallbackModels) {
     setWindowTitle("Select Model");
-    resize(400, 300);
+    resize(600, 400);
     setupUi();
 }
 
@@ -23,41 +24,74 @@ void ModelSelectionDialog::setupUi() {
     m_searchField->setClearButtonEnabled(true);
     mainLayout->addWidget(m_searchField);
 
-    m_modelList = new QListWidget(this);
-    mainLayout->addWidget(m_modelList);
+    m_modelTable = new QTableWidget(0, 5, this);
+    m_modelTable->setHorizontalHeaderLabels({"Name", "Size", "Family", "Parameters", "Quantization"});
+    m_modelTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_modelTable->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_modelTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_modelTable->horizontalHeader()->setStretchLastSection(true);
+    m_modelTable->verticalHeader()->setVisible(false);
+    mainLayout->addWidget(m_modelTable);
 
     QSettings settings;
     QStringList favorites = settings.value("favoriteModels").toStringList();
 
-    // Populate the list
-    for (const QString& model : m_allModels) {
-        if (favorites.contains(model)) {
-            QListWidgetItem* item = new QListWidgetItem("⭐ " + model);
-            item->setData(Qt::UserRole, model);
-            m_modelList->addItem(item);
+    // Determine the list of models to display
+    QList<OllamaModelInfo> itemsToDisplay;
+    if (!m_modelInfos.isEmpty()) {
+        itemsToDisplay = m_modelInfos;
+    } else {
+        for (const QString& name : m_fallbackModels) {
+            OllamaModelInfo info;
+            info.name = name;
+            itemsToDisplay.append(info);
         }
     }
 
-    for (const QString& model : m_allModels) {
-        if (!favorites.contains(model)) {
-            QListWidgetItem* item = new QListWidgetItem(model);
-            item->setData(Qt::UserRole, model);
-            m_modelList->addItem(item);
+    // Populate the list (favorites first)
+    int row = 0;
+    for (const OllamaModelInfo& info : itemsToDisplay) {
+        if (favorites.contains(info.name)) {
+            m_modelTable->insertRow(row);
+            QTableWidgetItem* nameItem = new QTableWidgetItem("⭐ " + info.name);
+            nameItem->setData(Qt::UserRole, info.name);
+            m_modelTable->setItem(row, 0, nameItem);
+            m_modelTable->setItem(row, 1, new QTableWidgetItem(info.size));
+            m_modelTable->setItem(row, 2, new QTableWidgetItem(info.family));
+            m_modelTable->setItem(row, 3, new QTableWidgetItem(info.parameterSize));
+            m_modelTable->setItem(row, 4, new QTableWidgetItem(info.quantizationLevel));
+            row++;
         }
     }
+
+    for (const OllamaModelInfo& info : itemsToDisplay) {
+        if (!favorites.contains(info.name)) {
+            m_modelTable->insertRow(row);
+            QTableWidgetItem* nameItem = new QTableWidgetItem(info.name);
+            nameItem->setData(Qt::UserRole, info.name);
+            m_modelTable->setItem(row, 0, nameItem);
+            m_modelTable->setItem(row, 1, new QTableWidgetItem(info.size));
+            m_modelTable->setItem(row, 2, new QTableWidgetItem(info.family));
+            m_modelTable->setItem(row, 3, new QTableWidgetItem(info.parameterSize));
+            m_modelTable->setItem(row, 4, new QTableWidgetItem(info.quantizationLevel));
+            row++;
+        }
+    }
+
+    m_modelTable->resizeColumnsToContents();
 
     // Connect signals
     connect(m_searchField, &QLineEdit::textChanged, this, &ModelSelectionDialog::onSearchChanged);
-    connect(m_modelList, &QListWidget::itemDoubleClicked, this, &ModelSelectionDialog::onItemSelected);
+    connect(m_modelTable, &QTableWidget::itemDoubleClicked, this, &ModelSelectionDialog::onItemSelected);
+
     // Allow enter to select if exactly one is visible
     connect(m_searchField, &QLineEdit::returnPressed, this, [this]() {
-        QListWidgetItem* selected = nullptr;
+        QTableWidgetItem* selected = nullptr;
         int visibleCount = 0;
-        for (int i = 0; i < m_modelList->count(); ++i) {
-            QListWidgetItem* item = m_modelList->item(i);
-            if (!item->isHidden()) {
+        for (int i = 0; i < m_modelTable->rowCount(); ++i) {
+            if (!m_modelTable->isRowHidden(i)) {
                 visibleCount++;
-                selected = item;
+                selected = m_modelTable->item(i, 0);
             }
         }
         if (visibleCount == 1 && selected) {
@@ -68,16 +102,22 @@ void ModelSelectionDialog::setupUi() {
 
 void ModelSelectionDialog::onSearchChanged(const QString& text) {
     QString query = text.toLower();
-    for (int i = 0; i < m_modelList->count(); ++i) {
-        QListWidgetItem* item = m_modelList->item(i);
-        QString itemName = item->data(Qt::UserRole).toString();
-        item->setHidden(!itemName.toLower().contains(query));
+    for (int i = 0; i < m_modelTable->rowCount(); ++i) {
+        QTableWidgetItem* item = m_modelTable->item(i, 0);
+        if (item) {
+            QString itemName = item->data(Qt::UserRole).toString();
+            m_modelTable->setRowHidden(i, !itemName.toLower().contains(query));
+        }
     }
 }
 
-void ModelSelectionDialog::onItemSelected(QListWidgetItem* item) {
+void ModelSelectionDialog::onItemSelected(QTableWidgetItem* item) {
     if (item) {
-        m_selectedModel = item->data(Qt::UserRole).toString();
-        accept();
+        int row = item->row();
+        QTableWidgetItem* nameItem = m_modelTable->item(row, 0);
+        if (nameItem) {
+            m_selectedModel = nameItem->data(Qt::UserRole).toString();
+            accept();
+        }
     }
 }

--- a/src/ModelSelectionDialog.h
+++ b/src/ModelSelectionDialog.h
@@ -3,27 +3,30 @@
 
 #include <QDialog>
 #include <QLineEdit>
-#include <QListWidget>
+#include <QTableWidget>
 #include <QPushButton>
+
+#include "OllamaModelInfo.h"
 
 class ModelSelectionDialog : public QDialog {
     Q_OBJECT
    public:
-    explicit ModelSelectionDialog(const QStringList& models, QWidget* parent = nullptr);
+    explicit ModelSelectionDialog(const QList<OllamaModelInfo>& modelInfos, const QStringList& fallbackModels, QWidget* parent = nullptr);
     ~ModelSelectionDialog();
 
     QString selectedModel() const;
 
    private slots:
     void onSearchChanged(const QString& text);
-    void onItemSelected(QListWidgetItem* item);
+    void onItemSelected(QTableWidgetItem* item);
 
    private:
     void setupUi();
 
     QLineEdit* m_searchField;
-    QListWidget* m_modelList;
-    QStringList m_allModels;
+    QTableWidget* m_modelTable;
+    QList<OllamaModelInfo> m_modelInfos;
+    QStringList m_fallbackModels;
     QString m_selectedModel;
 };
 

--- a/src/OllamaClient.cpp
+++ b/src/OllamaClient.cpp
@@ -42,16 +42,46 @@ void OllamaClient::fetchModels() {
             if (doc.isObject() && doc.object().contains("models") && doc.object()["models"].isArray()) {
                 QJsonArray modelsArray = doc.object()["models"].toArray();
                 QStringList modelNames;
+                QList<OllamaModelInfo> modelInfos;
                 for (const auto& modelVal : modelsArray) {
                     if (modelVal.isObject() && modelVal.toObject().contains("name")) {
-                        modelNames.append(modelVal.toObject()["name"].toString());
+                        QJsonObject modelObj = modelVal.toObject();
+                        QString name = modelObj["name"].toString();
+                        modelNames.append(name);
+
+                        OllamaModelInfo info;
+                        info.name = name;
+
+                        // Parse size
+                        if (modelObj.contains("size")) {
+                            qint64 sizeBytes = modelObj["size"].toVariant().toLongLong();
+                            if (sizeBytes > 1024LL * 1024LL * 1024LL) {
+                                info.size = QString::number(sizeBytes / (1024.0 * 1024.0 * 1024.0), 'f', 1) + " GB";
+                            } else if (sizeBytes > 1024 * 1024) {
+                                info.size = QString::number(sizeBytes / (1024.0 * 1024.0), 'f', 1) + " MB";
+                            } else {
+                                info.size = QString::number(sizeBytes) + " B";
+                            }
+                        }
+
+                        // Parse details
+                        if (modelObj.contains("details") && modelObj["details"].isObject()) {
+                            QJsonObject detailsObj = modelObj["details"].toObject();
+                            info.family = detailsObj["family"].toString();
+                            info.parameterSize = detailsObj["parameter_size"].toString();
+                            info.quantizationLevel = detailsObj["quantization_level"].toString();
+                        }
+
+                        modelInfos.append(info);
                     }
                 }
                 emit modelListUpdated(modelNames);
+                emit modelInfoUpdated(modelInfos);
             }
         } else {
             emit connectionStatusChanged(false);
             emit modelListUpdated(QStringList());  // Clear on error
+            emit modelInfoUpdated(QList<OllamaModelInfo>());
         }
         reply->deleteLater();
     });

--- a/src/OllamaClient.h
+++ b/src/OllamaClient.h
@@ -10,6 +10,8 @@
 #include <QUrl>
 #include <functional>
 
+#include "OllamaModelInfo.h"
+
 class OllamaClient : public QObject {
     Q_OBJECT
    public:
@@ -29,6 +31,7 @@ class OllamaClient : public QObject {
    signals:
     void connectionStatusChanged(bool isOk);
     void modelListUpdated(const QStringList& models);
+    void modelInfoUpdated(const QList<OllamaModelInfo>& models);
     void pullProgressUpdated(const QString& modelName, int percent, const QString& status);
     void pullFinished(const QString& modelName);
     void generationMetrics(double tokensPerSecond);

--- a/src/OllamaModelInfo.h
+++ b/src/OllamaModelInfo.h
@@ -1,0 +1,14 @@
+#ifndef OLLAMAMODELINFO_H
+#define OLLAMAMODELINFO_H
+
+#include <QString>
+
+struct OllamaModelInfo {
+    QString name;
+    QString size;
+    QString family;
+    QString parameterSize;
+    QString quantizationLevel;
+};
+
+#endif // OLLAMAMODELINFO_H


### PR DESCRIPTION
This pull request refactors the `ModelSelectionDialog` to use a `QTableWidget` instead of a `QListWidget`. This allows users to view more metadata about installed models, including their size, model family, parameter count, and quantization level, directly when picking a model for chats or defaults.

The `OllamaClient` was extended to parse the `details` and `size` fields from the Ollama `/api/tags` JSON response. A new `OllamaModelInfo` struct encapsulates these fields and is broadcast to the rest of the application via the new `modelInfoUpdated` signal, providing UI components with rich model context. Fallbacks are correctly implemented when offline cache strings are the only items available.

---
*PR created automatically by Jules for task [8641182105134218309](https://jules.google.com/task/8641182105134218309) started by @arran4*