### PR TITLE
feat: add {input} and {textarea} template tag support for AI operations

### DIFF
--- a/src/AIOperationsDialog.cpp
+++ b/src/AIOperationsDialog.cpp
@@ -79,11 +79,17 @@ void AIOperationsDialog::setForkOnlyMode(bool enabled) {
     }
 }
 
+struct InputWidgetInfo {
+    int start;
+    int length;
+    QWidget* widget;
+};
+
 void AIOperationsDialog::accept() {
     QString prompt = m_promptEdit->toPlainText();
     m_finalPrompt = prompt;
 
-    QRegularExpression re("\\{(input|textarea)\\s+\"([^\"]+)\"\\}");
+    QRegularExpression re("\\{(input|textarea)(?:\\s+\"([^\"]+)\")?\\}");
     QRegularExpressionMatchIterator i = re.globalMatch(prompt);
 
     if (i.hasNext()) {
@@ -94,13 +100,35 @@ void AIOperationsDialog::accept() {
         QFormLayout* form = new QFormLayout();
         layout->addLayout(form);
 
-        QList<QPair<QString, QWidget*>> inputWidgets;
+        QList<InputWidgetInfo> inputWidgets;
 
         while (i.hasNext()) {
             QRegularExpressionMatch match = i.next();
             QString type = match.captured(1);
             QString label = match.captured(2);
-            QString fullMatch = match.captured(0);
+
+            if (label.isEmpty()) {
+                int start = match.capturedStart(0);
+                int lineStart = prompt.lastIndexOf('\n', start - 1) + 1;
+                QString preceding = prompt.mid(lineStart, start - lineStart).trimmed();
+                if (!preceding.isEmpty()) {
+                    label = preceding;
+                } else {
+                    int end = match.capturedEnd(0);
+                    int nextLineStart = prompt.indexOf('\n', end);
+                    if (nextLineStart != -1) {
+                        int nextLineEnd = prompt.indexOf('\n', nextLineStart + 1);
+                        if (nextLineEnd == -1) nextLineEnd = prompt.length();
+                        QString nextLine = prompt.mid(nextLineStart + 1, nextLineEnd - nextLineStart - 1).trimmed();
+                        if (!nextLine.isEmpty() && nextLine.length() < 100) {
+                            label = nextLine;
+                        }
+                    }
+                }
+                if (label.isEmpty()) {
+                    label = "Input";
+                }
+            }
 
             QWidget* w = nullptr;
             if (type == "input") {
@@ -111,7 +139,7 @@ void AIOperationsDialog::accept() {
 
             if (w) {
                 form->addRow(label + ":", w);
-                inputWidgets.append({fullMatch, w});
+                inputWidgets.append({match.capturedStart(0), match.capturedLength(0), w});
             }
         }
 
@@ -127,14 +155,16 @@ void AIOperationsDialog::accept() {
         connect(okBtn, &QPushButton::clicked, &inputDlg, &QDialog::accept);
 
         if (inputDlg.exec() == QDialog::Accepted) {
-            for (const auto& pair : inputWidgets) {
+            // Replace backwards to preserve indices
+            for (int j = inputWidgets.size() - 1; j >= 0; --j) {
+                const auto& info = inputWidgets[j];
                 QString val;
-                if (QLineEdit* le = qobject_cast<QLineEdit*>(pair.second)) {
+                if (QLineEdit* le = qobject_cast<QLineEdit*>(info.widget)) {
                     val = le->text();
-                } else if (QTextEdit* te = qobject_cast<QTextEdit*>(pair.second)) {
+                } else if (QTextEdit* te = qobject_cast<QTextEdit*>(info.widget)) {
                     val = te->toPlainText();
                 }
-                prompt.replace(pair.first, val);
+                prompt.replace(info.start, info.length, val);
             }
             m_finalPrompt = prompt;
             QDialog::accept();

--- a/src/AIOperationsDialog.cpp
+++ b/src/AIOperationsDialog.cpp
@@ -39,6 +39,10 @@ AIOperationsDialog::AIOperationsDialog(BookDatabase* db, const QString& defaultP
     m_promptEdit->setPlainText(defaultPrompt);
     layout->addWidget(m_promptEdit);
 
+    // Dynamic Inputs
+    m_dynamicInputsLayout = new QFormLayout();
+    layout->addLayout(m_dynamicInputsLayout);
+
     // Buttons
     QHBoxLayout* btnLayout = new QHBoxLayout();
     QPushButton* cancelBtn = new QPushButton(tr("Cancel"), this);
@@ -63,6 +67,9 @@ AIOperationsDialog::AIOperationsDialog(BookDatabase* db, const QString& defaultP
     if (defaultPrompt.isEmpty() && m_operationCombo->count() > 0) {
         m_promptEdit->setPlainText(m_operationCombo->itemData(0, Qt::UserRole + 1).toString());
     }
+
+    connect(m_promptEdit, &QTextEdit::textChanged, this, &AIOperationsDialog::updateDynamicInputs);
+    updateDynamicInputs();
 }
 
 AIOperationsDialog::~AIOperationsDialog() {}
@@ -79,97 +86,121 @@ void AIOperationsDialog::setForkOnlyMode(bool enabled) {
     }
 }
 
-struct InputWidgetInfo {
-    int start;
-    int length;
-    QWidget* widget;
-};
-
-void AIOperationsDialog::accept() {
+void AIOperationsDialog::updateDynamicInputs() {
     QString prompt = m_promptEdit->toPlainText();
-    m_finalPrompt = prompt;
+
+    QList<DynamicInputInfo> newInputs;
 
     QRegularExpression re("\\{(input|textarea)(?:\\s+\"([^\"]+)\")?\\}");
     QRegularExpressionMatchIterator i = re.globalMatch(prompt);
 
-    if (i.hasNext()) {
-        QDialog inputDlg(this);
-        inputDlg.setWindowTitle(tr("Provide Inputs"));
-        inputDlg.resize(400, 300);
-        QVBoxLayout* layout = new QVBoxLayout(&inputDlg);
-        QFormLayout* form = new QFormLayout();
-        layout->addLayout(form);
+    while (i.hasNext()) {
+        QRegularExpressionMatch match = i.next();
+        QString type = match.captured(1);
+        QString label = match.captured(2);
+        QString fullMatch = match.captured(0);
 
-        QList<InputWidgetInfo> inputWidgets;
-
-        while (i.hasNext()) {
-            QRegularExpressionMatch match = i.next();
-            QString type = match.captured(1);
-            QString label = match.captured(2);
-
-            if (label.isEmpty()) {
-                int start = match.capturedStart(0);
-                int lineStart = prompt.lastIndexOf('\n', start - 1) + 1;
-                QString preceding = prompt.mid(lineStart, start - lineStart).trimmed();
-                if (!preceding.isEmpty()) {
-                    label = preceding;
-                } else {
-                    int end = match.capturedEnd(0);
-                    int nextLineStart = prompt.indexOf('\n', end);
-                    if (nextLineStart != -1) {
-                        int nextLineEnd = prompt.indexOf('\n', nextLineStart + 1);
-                        if (nextLineEnd == -1) nextLineEnd = prompt.length();
-                        QString nextLine = prompt.mid(nextLineStart + 1, nextLineEnd - nextLineStart - 1).trimmed();
-                        if (!nextLine.isEmpty() && nextLine.length() < 100) {
-                            label = nextLine;
-                        }
+        if (label.isEmpty()) {
+            int start = match.capturedStart(0);
+            int lineStart = start > 0 ? prompt.lastIndexOf('\n', start - 1) + 1 : 0;
+            QString preceding = prompt.mid(lineStart, start - lineStart).trimmed();
+            if (!preceding.isEmpty()) {
+                label = preceding;
+            } else {
+                int end = match.capturedEnd(0);
+                int nextLineStart = prompt.indexOf('\n', end);
+                if (nextLineStart != -1) {
+                    int nextLineEnd = prompt.indexOf('\n', nextLineStart + 1);
+                    if (nextLineEnd == -1) nextLineEnd = prompt.length();
+                    QString nextLine = prompt.mid(nextLineStart + 1, nextLineEnd - nextLineStart - 1).trimmed();
+                    if (!nextLine.isEmpty() && nextLine.length() < 100) {
+                        label = nextLine;
                     }
                 }
-                if (label.isEmpty()) {
-                    label = "Input";
-                }
             }
+            if (label.isEmpty()) {
+                label = "Input";
+            }
+        }
 
+        newInputs.append({fullMatch, type, label, nullptr});
+    }
+
+    // Check if the required inputs have changed
+    bool changed = (m_currentDynamicInputs.size() != newInputs.size());
+    if (!changed) {
+        for (int j = 0; j < newInputs.size(); ++j) {
+            if (m_currentDynamicInputs[j].type != newInputs[j].type ||
+                m_currentDynamicInputs[j].label != newInputs[j].label) {
+                changed = true;
+                break;
+            }
+        }
+    }
+
+    if (changed) {
+        // Clear layout
+        QLayoutItem* item;
+        while ((item = m_dynamicInputsLayout->takeAt(0)) != nullptr) {
+            if (QWidget* w = item->widget()) {
+                w->deleteLater();
+            }
+            delete item;
+        }
+        m_currentDynamicInputs.clear();
+
+        for (int j = 0; j < newInputs.size(); ++j) {
+            DynamicInputInfo& info = newInputs[j];
             QWidget* w = nullptr;
-            if (type == "input") {
-                w = new QLineEdit(&inputDlg);
-            } else if (type == "textarea") {
-                w = new QTextEdit(&inputDlg);
+            if (info.type == "input") {
+                w = new QLineEdit(this);
+            } else if (info.type == "textarea") {
+                QTextEdit* te = new QTextEdit(this);
+                te->setMaximumHeight(60);
+                w = te;
             }
 
             if (w) {
-                form->addRow(label + ":", w);
-                inputWidgets.append({match.capturedStart(0), match.capturedLength(0), w});
+                QLabel* labelWidget = new QLabel(info.label + ":", this);
+                m_dynamicInputsLayout->addRow(labelWidget, w);
+                info.widget = w;
+                m_currentDynamicInputs.append(info);
             }
         }
-
-        QHBoxLayout* btnLayout = new QHBoxLayout();
-        QPushButton* cancelBtn = new QPushButton(tr("Cancel"), &inputDlg);
-        QPushButton* okBtn = new QPushButton(tr("OK"), &inputDlg);
-        btnLayout->addStretch();
-        btnLayout->addWidget(cancelBtn);
-        btnLayout->addWidget(okBtn);
-        layout->addLayout(btnLayout);
-
-        connect(cancelBtn, &QPushButton::clicked, &inputDlg, &QDialog::reject);
-        connect(okBtn, &QPushButton::clicked, &inputDlg, &QDialog::accept);
-
-        if (inputDlg.exec() == QDialog::Accepted) {
-            // Replace backwards to preserve indices
-            for (int j = inputWidgets.size() - 1; j >= 0; --j) {
-                const auto& info = inputWidgets[j];
-                QString val;
-                if (QLineEdit* le = qobject_cast<QLineEdit*>(info.widget)) {
-                    val = le->text();
-                } else if (QTextEdit* te = qobject_cast<QTextEdit*>(info.widget)) {
-                    val = te->toPlainText();
-                }
-                prompt.replace(info.start, info.length, val);
-            }
-            m_finalPrompt = prompt;
-            QDialog::accept();
-        }
-    } else {
-        QDialog::accept();
     }
+}
+
+void AIOperationsDialog::accept() {
+    QString prompt = m_promptEdit->toPlainText();
+
+    QRegularExpression re("\\{(input|textarea)(?:\\s+\"([^\"]+)\")?\\}");
+    QRegularExpressionMatchIterator i = re.globalMatch(prompt);
+
+    struct MatchInfo {
+        int start;
+        int length;
+    };
+    QList<MatchInfo> matchInfos;
+    while (i.hasNext()) {
+        QRegularExpressionMatch match = i.next();
+        matchInfos.append({static_cast<int>(match.capturedStart(0)), static_cast<int>(match.capturedLength(0))});
+    }
+
+    if (matchInfos.size() == m_currentDynamicInputs.size()) {
+        for (int j = matchInfos.size() - 1; j >= 0; --j) {
+            const MatchInfo& minfo = matchInfos[j];
+            const DynamicInputInfo& dinfo = m_currentDynamicInputs[j];
+
+            QString val;
+            if (QLineEdit* le = qobject_cast<QLineEdit*>(dinfo.widget)) {
+                val = le->text();
+            } else if (QTextEdit* te = qobject_cast<QTextEdit*>(dinfo.widget)) {
+                val = te->toPlainText();
+            }
+            prompt.replace(minfo.start, minfo.length, val);
+        }
+    }
+
+    m_finalPrompt = prompt;
+    QDialog::accept();
 }

--- a/src/AIOperationsDialog.cpp
+++ b/src/AIOperationsDialog.cpp
@@ -8,6 +8,10 @@
 #include <QSettings>
 #include <QTextEdit>
 #include <QVBoxLayout>
+#include <QRegularExpression>
+#include <QDialog>
+#include <QFormLayout>
+#include <QLineEdit>
 
 AIOperationsDialog::AIOperationsDialog(BookDatabase* db, const QString& defaultPrompt, QWidget* parent) : QDialog(parent) {
     setWindowTitle(tr("AI Document Operations"));
@@ -65,12 +69,77 @@ AIOperationsDialog::~AIOperationsDialog() {}
 
 QString AIOperationsDialog::getOperation() const { return m_operationCombo->currentData().toString(); }
 
-QString AIOperationsDialog::getPrompt() const { return m_promptEdit->toPlainText(); }
+QString AIOperationsDialog::getPrompt() const { return m_finalPrompt; }
 
 void AIOperationsDialog::setForkOnlyMode(bool enabled) {
     if (enabled) {
         m_operationCombo->setEnabled(false);
     } else {
         m_operationCombo->setEnabled(true);
+    }
+}
+
+void AIOperationsDialog::accept() {
+    QString prompt = m_promptEdit->toPlainText();
+    m_finalPrompt = prompt;
+
+    QRegularExpression re("\\{(input|textarea)\\s+\"([^\"]+)\"\\}");
+    QRegularExpressionMatchIterator i = re.globalMatch(prompt);
+
+    if (i.hasNext()) {
+        QDialog inputDlg(this);
+        inputDlg.setWindowTitle(tr("Provide Inputs"));
+        inputDlg.resize(400, 300);
+        QVBoxLayout* layout = new QVBoxLayout(&inputDlg);
+        QFormLayout* form = new QFormLayout();
+        layout->addLayout(form);
+
+        QList<QPair<QString, QWidget*>> inputWidgets;
+
+        while (i.hasNext()) {
+            QRegularExpressionMatch match = i.next();
+            QString type = match.captured(1);
+            QString label = match.captured(2);
+            QString fullMatch = match.captured(0);
+
+            QWidget* w = nullptr;
+            if (type == "input") {
+                w = new QLineEdit(&inputDlg);
+            } else if (type == "textarea") {
+                w = new QTextEdit(&inputDlg);
+            }
+
+            if (w) {
+                form->addRow(label + ":", w);
+                inputWidgets.append({fullMatch, w});
+            }
+        }
+
+        QHBoxLayout* btnLayout = new QHBoxLayout();
+        QPushButton* cancelBtn = new QPushButton(tr("Cancel"), &inputDlg);
+        QPushButton* okBtn = new QPushButton(tr("OK"), &inputDlg);
+        btnLayout->addStretch();
+        btnLayout->addWidget(cancelBtn);
+        btnLayout->addWidget(okBtn);
+        layout->addLayout(btnLayout);
+
+        connect(cancelBtn, &QPushButton::clicked, &inputDlg, &QDialog::reject);
+        connect(okBtn, &QPushButton::clicked, &inputDlg, &QDialog::accept);
+
+        if (inputDlg.exec() == QDialog::Accepted) {
+            for (const auto& pair : inputWidgets) {
+                QString val;
+                if (QLineEdit* le = qobject_cast<QLineEdit*>(pair.second)) {
+                    val = le->text();
+                } else if (QTextEdit* te = qobject_cast<QTextEdit*>(pair.second)) {
+                    val = te->toPlainText();
+                }
+                prompt.replace(pair.first, val);
+            }
+            m_finalPrompt = prompt;
+            QDialog::accept();
+        }
+    } else {
+        QDialog::accept();
     }
 }

--- a/src/AIOperationsDialog.h
+++ b/src/AIOperationsDialog.h
@@ -7,6 +7,21 @@
 class QComboBox;
 class QTextEdit;
 class BookDatabase;
+class QFormLayout;
+
+struct DynamicInputInfo {
+    QString fullMatch;
+    QString type;
+    QString label;
+    QWidget* widget = nullptr;
+
+    bool operator==(const DynamicInputInfo& other) const {
+        return fullMatch == other.fullMatch && type == other.type && label == other.label;
+    }
+    bool operator!=(const DynamicInputInfo& other) const {
+        return !(*this == other);
+    }
+};
 
 class AIOperationsDialog : public QDialog {
     Q_OBJECT
@@ -22,9 +37,14 @@ class AIOperationsDialog : public QDialog {
    public slots:
     void accept() override;
 
+   private slots:
+    void updateDynamicInputs();
+
    private:
     QComboBox* m_operationCombo;
     QTextEdit* m_promptEdit;
+    QFormLayout* m_dynamicInputsLayout;
+    QList<DynamicInputInfo> m_currentDynamicInputs;
     QString m_finalPrompt;
 };
 

--- a/src/AIOperationsDialog.h
+++ b/src/AIOperationsDialog.h
@@ -19,9 +19,13 @@ class AIOperationsDialog : public QDialog {
 
     void setForkOnlyMode(bool enabled);
 
+   public slots:
+    void accept() override;
+
    private:
     QComboBox* m_operationCombo;
     QTextEdit* m_promptEdit;
+    QString m_finalPrompt;
 };
 
 #endif  // AIOPERATIONSDIALOG_H

--- a/src/AIOperationsEditorWidget.cpp
+++ b/src/AIOperationsEditorWidget.cpp
@@ -34,7 +34,7 @@ class EditOperationDialog : public QDialog {
 
         m_promptEdit = new QTextEdit(this);
         m_promptEdit->setPlainText(op.prompt);
-        form->addRow(tr("Prompt (use {context}):"), m_promptEdit);
+        form->addRow(tr("Prompt\n(use {context},\n{input \"label\"},\n{textarea \"label\"}):"), m_promptEdit);
 
         layout->addLayout(form);
 

--- a/src/AIOperationsManager.cpp
+++ b/src/AIOperationsManager.cpp
@@ -7,11 +7,11 @@ QList<AIOperation> AIOperationsManager::getBuiltInOperations() {
                 "built-in"});
     ops.append({"replace", "Replace entirely",
                 "Rewrite the following document according to your instructions. Only output the rewritten document, "
-                "nothing else.\n\nInstructions: <your instructions here>\n\nDocument:\n{context}",
+                "nothing else.\n\nInstructions: {textarea}\n\nDocument:\n{context}",
                 "built-in"});
     ops.append({"replace_in_place", "Replace in place",
                 "Rewrite the following text according to your instructions. Only output the rewritten text, nothing "
-                "else.\n\nInstructions: <your instructions here>\n\nText:\n{context}",
+                "else.\n\nInstructions: {textarea}\n\nText:\n{context}",
                 "built-in"});
     return ops;
 }

--- a/src/AiActionDialog.cpp
+++ b/src/AiActionDialog.cpp
@@ -27,6 +27,10 @@ AiActionDialog::AiActionDialog(const QString& title, const QString& labelText, c
     m_instructionEdit->setPlainText(defaultTemplate);
     layout->addWidget(m_instructionEdit);
 
+    // Dynamic Inputs
+    m_dynamicInputsLayout = new QFormLayout();
+    layout->addLayout(m_dynamicInputsLayout);
+
     if (!contextText.isEmpty()) {
         QLabel* contextLabel = new QLabel("Selected Text Context:", this);
         layout->addWidget(contextLabel);
@@ -42,106 +46,131 @@ AiActionDialog::AiActionDialog(const QString& title, const QString& labelText, c
     connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
     connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
     layout->addWidget(buttonBox);
+
+    connect(m_instructionEdit, &QTextEdit::textChanged, this, &AiActionDialog::updateDynamicInputs);
+    updateDynamicInputs();
 }
 
 QString AiActionDialog::getPrompt() const {
     return m_finalPrompt;
 }
 
-struct InputWidgetInfo {
-    int start;
-    int length;
-    QWidget* widget;
-};
-
-void AiActionDialog::accept() {
+void AiActionDialog::updateDynamicInputs() {
     QString prompt = m_instructionEdit->toPlainText();
-    m_finalPrompt = prompt;
+
+    QList<AiDynamicInputInfo> newInputs;
 
     QRegularExpression re("\\{(input|textarea)(?:\\s+\"([^\"]+)\")?\\}");
     QRegularExpressionMatchIterator i = re.globalMatch(prompt);
 
-    if (i.hasNext()) {
-        QDialog inputDlg(this);
-        inputDlg.setWindowTitle(tr("Provide Inputs"));
-        inputDlg.resize(400, 300);
-        QVBoxLayout* layout = new QVBoxLayout(&inputDlg);
-        QFormLayout* form = new QFormLayout();
-        layout->addLayout(form);
+    while (i.hasNext()) {
+        QRegularExpressionMatch match = i.next();
+        QString type = match.captured(1);
+        QString label = match.captured(2);
+        QString fullMatch = match.captured(0);
 
-        QList<InputWidgetInfo> inputWidgets;
-
-        while (i.hasNext()) {
-            QRegularExpressionMatch match = i.next();
-            QString type = match.captured(1);
-            QString label = match.captured(2);
-
-            if (label.isEmpty()) {
-                int start = match.capturedStart(0);
-                int lineStart = prompt.lastIndexOf('\n', start - 1) + 1;
-                QString preceding = prompt.mid(lineStart, start - lineStart).trimmed();
-                if (!preceding.isEmpty()) {
-                    label = preceding;
-                } else {
-                    int end = match.capturedEnd(0);
-                    int nextLineStart = prompt.indexOf('\n', end);
-                    if (nextLineStart != -1) {
-                        int nextLineEnd = prompt.indexOf('\n', nextLineStart + 1);
-                        if (nextLineEnd == -1) nextLineEnd = prompt.length();
-                        QString nextLine = prompt.mid(nextLineStart + 1, nextLineEnd - nextLineStart - 1).trimmed();
-                        if (!nextLine.isEmpty() && nextLine.length() < 100) {
-                            label = nextLine;
-                        }
+        if (label.isEmpty()) {
+            int start = match.capturedStart(0);
+            int lineStart = start > 0 ? prompt.lastIndexOf('\n', start - 1) + 1 : 0;
+            QString preceding = prompt.mid(lineStart, start - lineStart).trimmed();
+            if (!preceding.isEmpty()) {
+                label = preceding;
+            } else {
+                int end = match.capturedEnd(0);
+                int nextLineStart = prompt.indexOf('\n', end);
+                if (nextLineStart != -1) {
+                    int nextLineEnd = prompt.indexOf('\n', nextLineStart + 1);
+                    if (nextLineEnd == -1) nextLineEnd = prompt.length();
+                    QString nextLine = prompt.mid(nextLineStart + 1, nextLineEnd - nextLineStart - 1).trimmed();
+                    if (!nextLine.isEmpty() && nextLine.length() < 100) {
+                        label = nextLine;
                     }
                 }
-                if (label.isEmpty()) {
-                    label = "Input";
-                }
             }
+            if (label.isEmpty()) {
+                label = "Input";
+            }
+        }
 
+        newInputs.append({fullMatch, type, label, nullptr});
+    }
+
+    // Check if the required inputs have changed
+    bool changed = (m_currentDynamicInputs.size() != newInputs.size());
+    if (!changed) {
+        for (int j = 0; j < newInputs.size(); ++j) {
+            if (m_currentDynamicInputs[j].type != newInputs[j].type ||
+                m_currentDynamicInputs[j].label != newInputs[j].label) {
+                changed = true;
+                break;
+            }
+        }
+    }
+
+    if (changed) {
+        // Clear layout
+        QLayoutItem* item;
+        while ((item = m_dynamicInputsLayout->takeAt(0)) != nullptr) {
+            if (QWidget* w = item->widget()) {
+                w->deleteLater();
+            }
+            delete item;
+        }
+        m_currentDynamicInputs.clear();
+
+        for (int j = 0; j < newInputs.size(); ++j) {
+            AiDynamicInputInfo& info = newInputs[j];
             QWidget* w = nullptr;
-            if (type == "input") {
-                w = new QLineEdit(&inputDlg);
-            } else if (type == "textarea") {
-                w = new QTextEdit(&inputDlg);
+            if (info.type == "input") {
+                w = new QLineEdit(this);
+            } else if (info.type == "textarea") {
+                QTextEdit* te = new QTextEdit(this);
+                te->setMaximumHeight(60);
+                w = te;
             }
 
             if (w) {
-                form->addRow(label + ":", w);
-                inputWidgets.append({match.capturedStart(0), match.capturedLength(0), w});
+                QLabel* labelWidget = new QLabel(info.label + ":", this);
+                m_dynamicInputsLayout->addRow(labelWidget, w);
+                info.widget = w;
+                m_currentDynamicInputs.append(info);
             }
         }
-
-        QHBoxLayout* btnLayout = new QHBoxLayout();
-        QPushButton* cancelBtn = new QPushButton(tr("Cancel"), &inputDlg);
-        QPushButton* okBtn = new QPushButton(tr("OK"), &inputDlg);
-        btnLayout->addStretch();
-        btnLayout->addWidget(cancelBtn);
-        btnLayout->addWidget(okBtn);
-        layout->addLayout(btnLayout);
-
-        connect(cancelBtn, &QPushButton::clicked, &inputDlg, &QDialog::reject);
-        connect(okBtn, &QPushButton::clicked, &inputDlg, &QDialog::accept);
-
-        if (inputDlg.exec() == QDialog::Accepted) {
-            // Replace backwards to preserve indices
-            for (int j = inputWidgets.size() - 1; j >= 0; --j) {
-                const auto& info = inputWidgets[j];
-                QString val;
-                if (QLineEdit* le = qobject_cast<QLineEdit*>(info.widget)) {
-                    val = le->text();
-                } else if (QTextEdit* te = qobject_cast<QTextEdit*>(info.widget)) {
-                    val = te->toPlainText();
-                }
-                prompt.replace(info.start, info.length, val);
-            }
-            prompt.replace("{context}", m_contextText);
-            m_finalPrompt = prompt;
-            QDialog::accept();
-        }
-    } else {
-        prompt.replace("{context}", m_contextText);
-        m_finalPrompt = prompt;
-        QDialog::accept();
     }
+}
+
+void AiActionDialog::accept() {
+    QString prompt = m_instructionEdit->toPlainText();
+
+    QRegularExpression re("\\{(input|textarea)(?:\\s+\"([^\"]+)\")?\\}");
+    QRegularExpressionMatchIterator i = re.globalMatch(prompt);
+
+    struct MatchInfo {
+        int start;
+        int length;
+    };
+    QList<MatchInfo> matchInfos;
+    while (i.hasNext()) {
+        QRegularExpressionMatch match = i.next();
+        matchInfos.append({static_cast<int>(match.capturedStart(0)), static_cast<int>(match.capturedLength(0))});
+    }
+
+    if (matchInfos.size() == m_currentDynamicInputs.size()) {
+        for (int j = matchInfos.size() - 1; j >= 0; --j) {
+            const MatchInfo& minfo = matchInfos[j];
+            const AiDynamicInputInfo& dinfo = m_currentDynamicInputs[j];
+
+            QString val;
+            if (QLineEdit* le = qobject_cast<QLineEdit*>(dinfo.widget)) {
+                val = le->text();
+            } else if (QTextEdit* te = qobject_cast<QTextEdit*>(dinfo.widget)) {
+                val = te->toPlainText();
+            }
+            prompt.replace(minfo.start, minfo.length, val);
+        }
+    }
+
+    prompt.replace("{context}", m_contextText);
+    m_finalPrompt = prompt;
+    QDialog::accept();
 }

--- a/src/AiActionDialog.cpp
+++ b/src/AiActionDialog.cpp
@@ -48,12 +48,17 @@ QString AiActionDialog::getPrompt() const {
     return m_finalPrompt;
 }
 
+struct InputWidgetInfo {
+    int start;
+    int length;
+    QWidget* widget;
+};
+
 void AiActionDialog::accept() {
     QString prompt = m_instructionEdit->toPlainText();
-    prompt.replace("{context}", m_contextText);
     m_finalPrompt = prompt;
 
-    QRegularExpression re("\\{(input|textarea)\\s+\"([^\"]+)\"\\}");
+    QRegularExpression re("\\{(input|textarea)(?:\\s+\"([^\"]+)\")?\\}");
     QRegularExpressionMatchIterator i = re.globalMatch(prompt);
 
     if (i.hasNext()) {
@@ -64,13 +69,35 @@ void AiActionDialog::accept() {
         QFormLayout* form = new QFormLayout();
         layout->addLayout(form);
 
-        QList<QPair<QString, QWidget*>> inputWidgets;
+        QList<InputWidgetInfo> inputWidgets;
 
         while (i.hasNext()) {
             QRegularExpressionMatch match = i.next();
             QString type = match.captured(1);
             QString label = match.captured(2);
-            QString fullMatch = match.captured(0);
+
+            if (label.isEmpty()) {
+                int start = match.capturedStart(0);
+                int lineStart = prompt.lastIndexOf('\n', start - 1) + 1;
+                QString preceding = prompt.mid(lineStart, start - lineStart).trimmed();
+                if (!preceding.isEmpty()) {
+                    label = preceding;
+                } else {
+                    int end = match.capturedEnd(0);
+                    int nextLineStart = prompt.indexOf('\n', end);
+                    if (nextLineStart != -1) {
+                        int nextLineEnd = prompt.indexOf('\n', nextLineStart + 1);
+                        if (nextLineEnd == -1) nextLineEnd = prompt.length();
+                        QString nextLine = prompt.mid(nextLineStart + 1, nextLineEnd - nextLineStart - 1).trimmed();
+                        if (!nextLine.isEmpty() && nextLine.length() < 100) {
+                            label = nextLine;
+                        }
+                    }
+                }
+                if (label.isEmpty()) {
+                    label = "Input";
+                }
+            }
 
             QWidget* w = nullptr;
             if (type == "input") {
@@ -81,7 +108,7 @@ void AiActionDialog::accept() {
 
             if (w) {
                 form->addRow(label + ":", w);
-                inputWidgets.append({fullMatch, w});
+                inputWidgets.append({match.capturedStart(0), match.capturedLength(0), w});
             }
         }
 
@@ -97,19 +124,24 @@ void AiActionDialog::accept() {
         connect(okBtn, &QPushButton::clicked, &inputDlg, &QDialog::accept);
 
         if (inputDlg.exec() == QDialog::Accepted) {
-            for (const auto& pair : inputWidgets) {
+            // Replace backwards to preserve indices
+            for (int j = inputWidgets.size() - 1; j >= 0; --j) {
+                const auto& info = inputWidgets[j];
                 QString val;
-                if (QLineEdit* le = qobject_cast<QLineEdit*>(pair.second)) {
+                if (QLineEdit* le = qobject_cast<QLineEdit*>(info.widget)) {
                     val = le->text();
-                } else if (QTextEdit* te = qobject_cast<QTextEdit*>(pair.second)) {
+                } else if (QTextEdit* te = qobject_cast<QTextEdit*>(info.widget)) {
                     val = te->toPlainText();
                 }
-                prompt.replace(pair.first, val);
+                prompt.replace(info.start, info.length, val);
             }
+            prompt.replace("{context}", m_contextText);
             m_finalPrompt = prompt;
             QDialog::accept();
         }
     } else {
+        prompt.replace("{context}", m_contextText);
+        m_finalPrompt = prompt;
         QDialog::accept();
     }
 }

--- a/src/AiActionDialog.cpp
+++ b/src/AiActionDialog.cpp
@@ -4,6 +4,10 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QVBoxLayout>
+#include <QRegularExpression>
+#include <QFormLayout>
+#include <QLineEdit>
+#include <QPushButton>
 
 AiActionDialog::AiActionDialog(const QString& title, const QString& labelText, const QString& defaultTemplate,
                                const QString& contextText, QWidget* parent)
@@ -18,7 +22,7 @@ AiActionDialog::AiActionDialog(const QString& title, const QString& labelText, c
     layout->addWidget(instructionLabel);
 
     m_instructionEdit = new QTextEdit(this);
-    m_instructionEdit->setPlaceholderText("Configure prompt using {context} placeholder...");
+    m_instructionEdit->setPlaceholderText("Configure prompt using {context}, {input \"label\"}, or {textarea \"label\"} placeholders...");
     m_instructionEdit->setAcceptRichText(false);
     m_instructionEdit->setPlainText(defaultTemplate);
     layout->addWidget(m_instructionEdit);
@@ -41,6 +45,71 @@ AiActionDialog::AiActionDialog(const QString& title, const QString& labelText, c
 }
 
 QString AiActionDialog::getPrompt() const {
+    return m_finalPrompt;
+}
+
+void AiActionDialog::accept() {
     QString prompt = m_instructionEdit->toPlainText();
-    return prompt.replace("{context}", m_contextText);
+    prompt.replace("{context}", m_contextText);
+    m_finalPrompt = prompt;
+
+    QRegularExpression re("\\{(input|textarea)\\s+\"([^\"]+)\"\\}");
+    QRegularExpressionMatchIterator i = re.globalMatch(prompt);
+
+    if (i.hasNext()) {
+        QDialog inputDlg(this);
+        inputDlg.setWindowTitle(tr("Provide Inputs"));
+        inputDlg.resize(400, 300);
+        QVBoxLayout* layout = new QVBoxLayout(&inputDlg);
+        QFormLayout* form = new QFormLayout();
+        layout->addLayout(form);
+
+        QList<QPair<QString, QWidget*>> inputWidgets;
+
+        while (i.hasNext()) {
+            QRegularExpressionMatch match = i.next();
+            QString type = match.captured(1);
+            QString label = match.captured(2);
+            QString fullMatch = match.captured(0);
+
+            QWidget* w = nullptr;
+            if (type == "input") {
+                w = new QLineEdit(&inputDlg);
+            } else if (type == "textarea") {
+                w = new QTextEdit(&inputDlg);
+            }
+
+            if (w) {
+                form->addRow(label + ":", w);
+                inputWidgets.append({fullMatch, w});
+            }
+        }
+
+        QHBoxLayout* btnLayout = new QHBoxLayout();
+        QPushButton* cancelBtn = new QPushButton(tr("Cancel"), &inputDlg);
+        QPushButton* okBtn = new QPushButton(tr("OK"), &inputDlg);
+        btnLayout->addStretch();
+        btnLayout->addWidget(cancelBtn);
+        btnLayout->addWidget(okBtn);
+        layout->addLayout(btnLayout);
+
+        connect(cancelBtn, &QPushButton::clicked, &inputDlg, &QDialog::reject);
+        connect(okBtn, &QPushButton::clicked, &inputDlg, &QDialog::accept);
+
+        if (inputDlg.exec() == QDialog::Accepted) {
+            for (const auto& pair : inputWidgets) {
+                QString val;
+                if (QLineEdit* le = qobject_cast<QLineEdit*>(pair.second)) {
+                    val = le->text();
+                } else if (QTextEdit* te = qobject_cast<QTextEdit*>(pair.second)) {
+                    val = te->toPlainText();
+                }
+                prompt.replace(pair.first, val);
+            }
+            m_finalPrompt = prompt;
+            QDialog::accept();
+        }
+    } else {
+        QDialog::accept();
+    }
 }

--- a/src/AiActionDialog.h
+++ b/src/AiActionDialog.h
@@ -7,6 +7,22 @@
 #include <QString>
 #include <QTextEdit>
 
+class QFormLayout;
+
+struct AiDynamicInputInfo {
+    QString fullMatch;
+    QString type;
+    QString label;
+    QWidget* widget = nullptr;
+
+    bool operator==(const AiDynamicInputInfo& other) const {
+        return fullMatch == other.fullMatch && type == other.type && label == other.label;
+    }
+    bool operator!=(const AiDynamicInputInfo& other) const {
+        return !(*this == other);
+    }
+};
+
 class AiActionDialog : public QDialog {
     Q_OBJECT
    public:
@@ -18,10 +34,15 @@ class AiActionDialog : public QDialog {
    public slots:
     void accept() override;
 
+   private slots:
+    void updateDynamicInputs();
+
    private:
     QTextEdit* m_instructionEdit;
     QString m_contextText;
     QString m_finalPrompt;
+    QFormLayout* m_dynamicInputsLayout;
+    QList<AiDynamicInputInfo> m_currentDynamicInputs;
 };
 
 #endif  // AIACTIONDIALOG_H

--- a/src/AiActionDialog.h
+++ b/src/AiActionDialog.h
@@ -15,9 +15,13 @@ class AiActionDialog : public QDialog {
 
     QString getPrompt() const;
 
+   public slots:
+    void accept() override;
+
    private:
     QTextEdit* m_instructionEdit;
     QString m_contextText;
+    QString m_finalPrompt;
 };
 
 #endif  // AIACTIONDIALOG_H


### PR DESCRIPTION
This commit fulfills the feature request to add support for `{input "label"}` and `{textarea "label"}` tags in the AI Operations templating engine.

**Changes included:**
*   Modified `AiActionDialog` to support prompt interception and substitution.
*   Modified `AIOperationsDialog` to support prompt interception and substitution.
*   Added dynamic `QDialog` builders populated with `QLineEdit` and `QTextEdit` widgets to fulfill tags.
*   Updated UI hint text to document the new tags.

---
*PR created automatically by Jules for task [117669472196434181](https://jules.google.com/task/117669472196434181) started by @arran4*