### PR TITLE
Add font and zoom settings to global editor view

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -529,6 +529,21 @@ void MainWindow::setupUi() {
     splitter->setStretchFactor(0, 0);
     splitter->setStretchFactor(1, 1);
 
+    QAction* zoomInAction = new QAction(QIcon::fromTheme("zoom-in"), tr("Zoom In"), this);
+    zoomInAction->setShortcut(QKeySequence::ZoomIn);
+    actionCollection()->addAction(QStringLiteral("zoom_in"), zoomInAction);
+    connect(zoomInAction, &QAction::triggered, this, &MainWindow::zoomIn);
+
+    QAction* zoomOutAction = new QAction(QIcon::fromTheme("zoom-out"), tr("Zoom Out"), this);
+    zoomOutAction->setShortcut(QKeySequence::ZoomOut);
+    actionCollection()->addAction(QStringLiteral("zoom_out"), zoomOutAction);
+    connect(zoomOutAction, &QAction::triggered, this, &MainWindow::zoomOut);
+
+    QAction* resetZoomAction = new QAction(QIcon::fromTheme("zoom-original"), tr("Reset Zoom"), this);
+    resetZoomAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_0));
+    actionCollection()->addAction(QStringLiteral("reset_zoom"), resetZoomAction);
+    connect(resetZoomAction, &QAction::triggered, this, &MainWindow::resetZoom);
+
     QAction* newBookAction = new QAction(QIcon::fromTheme("document-new"), tr("New Book"), this);
     QAction* exportChatAction = new QAction(QIcon::fromTheme("document-export"), tr("Export Chat Session"), this);
     actionCollection()->addAction(QStringLiteral("export_chat_session"), exportChatAction);
@@ -654,11 +669,17 @@ void MainWindow::setupUi() {
     connect(draftDebounceTimer, &QTimer::timeout, this, saveDraftFunc);
     connect(inputField, &ChatInputWidget::textChanged, this, [this, draftDebounceTimer]() {
         draftDebounceTimer->start();
-        if (inputField->toPlainText().isEmpty()) dismissDraftBtn->hide(); else dismissDraftBtn->show();
+        if (inputField->toPlainText().isEmpty())
+            dismissDraftBtn->hide();
+        else
+            dismissDraftBtn->show();
     });
     connect(multiLineInput, &QTextEdit::textChanged, this, [this, draftDebounceTimer]() {
         draftDebounceTimer->start();
-        if (multiLineInput->toPlainText().isEmpty()) dismissDraftBtn->hide(); else dismissDraftBtn->show();
+        if (multiLineInput->toPlainText().isEmpty())
+            dismissDraftBtn->hide();
+        else
+            dismissDraftBtn->show();
     });
 
     connect(chatModel, &QStandardItemModel::itemChanged, this, &MainWindow::onItemChanged);
@@ -803,6 +824,7 @@ void MainWindow::setupUi() {
 
     updateEndpointsList();
     loadBooks();
+    updateApplicationFont();
 }
 
 /** * @brief Refreshes the combobox containing remote Ollama API endpoint targets. *  * This function is an integral
@@ -879,6 +901,7 @@ void MainWindow::showSettingsDialog() {
     connect(dlg, &SettingsDialog::settingsApplied, this, [this]() {
         updateEndpointsList();
         updateInputBehavior();
+        updateApplicationFont();
     });
     dlg->setAttribute(Qt::WA_DeleteOnClose);
     dlg->show();
@@ -2505,7 +2528,7 @@ void MainWindow::onDismissDraft() {
         if (cnDraft.version == m_activeDraftVersion) {
             cnDraft.draftPrompt = "";
             if (currentDb->updateChat(cnDraft)) {
-                m_activeDraftVersion++; // Sync with optimistic lock
+                m_activeDraftVersion++;  // Sync with optimistic lock
             }
         }
     }
@@ -2575,7 +2598,7 @@ void MainWindow::onSendMessage() {
             if (isInCurrentPath) {
                 hasActiveGeneration = true;
                 item = qItem;
-                break; // Found conflicting generation
+                break;  // Found conflicting generation
             }
         }
     }
@@ -2583,13 +2606,12 @@ void MainWindow::onSendMessage() {
     if (hasActiveGeneration) {
         QMessageBox msgBox(this);
         msgBox.setWindowTitle(tr("Active Generation Conflict"));
-        msgBox.setText(tr(
-            "This chat is currently generating a response.\nWhat would you like to do with your new message?"));
+        msgBox.setText(
+            tr("This chat is currently generating a response.\nWhat would you like to do with your new message?"));
 
         QPushButton* queueBtn = msgBox.addButton(tr("Queue to send later"), QMessageBox::AcceptRole);
         QPushButton* forkBtn = msgBox.addButton(tr("Fork and send"), QMessageBox::AcceptRole);
-        QPushButton* cancelReplaceBtn =
-            msgBox.addButton(tr("Cancel previous and replace"), QMessageBox::AcceptRole);
+        QPushButton* cancelReplaceBtn = msgBox.addButton(tr("Cancel previous and replace"), QMessageBox::AcceptRole);
         QPushButton* draftsBtn = msgBox.addButton(tr("Save to drafts"), QMessageBox::ActionRole);
         QPushButton* ignoreBtn = msgBox.addButton(tr("Ignore text and clear"), QMessageBox::DestructiveRole);
         QPushButton* cancelBtn = msgBox.addButton(tr("Cancel"), QMessageBox::RejectRole);
@@ -3875,18 +3897,21 @@ class GlobalSpyWindow : public QWidget {
 
         m_spyTextEdit = new QTextEdit(this);
         m_spyTextEdit->setReadOnly(true);
-        m_spyTextEdit->document()->setMaximumBlockCount(1000); // Act as a circular buffer
+        m_spyTextEdit->document()->setMaximumBlockCount(1000);  // Act as a circular buffer
         baseLayout->addWidget(m_spyTextEdit);
 
         if (OllamaClient* client = QueueManager::instance().client()) {
             connect(client, &OllamaClient::requestSent, this,
                     [this](const QString& model, const QString& systemPrompt, const QString& prompt) {
                         m_spyTextEdit->moveCursor(QTextCursor::End);
-                        m_spyTextEdit->insertHtml(QString("<hr><b>[Request Sent]</b> Model: %1<br>").arg(model.toHtmlEscaped()));
+                        m_spyTextEdit->insertHtml(
+                            QString("<hr><b>[Request Sent]</b> Model: %1<br>").arg(model.toHtmlEscaped()));
                         if (!systemPrompt.isEmpty()) {
-                            m_spyTextEdit->insertHtml(QString("<b>System:</b><br>%1<br>").arg(systemPrompt.toHtmlEscaped().replace("\n", "<br>")));
+                            m_spyTextEdit->insertHtml(QString("<b>System:</b><br>%1<br>")
+                                                          .arg(systemPrompt.toHtmlEscaped().replace("\n", "<br>")));
                         }
-                        m_spyTextEdit->insertHtml(QString("<b>User:</b><br>%1<br><br><b>Response:</b><br>").arg(prompt.toHtmlEscaped().replace("\n", "<br>")));
+                        m_spyTextEdit->insertHtml(QString("<b>User:</b><br>%1<br><br><b>Response:</b><br>")
+                                                      .arg(prompt.toHtmlEscaped().replace("\n", "<br>")));
                         m_spyTextEdit->moveCursor(QTextCursor::End);
                     });
         }
@@ -3901,7 +3926,8 @@ class GlobalSpyWindow : public QWidget {
         connect(&QueueManager::instance(), &QueueManager::processingFinished, this,
                 [this](std::shared_ptr<BookDatabase> db, int messageId, bool success, const QString& type) {
                     m_spyTextEdit->moveCursor(QTextCursor::End);
-                    m_spyTextEdit->insertHtml(success ? "<br><br><b>[Finished]</b><br>" : "<br><br><b><font color='red'>[Error]</font></b><br>");
+                    m_spyTextEdit->insertHtml(success ? "<br><br><b>[Finished]</b><br>"
+                                                      : "<br><br><b><font color='red'>[Error]</font></b><br>");
                     m_spyTextEdit->moveCursor(QTextCursor::End);
                 });
     }
@@ -4640,4 +4666,42 @@ void MainWindow::onChatForkExplorerContextMenu(const QPoint& pos) {
             if (currentDb) updateLinearChatView(currentLastNodeId, currentDb->getMessages());
         }
     }
+}
+
+void MainWindow::updateApplicationFont() {
+    QSettings settings;
+    QFont defaultFont = QApplication::font();
+    QString fontFamily = settings.value("globalFontFamily", defaultFont.family()).toString();
+    int fontSize = settings.value("globalFontSize", defaultFont.pointSize()).toInt();
+
+    // The zoom feature will apply a delta over the base font size.
+    int zoomDelta = settings.value("zoomDelta", 0).toInt();
+
+    QFont appFont(fontFamily, fontSize + zoomDelta);
+
+    if (chatTextArea) chatTextArea->setFont(appFont);
+    if (documentEditorView) documentEditorView->setFont(appFont);
+    if (noteEditorView) noteEditorView->setFont(appFont);
+    if (inputField) inputField->setFont(appFont);
+    if (multiLineInput) multiLineInput->setFont(appFont);
+}
+
+void MainWindow::zoomIn() {
+    QSettings settings;
+    int zoomDelta = settings.value("zoomDelta", 0).toInt();
+    settings.setValue("zoomDelta", zoomDelta + 1);
+    updateApplicationFont();
+}
+
+void MainWindow::zoomOut() {
+    QSettings settings;
+    int zoomDelta = settings.value("zoomDelta", 0).toInt();
+    settings.setValue("zoomDelta", zoomDelta - 1);
+    updateApplicationFont();
+}
+
+void MainWindow::resetZoom() {
+    QSettings settings;
+    settings.setValue("zoomDelta", 0);
+    updateApplicationFont();
 }

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -104,6 +104,10 @@ class MainWindow : public KXmlGuiWindow {
     void showInputSettingsMenu();
     void showChatSettingsDialog(int messageId);
     void updateInputBehavior();
+    void updateApplicationFont();
+    void zoomIn();
+    void zoomOut();
+    void resetZoom();
     void exportChatSession();
     void importChatSession();
     void exportDocument(int id, const QString& type);

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -1,12 +1,15 @@
 #include "SettingsDialog.h"
 
+#include <QApplication>
 #include <QCheckBox>
 #include <QComboBox>
+#include <QFontComboBox>
 #include <QFormLayout>
 #include <QInputDialog>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QSpinBox>
 #include <QTabWidget>
 
 ConnectionDialog::ConnectionDialog(QWidget* parent, const QString& name, const QString& backend, const QString& url,
@@ -103,6 +106,21 @@ SettingsDialog::SettingsDialog(QWidget* parent) : QDialog(parent) {
     QLabel* chatSettingsLabel = new QLabel(tr("<b>Chat Settings</b>"), this);
     generalLayout->addWidget(chatSettingsLabel);
 
+    QHBoxLayout* fontLayout = new QHBoxLayout();
+    QLabel* fontLabel = new QLabel(tr("Global Editor Font:"), this);
+    m_fontFamilyCombo = new QFontComboBox(this);
+    QLabel* sizeLabel = new QLabel(tr("Size:"), this);
+    m_fontSizeSpinBox = new QSpinBox(this);
+    m_fontSizeSpinBox->setRange(6, 72);
+    fontLayout->addWidget(fontLabel);
+    fontLayout->addWidget(m_fontFamilyCombo);
+    fontLayout->addWidget(sizeLabel);
+    fontLayout->addWidget(m_fontSizeSpinBox);
+    fontLayout->addStretch();
+    generalLayout->addLayout(fontLayout);
+
+    generalLayout->addSpacing(10);
+
     QHBoxLayout* sendBehaviorLayout = new QHBoxLayout();
     QLabel* sendBehaviorLabel = new QLabel(tr("Global Send Behavior:"), this);
     m_sendBehaviorCombo = new QComboBox(this);
@@ -173,10 +191,8 @@ SettingsDialog::SettingsDialog(QWidget* parent) : QDialog(parent) {
 
     // AI Operations Tab
     m_aiOperationsEditor = new AIOperationsEditorWidget("global", this);
-    m_aiOperationsEditor->setOperations(
-        AIOperationsManager::getGlobalOperations(),
-        AIOperationsManager::getBuiltInOperations()
-    );
+    m_aiOperationsEditor->setOperations(AIOperationsManager::getGlobalOperations(),
+                                        AIOperationsManager::getBuiltInOperations());
     tabWidget->addTab(m_aiOperationsEditor, tr("AI Operations"));
 
     mainLayout->addWidget(tabWidget);
@@ -199,6 +215,10 @@ SettingsDialog::SettingsDialog(QWidget* parent) : QDialog(parent) {
     connect(m_cancelButton, &QPushButton::clicked, this, &QDialog::reject);
 
     loadConnections();
+
+    QFont defaultFont = QApplication::font();
+    m_fontFamilyCombo->setCurrentFont(QFont(m_settings.value("globalFontFamily", defaultFont.family()).toString()));
+    m_fontSizeSpinBox->setValue(m_settings.value("globalFontSize", defaultFont.pointSize()).toInt());
 
     QString globalBehavior = m_settings.value("globalSendBehavior", "EnterToSend").toString();
     int index = m_sendBehaviorCombo->findData(globalBehavior);
@@ -328,6 +348,10 @@ void SettingsDialog::onApply() {
     saveConnections();
 
     QString selectedBehavior = m_sendBehaviorCombo->currentData().toString();
+
+    m_settings.setValue("globalFontFamily", m_fontFamilyCombo->currentFont().family());
+    m_settings.setValue("globalFontSize", m_fontSizeSpinBox->value());
+
     m_settings.setValue("globalSendBehavior", selectedBehavior);
     m_settings.setValue("globalSystemPrompt", m_globalSystemPromptEdit->toPlainText().trimmed());
     m_settings.setValue("queueProcessing", m_queueProcessingCombo->currentData().toString());

--- a/src/SettingsDialog.h
+++ b/src/SettingsDialog.h
@@ -3,6 +3,7 @@
 
 #include <QComboBox>
 #include <QDialog>
+#include <QFontComboBox>
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QLabel>
@@ -10,11 +11,13 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QSettings>
+#include <QSpinBox>
 #include <QTableWidget>
 #include <QTextEdit>
 #include <QVBoxLayout>
 #include <QVariantList>
 #include <QVariantMap>
+
 #include "AIOperationsEditorWidget.h"
 
 class ConnectionDialog : public QDialog {
@@ -69,6 +72,8 @@ class SettingsDialog : public QDialog {
     QPushButton* m_cancelButton;
     QSettings m_settings;
     QComboBox* m_sendBehaviorCombo;
+    QFontComboBox* m_fontFamilyCombo;
+    QSpinBox* m_fontSizeSpinBox;
     QTextEdit* m_globalSystemPromptEdit;
     QComboBox* m_queueProcessingCombo;
     QCheckBox* m_prioritizeSameModelCheck;

--- a/src/kllamabooksui.rc
+++ b/src/kllamabooksui.rc
@@ -33,6 +33,10 @@
         </Menu>
         <Menu name="view">
             <text>&amp;View</text>
+            <Action name="zoom_in" />
+            <Action name="zoom_out" />
+            <Action name="reset_zoom" />
+            <Separator />
             <Action name="show_queue" />
             <Action name="show_spy" />
         </Menu>


### PR DESCRIPTION
Adds an application-wide font selector and scaling feature as requested, handling defaults and dynamically pushing updates across document editors and chat windows without restarting.

---
*PR created automatically by Jules for task [6920558851452378511](https://jules.google.com/task/6920558851452378511) started by @arran4*