### PR TITLE
feat: Configure concurrent generations per LLM connection

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -807,11 +807,13 @@ void MainWindow::updateEndpointsList() {
         // Fallback for old setting
         endpointComboBox->addItem("Default Ollama", settings.value("ollamaUrl", "http://localhost:11434").toString());
         endpointComboBox->setItemData(0, "", Qt::UserRole + 1);  // Auth Key
+        endpointComboBox->setItemData(0, 1, Qt::UserRole + 2);   // Concurrency
     } else {
         for (int i = 0; i < connections.size(); ++i) {
             QVariantMap map = connections[i].toMap();
             endpointComboBox->addItem(map["name"].toString(), map["url"].toString());
             endpointComboBox->setItemData(i, map["authKey"].toString(), Qt::UserRole + 1);
+            endpointComboBox->setItemData(i, map.value("concurrency", 1).toInt(), Qt::UserRole + 2);
         }
     }
 
@@ -834,10 +836,14 @@ void MainWindow::onActiveEndpointChanged(int index) {
 
     QString url = endpointComboBox->itemData(index, Qt::UserRole).toString();
     QString authKey = endpointComboBox->itemData(index, Qt::UserRole + 1).toString();
+    int concurrency = endpointComboBox->itemData(index, Qt::UserRole + 2).toInt();
+    if (concurrency < 1) concurrency = 1;
 
     ollamaClient.setBaseUrl(url);
     ollamaClient.setAuthKey(authKey);
     ollamaClient.fetchModels();  // Test connection and fetch
+
+    QueueManager::instance().setMaxConcurrent(concurrency);
 
     QSettings settings;
     settings.setValue("lastEndpointIndex", index);
@@ -2495,86 +2501,97 @@ void MainWindow::onSendMessage() {
         if (text.isEmpty()) return;
     }
 
-    if (QueueManager::instance().isProcessing() && QueueManager::instance().currentProcessingDb() == currentDb) {
-        QueueItem item = QueueManager::instance().currentProcessingItem();
-        if (item.targetType == "message") {
-            bool isInCurrentPath = false;
-            if (item.messageId == currentLastNodeId) {
-                isInCurrentPath = true;
-            } else {
-                for (const auto& msg : currentChatPath) {
-                    if (msg.id == item.messageId) {
-                        isInCurrentPath = true;
-                        break;
+    if (QueueManager::instance().isProcessing() && QueueManager::instance().currentProcessingDbs().contains(currentDb)) {
+        QList<QueueItem> items = QueueManager::instance().currentProcessingItems();
+        bool conflictFound = false;
+        int conflictingItemId = -1;
+
+        for (const auto& item : items) {
+            if (item.targetType == "message") {
+                bool isInCurrentPath = false;
+                if (item.messageId == currentLastNodeId) {
+                    isInCurrentPath = true;
+                } else {
+                    for (const auto& msg : currentChatPath) {
+                        if (msg.id == item.messageId) {
+                            isInCurrentPath = true;
+                            break;
+                        }
                     }
+                }
+
+                if (isInCurrentPath) {
+                    conflictFound = true;
+                    conflictingItemId = item.id;
+                    break;
                 }
             }
+        }
 
-            if (isInCurrentPath) {
-                QMessageBox msgBox(this);
-                msgBox.setWindowTitle(tr("Active Generation Conflict"));
-                msgBox.setText(tr(
-                    "This chat is currently generating a response.\nWhat would you like to do with your new message?"));
+        if (conflictFound) {
+            QMessageBox msgBox(this);
+            msgBox.setWindowTitle(tr("Active Generation Conflict"));
+            msgBox.setText(tr(
+                "This chat is currently generating a response.\nWhat would you like to do with your new message?"));
 
-                QPushButton* queueBtn = msgBox.addButton(tr("Queue to send later"), QMessageBox::AcceptRole);
-                QPushButton* forkBtn = msgBox.addButton(tr("Fork and send"), QMessageBox::AcceptRole);
-                QPushButton* cancelReplaceBtn =
-                    msgBox.addButton(tr("Cancel previous and replace"), QMessageBox::AcceptRole);
-                QPushButton* draftsBtn = msgBox.addButton(tr("Save to drafts"), QMessageBox::ActionRole);
-                QPushButton* ignoreBtn = msgBox.addButton(tr("Ignore text and clear"), QMessageBox::DestructiveRole);
-                QPushButton* cancelBtn = msgBox.addButton(tr("Cancel"), QMessageBox::RejectRole);
+            QPushButton* queueBtn = msgBox.addButton(tr("Queue to send later"), QMessageBox::AcceptRole);
+            QPushButton* forkBtn = msgBox.addButton(tr("Fork and send"), QMessageBox::AcceptRole);
+            QPushButton* cancelReplaceBtn =
+                msgBox.addButton(tr("Cancel previous and replace"), QMessageBox::AcceptRole);
+            QPushButton* draftsBtn = msgBox.addButton(tr("Save to drafts"), QMessageBox::ActionRole);
+            QPushButton* ignoreBtn = msgBox.addButton(tr("Ignore text and clear"), QMessageBox::DestructiveRole);
+            QPushButton* cancelBtn = msgBox.addButton(tr("Cancel"), QMessageBox::RejectRole);
 
-                msgBox.exec();
+            msgBox.exec();
 
-                QAbstractButton* clicked = msgBox.clickedButton();
-                if (clicked == draftsBtn) {
-                    currentDb->addDraft(0, text.left(30) + "...", text);
-                    if (!toggleInputModeBtn->isChecked())
-                        inputField->clear();
-                    else
-                        multiLineInput->clear();
-                    loadDocumentsAndNotes();
-                    return;
-                } else if (clicked == ignoreBtn) {
-                    if (!toggleInputModeBtn->isChecked())
-                        inputField->clear();
-                    else
-                        multiLineInput->clear();
-                    return;
-                } else if (clicked == cancelBtn) {
-                    return;  // Abort sending, keep text
-                } else if (clicked == cancelReplaceBtn) {
-                    QueueManager::instance().cancelItem(currentDb, item.id);
-                } else if (clicked == forkBtn) {
-                    // To fork from the parent of the currently generating node:
-                    int forkParentId = 0;
-                    if (currentChatPath.size() >= 2) {
-                        forkParentId = currentChatPath[currentChatPath.size() - 2].id;
-                    }
-
-                    if (!toggleInputModeBtn->isChecked())
-                        inputField->clear();
-                    else
-                        multiLineInput->clear();
-
-                    int userMsgId = currentDb->addMessage(forkParentId, text, "user");
-                    int aiId = currentDb->addMessage(userMsgId, "", "assistant");
-                    currentLastNodeId = aiId;
-
-                    QString model = m_selectedModel;
-                    if (model.isEmpty() && !m_availableModels.isEmpty()) {
-                        model = m_availableModels.first();
-                    }
-
-                    QueueManager::instance().enqueuePrompt(aiId, model, text);
-
-                    loadDocumentsAndNotes();  // Refresh tree
-                    updateLinearChatView(currentLastNodeId, currentDb->getMessages());
-                    statusBar->showMessage(tr("Fork task queued."), 3000);
-                    return;
-                } else if (clicked == queueBtn) {
-                    // Fallthrough to normal send, it will queue naturally because it is an enqueuePrompt call.
+            QAbstractButton* clicked = msgBox.clickedButton();
+            if (clicked == draftsBtn) {
+                currentDb->addDraft(0, text.left(30) + "...", text);
+                if (!toggleInputModeBtn->isChecked())
+                    inputField->clear();
+                else
+                    multiLineInput->clear();
+                loadDocumentsAndNotes();
+                return;
+            } else if (clicked == ignoreBtn) {
+                if (!toggleInputModeBtn->isChecked())
+                    inputField->clear();
+                else
+                    multiLineInput->clear();
+                return;
+            } else if (clicked == cancelBtn) {
+                return;  // Abort sending, keep text
+            } else if (clicked == cancelReplaceBtn) {
+                QueueManager::instance().cancelItem(currentDb, conflictingItemId);
+            } else if (clicked == forkBtn) {
+                // To fork from the parent of the currently generating node:
+                int forkParentId = 0;
+                if (currentChatPath.size() >= 2) {
+                    forkParentId = currentChatPath[currentChatPath.size() - 2].id;
                 }
+
+                if (!toggleInputModeBtn->isChecked())
+                    inputField->clear();
+                else
+                    multiLineInput->clear();
+
+                int userMsgId = currentDb->addMessage(forkParentId, text, "user");
+                int aiId = currentDb->addMessage(userMsgId, "", "assistant");
+                currentLastNodeId = aiId;
+
+                QString model = m_selectedModel;
+                if (model.isEmpty() && !m_availableModels.isEmpty()) {
+                    model = m_availableModels.first();
+                }
+
+                QueueManager::instance().enqueuePrompt(aiId, model, text);
+
+                loadDocumentsAndNotes();  // Refresh tree
+                updateLinearChatView(currentLastNodeId, currentDb->getMessages());
+                statusBar->showMessage(tr("Fork task queued."), 3000);
+                return;
+            } else if (clicked == queueBtn) {
+                // Fallthrough to normal send, it will queue naturally because it is an enqueuePrompt call.
             }
         }
     }

--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -26,11 +26,40 @@ void QueueManager::addDatabase(std::shared_ptr<BookDatabase> db) {
 void QueueManager::removeDatabase(std::shared_ptr<BookDatabase> db) {
     m_databases.removeAll(db);
     if (m_activeDb == db) m_activeDb = nullptr;
-    if (m_currentDb == db) {
-        m_currentDb = nullptr;
-        m_isProcessing = false;
+
+    QList<int> keysToRemove;
+    for (auto it = m_activeItems.begin(); it != m_activeItems.end(); ++it) {
+        if (it.value().db == db) {
+            keysToRemove.append(it.key());
+        }
+    }
+    for (int key : keysToRemove) {
+        m_activeItems.remove(key);
     }
     emit queueChanged();
+}
+
+QList<QueueItem> QueueManager::currentProcessingItems() const {
+    QList<QueueItem> items;
+    for (const auto& mergedItem : m_activeItems) {
+        items.append(mergedItem.item);
+    }
+    return items;
+}
+
+QList<std::shared_ptr<BookDatabase>> QueueManager::currentProcessingDbs() const {
+    QList<std::shared_ptr<BookDatabase>> dbs;
+    for (const auto& mergedItem : m_activeItems) {
+        if (!dbs.contains(mergedItem.db)) {
+            dbs.append(mergedItem.db);
+        }
+    }
+    return dbs;
+}
+
+void QueueManager::setMaxConcurrent(int max) {
+    m_maxConcurrent = max;
+    QTimer::singleShot(0, this, &QueueManager::checkQueue);
 }
 
 void QueueManager::retryItem(std::shared_ptr<BookDatabase> db, int queueId) {
@@ -97,7 +126,7 @@ int QueueManager::pendingCount(std::shared_ptr<BookDatabase> db) const {
 }
 
 void QueueManager::checkQueue() {
-    if (m_isProcessing || m_isPaused || !m_client || m_databases.isEmpty()) return;
+    if (m_activeItems.size() >= m_maxConcurrent || m_isPaused || !m_client || m_databases.isEmpty()) return;
     processNext();
 }
 
@@ -124,10 +153,9 @@ QList<QueueManager::MergedQueueItem> QueueManager::getMergedQueue() const {
  */
 void QueueManager::cancelItem(std::shared_ptr<BookDatabase> db, int queueId) {
     if (db) db->deleteQueueItem(queueId);
-    if (m_currentDb == db && m_currentItem.id == queueId) {
+    if (m_activeItems.contains(queueId) && m_activeItems[queueId].db == db) {
         // Ideally we'd abort the network request here
-        m_isProcessing = false;
-        m_currentDb = nullptr;
+        m_activeItems.remove(queueId);
     }
     emit queueChanged();
 }
@@ -164,7 +192,7 @@ void QueueManager::resumeQueue() {
  * @brief Advances the queue consumer to begin execution of the next pending element.
  */
 void QueueManager::processNext() {
-    if (m_isProcessing) return;
+    if (m_activeItems.size() >= m_maxConcurrent) return;
 
     QSettings settings;
     QString processingMode = settings.value("queueProcessing", "FCFS").toString();
@@ -175,7 +203,7 @@ void QueueManager::processNext() {
         if (!db || !db->isOpen()) continue;
         auto items = db->getQueue();
         for (const auto& item : items) {
-            if (item.processingId == 0 && item.lastError.isEmpty()) {
+            if (item.processingId == 0 && item.lastError.isEmpty() && !m_activeItems.contains(item.id)) {
                 allPending.append({db, item});
             }
         }
@@ -231,32 +259,35 @@ void QueueManager::processNext() {
                   }
               });
 
-    auto nextItem = allPending.first();
-    m_currentDb = nextItem.db;
-    m_currentItem = nextItem.item;
+    while (m_activeItems.size() < m_maxConcurrent && !allPending.isEmpty()) {
+        auto nextItem = allPending.takeFirst();
+        int queueId = nextItem.item.id;
 
-    m_isProcessing = true;
-    m_currentItem.processingId = QCoreApplication::applicationPid();
-    m_currentDb->updateQueueProcessingId(m_currentItem.id, m_currentItem.processingId);
-    m_currentDb->updateQueueItemState(m_currentItem.id, "processing");
-    m_currentItem.state = "processing";
-    m_lastProcessedModel = m_currentItem.model;
-    emit processingStarted(m_currentDb, m_currentItem.messageId, m_currentItem.targetType);
-    emit queueChanged();
+        nextItem.item.processingId = QCoreApplication::applicationPid();
+        nextItem.db->updateQueueProcessingId(queueId, nextItem.item.processingId);
+        nextItem.db->updateQueueItemState(queueId, "processing");
+        nextItem.item.state = "processing";
+        m_lastProcessedModel = nextItem.item.model;
 
-    QString sysPrompt = m_currentDb->getInheritedSetting(m_currentItem.messageId, "systemPrompt");
-    if (sysPrompt.isEmpty()) {
-        sysPrompt = m_currentDb->getSetting("book", 0, "systemPrompt", "");
+        m_activeItems[queueId] = nextItem;
+
+        emit processingStarted(nextItem.db, nextItem.item.messageId, nextItem.item.targetType);
+        emit queueChanged();
+
+        QString sysPrompt = nextItem.db->getInheritedSetting(nextItem.item.messageId, "systemPrompt");
+        if (sysPrompt.isEmpty()) {
+            sysPrompt = nextItem.db->getSetting("book", 0, "systemPrompt", "");
+        }
+        if (sysPrompt.isEmpty()) {
+            QSettings settings;
+            sysPrompt = settings.value("globalSystemPrompt", "").toString();
+        }
+        m_client->setSystemPrompt(sysPrompt);
+
+        m_client->generate(
+            nextItem.item.model, nextItem.item.prompt, [this, queueId](const QString& chunk) { onChunk(queueId, chunk); },
+            [this, queueId](const QString& response) { onComplete(queueId, response); }, [this, queueId](const QString& error) { onError(queueId, error); });
     }
-    if (sysPrompt.isEmpty()) {
-        QSettings settings;
-        sysPrompt = settings.value("globalSystemPrompt", "").toString();
-    }
-    m_client->setSystemPrompt(sysPrompt);
-
-    m_client->generate(
-        m_currentItem.model, m_currentItem.prompt, [this](const QString& chunk) { onChunk(chunk); },
-        [this](const QString& response) { onComplete(response); }, [this](const QString& error) { onError(error); });
 }
 
 /**
@@ -264,25 +295,26 @@ void QueueManager::processNext() {
  *
  * @param chunk The text sequence slice.
  */
-void QueueManager::onChunk(const QString& chunk) {
-    if (!m_isProcessing) return;
-    if (m_currentDb && m_currentDb->isOpen()) {
+void QueueManager::onChunk(int queueId, const QString& chunk) {
+    if (!m_activeItems.contains(queueId)) return;
+    auto item = m_activeItems[queueId];
+    if (item.db && item.db->isOpen()) {
         QString currentContent;
-        if (m_currentItem.targetType == "document") {
+        if (item.item.targetType == "document") {
             // For documents, we do not update the document directly.
             // Just emit the chunk for the preview.
         } else {
             // Get existing content and append
-            auto messages = m_currentDb->getMessages();
+            auto messages = item.db->getMessages();
             for (const auto& m : messages) {
-                if (m.id == m_currentItem.messageId) {
+                if (m.id == item.item.messageId) {
                     currentContent = m.content;
                     break;
                 }
             }
-            m_currentDb->updateMessage(m_currentItem.messageId, currentContent + chunk);
+            item.db->updateMessage(item.item.messageId, currentContent + chunk);
         }
-        emit processingChunk(m_currentDb, m_currentItem.messageId, chunk, m_currentItem.targetType);
+        emit processingChunk(item.db, item.item.messageId, chunk, item.item.targetType);
     }
 }
 
@@ -291,38 +323,36 @@ void QueueManager::onChunk(const QString& chunk) {
  *
  * @param response The complete generated text payload.
  */
-void QueueManager::onComplete(const QString& response) {
-    if (!m_isProcessing) return;
-    if (m_currentDb && m_currentDb->isOpen()) {
-        if (m_currentItem.targetType == "document") {
+void QueueManager::onComplete(int queueId, const QString& response) {
+    if (!m_activeItems.contains(queueId)) return;
+    auto item = m_activeItems.take(queueId);
+
+    if (item.db && item.db->isOpen()) {
+        if (item.item.targetType == "document") {
             // Document results are queued for review, NOT applied immediately.
-            m_currentDb->updateQueueItemState(m_currentItem.id, "completed", response);
-            m_currentDb->addNotification(m_currentItem.id, "review_needed");
+            item.db->updateQueueItemState(item.item.id, "completed", response);
+            item.db->addNotification(item.item.id, "review_needed");
         } else {
-            m_currentDb->updateMessage(m_currentItem.messageId, response);
-            m_currentDb->deleteQueueItem(m_currentItem.id);
-            m_currentDb->addNotification(m_currentItem.messageId, "responded_to");
+            item.db->updateMessage(item.item.messageId, response);
+            item.db->deleteQueueItem(item.item.id);
+            item.db->addNotification(item.item.messageId, "responded_to");
         }
 
-        m_currentItem.processingId = 0;
+        item.item.processingId = 0;
 
-        // Remove tracking completed items in memory to let DB act as source of truth.
-        // m_completedItems.append({m_currentDb, m_currentItem}); // deprecated
+        item.db->setSetting(item.item.targetType, item.item.messageId, "model", item.item.model);
 
-        m_currentDb->setSetting(m_currentItem.targetType, m_currentItem.messageId, "model", m_currentItem.model);
-
-        QString sysPrompt = m_currentDb->getInheritedSetting(m_currentItem.messageId, "systemPrompt");
+        QString sysPrompt = item.db->getInheritedSetting(item.item.messageId, "systemPrompt");
         if (sysPrompt.isEmpty()) {
-            sysPrompt = m_currentDb->getSetting("book", 0, "systemPrompt", "");
+            sysPrompt = item.db->getSetting("book", 0, "systemPrompt", "");
         }
         if (sysPrompt.isEmpty()) {
             QSettings settings;
             sysPrompt = settings.value("globalSystemPrompt", "").toString();
         }
-        m_currentDb->setSetting(m_currentItem.targetType, m_currentItem.messageId, "systemPrompt", sysPrompt);
+        item.db->setSetting(item.item.targetType, item.item.messageId, "systemPrompt", sysPrompt);
     }
-    m_isProcessing = false;
-    emit processingFinished(m_currentDb, m_currentItem.messageId, true, m_currentItem.targetType);
+    emit processingFinished(item.db, item.item.messageId, true, item.item.targetType);
     emit queueChanged();
 
     // Pick up next item after a short delay to avoid tight loop issues
@@ -334,14 +364,15 @@ void QueueManager::onComplete(const QString& response) {
  *
  * @param error The descriptive error message.
  */
-void QueueManager::onError(const QString& error) {
-    if (!m_isProcessing) return;
-    if (m_currentDb && m_currentDb->isOpen()) {
-        m_currentDb->updateQueueError(m_currentItem.id, error);
-        m_currentDb->addNotification(m_currentItem.messageId, "error");
+void QueueManager::onError(int queueId, const QString& error) {
+    if (!m_activeItems.contains(queueId)) return;
+    auto item = m_activeItems.take(queueId);
+
+    if (item.db && item.db->isOpen()) {
+        item.db->updateQueueError(item.item.id, error);
+        item.db->addNotification(item.item.messageId, "error");
     }
-    m_isProcessing = false;
-    emit processingFinished(m_currentDb, m_currentItem.messageId, false, m_currentItem.targetType);
+    emit processingFinished(item.db, item.item.messageId, false, item.item.targetType);
     emit queueChanged();
 
     QTimer::singleShot(500, this, &QueueManager::checkQueue);

--- a/src/QueueManager.h
+++ b/src/QueueManager.h
@@ -41,9 +41,11 @@ class QueueManager : public QObject {
     void resumeQueue();
     bool isPaused() const { return m_isPaused; }
 
-    bool isProcessing() const { return m_isProcessing; }
-    QueueItem currentProcessingItem() const { return m_currentItem; }
-    std::shared_ptr<BookDatabase> currentProcessingDb() const { return m_currentDb; }
+    bool isProcessing() const { return !m_activeItems.isEmpty(); }
+    QList<QueueItem> currentProcessingItems() const;
+    QList<std::shared_ptr<BookDatabase>> currentProcessingDbs() const;
+
+    void setMaxConcurrent(int max);
 
    public slots:
     void checkQueue();
@@ -57,9 +59,9 @@ class QueueManager : public QObject {
                             const QString& targetType = "message");
 
    private slots:
-    void onChunk(const QString& chunk);
-    void onComplete(const QString& response);
-    void onError(const QString& error);
+    void onChunk(int queueId, const QString& chunk);
+    void onComplete(int queueId, const QString& response);
+    void onError(int queueId, const QString& error);
 
    private:
     explicit QueueManager(QObject* parent = nullptr);
@@ -70,9 +72,9 @@ class QueueManager : public QObject {
     OllamaClient* m_client = nullptr;
     QTimer* m_timer;
 
-    bool m_isProcessing = false;
-    std::shared_ptr<BookDatabase> m_currentDb = nullptr;
-    QueueItem m_currentItem;
+    QMap<int, MergedQueueItem> m_activeItems;
+    int m_maxConcurrent = 1;
+
     int m_currentIndex = 0;
     bool m_isPaused = false;
     QString m_lastProcessedModel;

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -9,7 +9,7 @@
 #include <QNetworkRequest>
 
 ConnectionDialog::ConnectionDialog(QWidget* parent, const QString& name, const QString& backend, const QString& url,
-                                   const QString& authKey)
+                                   const QString& authKey, int concurrency)
     : QDialog(parent) {
     setWindowTitle(tr("Connection Settings"));
 
@@ -30,6 +30,11 @@ ConnectionDialog::ConnectionDialog(QWidget* parent, const QString& name, const Q
     m_authKeyEdit = new QLineEdit(authKey, this);
     m_authKeyEdit->setEchoMode(QLineEdit::PasswordEchoOnEdit);
     formLayout->addRow(tr("Auth Key:"), m_authKeyEdit);
+
+    m_concurrencySpin = new QSpinBox(this);
+    m_concurrencySpin->setRange(1, 10);
+    m_concurrencySpin->setValue(concurrency);
+    formLayout->addRow(tr("Concurrency:"), m_concurrencySpin);
 
     mainLayout->addLayout(formLayout);
 
@@ -59,6 +64,8 @@ QString ConnectionDialog::backend() const { return m_backendCombo->currentText()
 QString ConnectionDialog::url() const { return m_urlEdit->text(); }
 
 QString ConnectionDialog::authKey() const { return m_authKeyEdit->text(); }
+
+int ConnectionDialog::concurrency() const { return m_concurrencySpin->value(); }
 
 void ConnectionDialog::onTestConnection() {
     m_testButton->setEnabled(false);
@@ -141,8 +148,8 @@ SettingsDialog::SettingsDialog(QWidget* parent) : QDialog(parent) {
     mainLayout->addWidget(llmLabel);
 
     m_connectionsTable = new QTableWidget(this);
-    m_connectionsTable->setColumnCount(4);
-    m_connectionsTable->setHorizontalHeaderLabels({tr("Name"), tr("Backend"), tr("URL"), tr("Auth Key")});
+    m_connectionsTable->setColumnCount(5);
+    m_connectionsTable->setHorizontalHeaderLabels({tr("Name"), tr("Backend"), tr("URL"), tr("Auth Key"), tr("Concurrency")});
     m_connectionsTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
     m_connectionsTable->setSelectionBehavior(QAbstractItemView::SelectRows);
     m_connectionsTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
@@ -208,6 +215,7 @@ void SettingsDialog::loadConnections() {
         defaultConn["backend"] = "Ollama";
         defaultConn["url"] = m_settings.value("ollamaUrl", "http://localhost:11434").toString();
         defaultConn["authKey"] = "";
+        defaultConn["concurrency"] = 1;
         connections.append(defaultConn);
     }
 
@@ -220,6 +228,7 @@ void SettingsDialog::loadConnections() {
         m_connectionsTable->setItem(row, 1, new QTableWidgetItem(map.value("backend", "Ollama").toString()));
         m_connectionsTable->setItem(row, 2, new QTableWidgetItem(map["url"].toString()));
         m_connectionsTable->setItem(row, 3, new QTableWidgetItem(map["authKey"].toString()));
+        m_connectionsTable->setItem(row, 4, new QTableWidgetItem(QString::number(map.value("concurrency", 1).toInt())));
     }
 }
 
@@ -231,6 +240,7 @@ void SettingsDialog::saveConnections() {
         map["backend"] = m_connectionsTable->item(i, 1)->text();
         map["url"] = m_connectionsTable->item(i, 2)->text();
         map["authKey"] = m_connectionsTable->item(i, 3)->text();
+        map["concurrency"] = m_connectionsTable->item(i, 4)->text().toInt();
         connections.append(map);
     }
     m_settings.setValue("llmConnections", connections);
@@ -245,6 +255,7 @@ void SettingsDialog::onAddConnection() {
         m_connectionsTable->setItem(row, 1, new QTableWidgetItem(dialog.backend()));
         m_connectionsTable->setItem(row, 2, new QTableWidgetItem(dialog.url()));
         m_connectionsTable->setItem(row, 3, new QTableWidgetItem(dialog.authKey()));
+        m_connectionsTable->setItem(row, 4, new QTableWidgetItem(QString::number(dialog.concurrency())));
     }
 }
 
@@ -256,13 +267,15 @@ void SettingsDialog::onEditConnection() {
     QString backend = m_connectionsTable->item(row, 1)->text();
     QString url = m_connectionsTable->item(row, 2)->text();
     QString authKey = m_connectionsTable->item(row, 3)->text();
+    int concurrency = m_connectionsTable->item(row, 4)->text().toInt();
 
-    ConnectionDialog dialog(this, name, backend, url, authKey);
+    ConnectionDialog dialog(this, name, backend, url, authKey, concurrency);
     if (dialog.exec() == QDialog::Accepted) {
         m_connectionsTable->item(row, 0)->setText(dialog.name());
         m_connectionsTable->item(row, 1)->setText(dialog.backend());
         m_connectionsTable->item(row, 2)->setText(dialog.url());
         m_connectionsTable->item(row, 3)->setText(dialog.authKey());
+        m_connectionsTable->item(row, 4)->setText(QString::number(dialog.concurrency()));
     }
 }
 

--- a/src/SettingsDialog.h
+++ b/src/SettingsDialog.h
@@ -16,18 +16,21 @@
 #include <QVariantList>
 #include <QVariantMap>
 
+#include <QSpinBox>
+
 class ConnectionDialog : public QDialog {
     Q_OBJECT
    public:
     explicit ConnectionDialog(QWidget* parent = nullptr, const QString& name = "New Connection",
                               const QString& backend = "Ollama", const QString& url = "http://localhost:11434",
-                              const QString& authKey = "");
+                              const QString& authKey = "", int concurrency = 1);
     ~ConnectionDialog();
 
     QString name() const;
     QString backend() const;
     QString url() const;
     QString authKey() const;
+    int concurrency() const;
 
    private slots:
     void onTestConnection();
@@ -37,6 +40,7 @@ class ConnectionDialog : public QDialog {
     QComboBox* m_backendCombo;
     QLineEdit* m_urlEdit;
     QLineEdit* m_authKeyEdit;
+    QSpinBox* m_concurrencySpin;
     QPushButton* m_testButton;
 };
 


### PR DESCRIPTION
This change allows users to configure the number of concurrent LLM generations on a per-connection basis within the Settings dialog.

Previously, `QueueManager` enforced strict single-item processing. It has now been refactored to handle multiple parallel requests by iterating up to the configured `m_maxConcurrent` limit for the active endpoint. Corresponding checks throughout the application, such as verifying active message paths in `MainWindow::onSendMessage`, have been updated to evaluate the entire list of currently generating items instead of just a single active item.

---
*PR created automatically by Jules for task [14113479432969075849](https://jules.google.com/task/14113479432969075849) started by @arran4*