### PR TITLE
fix: clear completed queue events for items with errors

### DIFF
--- a/src/BookDatabase.cpp
+++ b/src/BookDatabase.cpp
@@ -1228,11 +1228,15 @@ bool BookDatabase::updateQueueProcessingId(int id, int processingId) {
 
 bool BookDatabase::updateQueueError(int id, const QString& error) {
     if (!m_isOpen) return false;
-    const char* sql = "UPDATE queue SET last_error = ?, processing_id = 0 WHERE id = ?;";
+    const char* sql = "UPDATE queue SET last_error = ?, processing_id = 0, state = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
     if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+
+    QString state = error.isEmpty() ? "pending" : "error";
+
     sqlite3_bind_text(stmt, 1, error.toUtf8().constData(), -1, SQLITE_TRANSIENT);
-    sqlite3_bind_int(stmt, 2, id);
+    sqlite3_bind_text(stmt, 2, state.toUtf8().constData(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 3, id);
     int rc = sqlite3_step(stmt);
     sqlite3_finalize(stmt);
     return rc == SQLITE_DONE;

--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -139,7 +139,7 @@ void QueueManager::clearCompleted() {
         if (!db || !db->isOpen()) continue;
         auto items = db->getQueue();
         for (const auto& item : items) {
-            if (item.state == "completed" || item.state == "error") {
+            if (item.state == "completed" || item.state == "error" || !item.lastError.isEmpty()) {
                 if (item.targetType == "document" && item.state == "completed") {
                     // Do not delete completed document generations automatically so user can review them.
                     continue;


### PR DESCRIPTION
Fixes the "Clear Completed" button functionality in the LLM Request Queue window to ensure that items with errors are also cleared properly. It modifies the underlying database operation to explicitly change the item state to 'error' rather than just setting an error string, and provides a fallback condition when evaluating whether an item is clearable.

---
*PR created automatically by Jules for task [4964021861433599432](https://jules.google.com/task/4964021861433599432) started by @arran4*