### PR TITLE
Add Danger Zone submenu and comprehensive delete actions

### DIFF
--- a/src/BookDatabase.cpp
+++ b/src/BookDatabase.cpp
@@ -963,6 +963,17 @@ QList<DocumentNode> BookDatabase::getTemplates(int folderId) const {
     return nodes;
 }
 
+bool BookDatabase::deleteTemplate(int id) {
+    if (!m_isOpen) return false;
+    const char* sql = "DELETE FROM templates WHERE id = ?;";
+    sqlite3_stmt* stmt;
+    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    sqlite3_bind_int(stmt, 1, id);
+    int rc = sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    return rc == SQLITE_DONE;
+}
+
 int BookDatabase::addDraft(int folderId, const QString& title, const QString& content) {
     if (!m_isOpen) return -1;
 

--- a/src/BookDatabase.h
+++ b/src/BookDatabase.h
@@ -137,6 +137,7 @@ class BookDatabase {
     int addTemplate(int folderId, const QString& title, const QString& content);
     bool updateTemplate(int id, const QString& newTitle, const QString& newContent);
     QList<DocumentNode> getTemplates(int folderId = -1) const;
+    bool deleteTemplate(int id);
 
     // Drafts
     int addDraft(int folderId, const QString& title, const QString& content);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1682,6 +1682,15 @@ void MainWindow::showItemContextMenu(QStandardItem* item, const QPoint& globalPo
 
         QAction* settingsAction = menu.addAction(QIcon::fromTheme("configure"), "Chat Settings...");
 
+        menu.addSeparator();
+        QMenu* dangerMenu = menu.addMenu(QIcon::fromTheme("dialog-warning"), "Danger Zone");
+        QAction* deleteAction = nullptr;
+        if (type == "chat_session") {
+            deleteAction = dangerMenu->addAction(QIcon::fromTheme("edit-delete"), "Delete Chat Session");
+        } else {
+            deleteAction = dangerMenu->addAction(QIcon::fromTheme("edit-delete"), "Delete Message");
+        }
+
         QAction* selectedAction = menu.exec(globalPos);
         if (selectedAction == copyAction) {
             QString fullText = item->text();
@@ -1705,6 +1714,20 @@ void MainWindow::showItemContextMenu(QStandardItem* item, const QPoint& globalPo
             exportChatSession();
         } else if (selectedAction == settingsAction) {
             showChatSettingsDialog(item->data(Qt::UserRole).toInt());
+        } else if (selectedAction == deleteAction) {
+            int id = item->data(Qt::UserRole).toInt();
+            if (currentDb) {
+                QString confirmMsg = type == "chat_session" ? tr("Are you sure you want to delete this Chat Session?") : tr("Are you sure you want to delete this Message?");
+                if (QMessageBox::question(this, tr("Confirm Delete"), confirmMsg, QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
+                    if (type == "chat_session") {
+                        currentDb->deleteFolder(id);
+                    } else {
+                        currentDb->deleteMessage(id);
+                    }
+                    loadDocumentsAndNotes();
+                    statusBar->showMessage(tr("Deleted successfully."), 3000);
+                }
+            }
         }
     } else if (type == "document" || type == "note" || type == "template" || type == "draft") {
         QMenu menu(this);
@@ -1721,15 +1744,24 @@ void MainWindow::showItemContextMenu(QStandardItem* item, const QPoint& globalPo
             menu.addSeparator();
         }
 
-        QAction* discardAction = nullptr;
-        if (type == "draft") {
-            discardAction = menu.addAction(QIcon::fromTheme("edit-delete"), "Discard Draft");
-            menu.addSeparator();
-        }
-
         if (type == "document" || type == "note") {
             exportAction = menu.addAction(QIcon::fromTheme("document-export"), "Export Markdown...");
             replaceAction = menu.addAction(QIcon::fromTheme("document-import"), "Replace with Import...");
+        }
+
+        menu.addSeparator();
+        QMenu* dangerMenu = menu.addMenu(QIcon::fromTheme("dialog-warning"), "Danger Zone");
+        QAction* discardAction = nullptr;
+        QAction* deleteAction = nullptr;
+
+        if (type == "draft") {
+            discardAction = dangerMenu->addAction(QIcon::fromTheme("edit-delete"), "Discard Draft");
+        } else if (type == "document") {
+            deleteAction = dangerMenu->addAction(QIcon::fromTheme("edit-delete"), "Delete Document");
+        } else if (type == "note") {
+            deleteAction = dangerMenu->addAction(QIcon::fromTheme("edit-delete"), "Delete Note");
+        } else if (type == "template") {
+            deleteAction = dangerMenu->addAction(QIcon::fromTheme("edit-delete"), "Delete Template");
         }
 
         QAction* selectedAction = menu.exec(globalPos);
@@ -1761,6 +1793,21 @@ void MainWindow::showItemContextMenu(QStandardItem* item, const QPoint& globalPo
                 currentDb->deleteDraft(docId);
                 loadDocumentsAndNotes();
                 statusBar->showMessage(tr("Draft discarded."), 3000);
+            }
+        } else if (deleteAction && selectedAction == deleteAction) {
+            int id = item->data(Qt::UserRole).toInt();
+            if (currentDb) {
+                if (QMessageBox::question(this, tr("Confirm Delete"), tr("Are you sure you want to delete this item?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
+                    if (type == "document") {
+                        currentDb->deleteDocument(id);
+                    } else if (type == "note") {
+                        currentDb->deleteNote(id);
+                    } else if (type == "template") {
+                        currentDb->deleteTemplate(id);
+                    }
+                    loadDocumentsAndNotes();
+                    statusBar->showMessage(tr("Deleted successfully."), 3000);
+                }
             }
         } else if (exportAction && selectedAction == exportAction) {
             exportDocument(item->data(Qt::UserRole).toInt(), type);


### PR DESCRIPTION
This PR introduces a "Danger Zone" submenu to the context menus of various items (chats, documents, notes, templates, drafts). This safely groups destructive actions together. It includes the logic to delete these entities securely via the `BookDatabase`, including a newly implemented `deleteTemplate` method. User confirmation is requested before performing any deletion.

---
*PR created automatically by Jules for task [13913867188000737658](https://jules.google.com/task/13913867188000737658) started by @arran4*