### PR TITLE
Fix notification Goto jump by explicitly storing target_type

### DIFF
--- a/src/BookDatabase.cpp
+++ b/src/BookDatabase.cpp
@@ -286,10 +286,11 @@ bool BookDatabase::initSchema() {
             ");"
             "CREATE TABLE IF NOT EXISTS notifications ("
             "id INTEGER PRIMARY KEY AUTOINCREMENT, "
-            "message_id INTEGER, "
-            "type TEXT, "  // responded_to, error
+            "target_id INTEGER, "
+            "type TEXT, "  // responded_to, error, review_needed
             "is_dismissed BOOLEAN DEFAULT 0, "
-            "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"
+            "created_at DATETIME DEFAULT CURRENT_TIMESTAMP, "
+            "target_type TEXT DEFAULT 'chat_node'"
             ");";
         sqlite3_exec((sqlite3*)m_db, sql, nullptr, nullptr, nullptr);
         sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (5);", nullptr, nullptr,
@@ -458,6 +459,18 @@ bool BookDatabase::initSchema() {
                      nullptr);
         sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 14;", nullptr, nullptr, nullptr);
         userVersion = 14;
+    }
+
+    if (userVersion < 15) {
+        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE notifications RENAME COLUMN message_id TO target_id;", nullptr,
+                     nullptr, nullptr);
+        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE notifications ADD COLUMN target_type TEXT DEFAULT 'chat_node';", nullptr,
+                     nullptr, nullptr);
+
+        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (15);", nullptr, nullptr,
+                     nullptr);
+        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 15;", nullptr, nullptr, nullptr);
+        userVersion = 15;
     }
 
     return true;
@@ -1261,13 +1274,14 @@ bool BookDatabase::deleteQueueItem(int id) {
     return rc == SQLITE_DONE;
 }
 
-int BookDatabase::addNotification(int messageId, const QString& type) {
+int BookDatabase::addNotification(int targetId, const QString& type, const QString& targetType) {
     if (!m_isOpen) return -1;
-    const char* sql = "INSERT INTO notifications (message_id, type) VALUES (?, ?);";
+    const char* sql = "INSERT INTO notifications (target_id, type, target_type) VALUES (?, ?, ?);";
     sqlite3_stmt* stmt;
     if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return -1;
-    sqlite3_bind_int(stmt, 1, messageId);
+    sqlite3_bind_int(stmt, 1, targetId);
     sqlite3_bind_text(stmt, 2, type.toUtf8().constData(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 3, targetType.toUtf8().constData(), -1, SQLITE_TRANSIENT);
     int rc = sqlite3_step(stmt);
     if (rc != SQLITE_DONE) {
         sqlite3_finalize(stmt);
@@ -1281,7 +1295,7 @@ int BookDatabase::addNotification(int messageId, const QString& type) {
 QList<Notification> BookDatabase::getNotifications(bool includeDismissed) const {
     QList<Notification> notifications;
     if (!m_isOpen) return notifications;
-    QString sql = "SELECT id, message_id, type, is_dismissed, created_at FROM notifications";
+    QString sql = "SELECT id, target_id, type, is_dismissed, created_at, target_type FROM notifications";
     if (!includeDismissed) sql += " WHERE is_dismissed = 0";
     sql += " ORDER BY created_at DESC;";
     sqlite3_stmt* stmt;
@@ -1290,10 +1304,13 @@ QList<Notification> BookDatabase::getNotifications(bool includeDismissed) const 
     while (sqlite3_step(stmt) == SQLITE_ROW) {
         Notification n;
         n.id = sqlite3_column_int(stmt, 0);
-        n.messageId = sqlite3_column_int(stmt, 1);
+        n.targetId = sqlite3_column_int(stmt, 1);
         n.type = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
         n.isDismissed = sqlite3_column_int(stmt, 3) != 0;
         n.timestamp = QDateTime::fromString(QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4)), Qt::ISODate);
+        const unsigned char* targetTypeTxt = sqlite3_column_text(stmt, 5);
+        if (targetTypeTxt) n.targetType = QString::fromUtf8((const char*)targetTypeTxt);
+        else n.targetType = "chat_node"; // Fallback for old notifications
         notifications.append(n);
     }
     sqlite3_finalize(stmt);
@@ -1311,12 +1328,13 @@ bool BookDatabase::dismissNotification(int id) {
     return rc == SQLITE_DONE;
 }
 
-bool BookDatabase::dismissNotificationByMessageId(int messageId) {
+bool BookDatabase::dismissNotificationByTarget(int targetId, const QString& targetType) {
     if (!m_isOpen) return false;
-    const char* sql = "UPDATE notifications SET is_dismissed = 1 WHERE message_id = ?;";
+    const char* sql = "UPDATE notifications SET is_dismissed = 1 WHERE target_id = ? AND target_type = ?;";
     sqlite3_stmt* stmt;
     if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
-    sqlite3_bind_int(stmt, 1, messageId);
+    sqlite3_bind_int(stmt, 1, targetId);
+    sqlite3_bind_text(stmt, 2, targetType.toUtf8().constData(), -1, SQLITE_TRANSIENT);
     int rc = sqlite3_step(stmt);
     sqlite3_finalize(stmt);
     return rc == SQLITE_DONE;

--- a/src/BookDatabase.h
+++ b/src/BookDatabase.h
@@ -81,10 +81,11 @@ struct CommentNode {
 
 struct Notification {
     int id;
-    int messageId;
-    QString type;  // "responded_to", "error"
+    int targetId;
+    QString type;  // "responded_to", "error", "review_needed"
     bool isDismissed;
     QDateTime timestamp;
+    QString targetType;
 };
 
 class BookDatabase {
@@ -176,10 +177,10 @@ class BookDatabase {
     bool deleteComment(int id);
 
     // Notifications
-    int addNotification(int messageId, const QString& type);
+    int addNotification(int targetId, const QString& type, const QString& targetType);
     QList<Notification> getNotifications(bool includeDismissed = false) const;
     bool dismissNotification(int id);
-    bool dismissNotificationByMessageId(int messageId);
+    bool dismissNotificationByTarget(int targetId, const QString& targetType);
 
     QString getDatabaseDebugInfo() const;
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2216,7 +2216,8 @@ void MainWindow::updateLinearChatView(int tailNodeId, const QList<MessageNode>& 
     }
 
     if (currentDb) {
-        currentDb->dismissNotificationByMessageId(tailNodeId);
+        // Linear chat view always operates on message nodes (chat_node)
+        currentDb->dismissNotificationByTarget(tailNodeId, "message");
         updateNotificationStatus();
     }
     chatTextArea->blockSignals(true);
@@ -3795,8 +3796,8 @@ void MainWindow::updateNotificationStatus() {
 
                     QString typeStr = (n.type == "error") ? tr("Error") : tr("Finished");
                     QLabel* summary =
-                        new QLabel(QString("<b>Book:</b> %1<br><b>Status:</b> %2<br><b>Message ID:</b> %3")
-                                       .arg(bookName, typeStr, QString::number(n.messageId)));
+                        new QLabel(QString("<b>Book:</b> %1<br><b>Status:</b> %2<br><b>Target ID:</b> %3")
+                                       .arg(bookName, typeStr, QString::number(n.targetId)));
                     summary->setWordWrap(true);
                     layout->addWidget(summary);
 
@@ -4005,12 +4006,12 @@ void MainWindow::updateVfsMarkers(const QList<Notification>& notifications) {
             int id = item->data(Qt::UserRole).toInt();
             QString itemType = item->data(Qt::UserRole + 1).toString();
             int nType = 0;
-            if (itemType == "chat_node") {
-                for (const auto& n : notifications) {
-                    if (n.messageId == id && !n.isDismissed) {
-                        nType = (n.type == "error") ? 2 : 1;
-                        break;
-                    }
+            for (const auto& n : notifications) {
+                QString mappedType = n.targetType;
+                if (mappedType == "message") mappedType = "chat_node";
+                if (n.targetId == id && mappedType == itemType && !n.isDismissed) {
+                    nType = (n.type == "error") ? 2 : 1;
+                    break;
                 }
             }
             item->setData(nType, Qt::UserRole + 10);
@@ -4022,12 +4023,12 @@ void MainWindow::updateVfsMarkers(const QList<Notification>& notifications) {
             int id = item->data(Qt::UserRole).toInt();
             QString itemType = item->data(Qt::UserRole + 1).toString();
             int nType = 0;
-            if (itemType == "chat_node") {
-                for (const auto& n : notifications) {
-                    if (n.messageId == id && !n.isDismissed) {
-                        nType = (n.type == "error") ? 2 : 1;
-                        break;
-                    }
+            for (const auto& n : notifications) {
+                QString mappedType = n.targetType;
+                if (mappedType == "message") mappedType = "chat_node";
+                if (n.targetId == id && mappedType == itemType && !n.isDismissed) {
+                    nType = (n.type == "error") ? 2 : 1;
+                    break;
                 }
             }
             item->setData(nType, Qt::UserRole + 10);
@@ -4046,12 +4047,12 @@ void MainWindow::updateTreeMarkersRecursive(QStandardItem* parent, const QList<N
         int messageId = child->data(Qt::UserRole).toInt();
         QString itemType = child->data(Qt::UserRole + 1).toString();
         int notifyType = 0;
-        if (itemType == "chat_node") {
-            for (const auto& n : notifications) {
-                if (n.messageId == messageId && !n.isDismissed) {
-                    notifyType = (n.type == "error") ? 2 : 1;
-                    break;
-                }
+        for (const auto& n : notifications) {
+            QString mappedType = n.targetType;
+            if (mappedType == "message") mappedType = "chat_node";
+            if (n.targetId == messageId && mappedType == itemType && !n.isDismissed) {
+                notifyType = (n.type == "error") ? 2 : 1;
+                break;
             }
         }
         child->setData(notifyType, Qt::UserRole + 10);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -3759,13 +3759,24 @@ void MainWindow::updateNotificationStatus() {
             QString typeStr =
                 (n.type == "error") ? tr("Error") : (n.type == "review_needed" ? tr("Review Needed") : tr("Finished"));
             QAction* action = notificationMenu->addAction(
-                QString("[%1] %2: Msg %3").arg(bookName, typeStr, QString::number(n.messageId)));
+                QString("[%1] %2: Target ID %3").arg(bookName, typeStr, QString::number(n.targetId)));
             connect(action, &QAction::triggered, this, [this, db, n, bookName]() {
                 if (n.type == "review_needed") {
-                    DocumentReviewDialog reviewDlg(db, n.messageId, this);
-                    if (reviewDlg.exec() == QDialog::Accepted) {
-                        db->dismissNotification(n.id);
-                        updateNotificationStatus();
+                    // DocumentReviewDialog expects the queue item ID.
+                    // The notification contains the targetId (document id). We need to find the queue item ID.
+                    int queueId = -1;
+                    for (const auto& item : db->getQueue()) {
+                        if (item.messageId == n.targetId && item.targetType == "document" && item.state == "completed") {
+                            queueId = item.id;
+                            break;
+                        }
+                    }
+                    if (queueId != -1) {
+                        DocumentReviewDialog reviewDlg(db, queueId, this);
+                        if (reviewDlg.exec() == QDialog::Accepted) {
+                            db->dismissNotification(n.id);
+                            updateNotificationStatus();
+                        }
                     }
 
                     if (currentDb == db && currentDocumentId != 0) {
@@ -3800,7 +3811,7 @@ void MainWindow::updateNotificationStatus() {
                     layout->addLayout(btnLayout);
 
                     connect(gotoBtn, &QPushButton::clicked, [&]() {
-                        onQueueItemClicked(db, n.messageId);
+                        onQueueItemClicked(db, n.targetId, n.targetType);
                         dialog.accept();
                     });
 
@@ -3925,26 +3936,23 @@ void MainWindow::showSpyWindow() {
 /** * @brief Executes logic for onQueueItemClicked. This function manages component initialization and handles state
  * transitions for the UI. *  * This function is an integral component of the MainWindow class structure. * It ensures
  * that side effects map accurately to internal application models. */
-void MainWindow::onQueueItemClicked(std::shared_ptr<BookDatabase> db, int messageId) {
+void MainWindow::onQueueItemClicked(std::shared_ptr<BookDatabase> db, int targetId, const QString& targetType) {
     if (!db) return;
 
     // Check if this is a document queue item that is completed.
-    // If we double-click a queue item, the "messageId" parameter might actually be the queue ID
-    // or the target document ID. Let's find the queue item to be safe.
-    // Wait, the signal sends messageId. Let's look up if there's a queue item with this messageId that is completed.
     bool openedReview = false;
     for (const auto& item : db->getQueue()) {
-        if (item.messageId == messageId && item.targetType == "document" && item.state == "completed") {
+        if (item.messageId == targetId && item.targetType == "document" && item.state == "completed") {
             DocumentReviewDialog reviewDlg(db, item.id, this);
             if (reviewDlg.exec() == QDialog::Accepted) {
-                db->dismissNotificationByMessageId(item.id);
+                db->dismissNotificationByTarget(targetId, item.targetType);
                 updateNotificationStatus();
             }
             openedReview = true;
 
             // Reload document editor view just in case the dialog made edits (replace/append)
             // or to revert a live preview if the user discarded.
-            if (currentDocumentId == messageId) {
+            if (currentDocumentId == targetId) {
                 QString outTitle, outContent;
                 getDocumentContent(currentDocumentId, "document", outTitle, outContent);
                 documentEditorView->blockSignals(true);
@@ -3966,26 +3974,24 @@ void MainWindow::onQueueItemClicked(std::shared_ptr<BookDatabase> db, int messag
         }
     }
 
-    QStringList types = {"chat_node", "document", "note", "template", "draft"};
-    QStandardItem* foundItem = nullptr;
-    for (const QString& type : types) {
-        foundItem = findItemInTree(messageId, type);
-        if (foundItem) break;
-    }
+    QString mappedType = targetType;
+    if (mappedType == "message") mappedType = "chat_node";
+
+    QStandardItem* foundItem = findItemInTree(targetId, mappedType);
 
     if (foundItem) {
         openBooksTree->setCurrentIndex(foundItem->index());
         openBooksTree->selectionModel()->select(foundItem->index(),
                                                 QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Current);
         openBooksTree->scrollTo(foundItem->index());
-    } else if (!openedReview) {
+    } else if (!openedReview && (mappedType == "chat_node" || mappedType == "message")) {
         // Fallback to chat node logic just in case it wasn't rendered yet
-        currentLastNodeId = messageId;
+        currentLastNodeId = targetId;
         updateLinearChatView(currentLastNodeId, currentDb->getMessages());
         mainContentStack->setCurrentWidget(chatWindowView);
     }
 
-    db->dismissNotificationByMessageId(messageId);
+    db->dismissNotificationByTarget(targetId, targetType);
     updateNotificationStatus();
 }
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -113,7 +113,7 @@ class MainWindow : public KXmlGuiWindow {
     void showNotificationMenu();
     void showQueueWindow();
     void showSpyWindow();
-    void onQueueItemClicked(std::shared_ptr<BookDatabase> db, int messageId);
+    void onQueueItemClicked(std::shared_ptr<BookDatabase> db, int targetId, const QString& targetType);
     void updateTreeMarkersRecursive(QStandardItem* parent, const QList<Notification>& notifications);
     void updateVfsMarkers(const QList<Notification>& notifications);
     bool moveItemToFolder(QStandardItem* draggedItem, QStandardItem* targetItem, bool isCopy = false);

--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -301,7 +301,7 @@ void QueueManager::onComplete(const QString& response) {
         } else {
             m_currentDb->updateMessage(m_currentItem.messageId, response);
             m_currentDb->deleteQueueItem(m_currentItem.id);
-            m_currentDb->addNotification(m_currentItem.messageId, "responded_to");
+            m_currentDb->addNotification(m_currentItem.messageId, "responded_to", m_currentItem.targetType);
         }
 
         m_currentItem.processingId = 0;
@@ -338,7 +338,7 @@ void QueueManager::onError(const QString& error) {
     if (!m_isProcessing) return;
     if (m_currentDb && m_currentDb->isOpen()) {
         m_currentDb->updateQueueError(m_currentItem.id, error);
-        m_currentDb->addNotification(m_currentItem.messageId, "error");
+        m_currentDb->addNotification(m_currentItem.messageId, "error", m_currentItem.targetType);
     }
     m_isProcessing = false;
     emit processingFinished(m_currentDb, m_currentItem.messageId, false, m_currentItem.targetType);

--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -297,7 +297,7 @@ void QueueManager::onComplete(const QString& response) {
         if (m_currentItem.targetType == "document") {
             // Document results are queued for review, NOT applied immediately.
             m_currentDb->updateQueueItemState(m_currentItem.id, "completed", response);
-            m_currentDb->addNotification(m_currentItem.id, "review_needed");
+            m_currentDb->addNotification(m_currentItem.messageId, "review_needed", m_currentItem.targetType);
         } else {
             m_currentDb->updateMessage(m_currentItem.messageId, response);
             m_currentDb->deleteQueueItem(m_currentItem.id);

--- a/src/QueueWindow.cpp
+++ b/src/QueueWindow.cpp
@@ -60,7 +60,8 @@ QueueWindow::QueueWindow(QWidget* parent) : QWidget(parent, Qt::Window) {
                         if (mainWin) {
                             QMetaObject::invokeMethod(mainWin, "onQueueItemClicked",
                                                       Q_ARG(std::shared_ptr<BookDatabase>, db),
-                                                      Q_ARG(int, mi.item.messageId));
+                                                      Q_ARG(int, mi.item.messageId),
+                                                      Q_ARG(QString, mi.item.targetType));
                         }
                         break;
                     }


### PR DESCRIPTION
This commit addresses the issue where `Goto` actions from notifications (like finished messages or errors) failed to correctly jump to elements in the tree or jumped to the wrong elements due to relying on a hardcoded list of guessed types.

By renaming `message_id` to `target_id` and adding an explicit `target_type` string column to the `notifications` table, the UI can now unambiguously locate the element in the `openBooksTree` regardless of whether it is a chat node, document, template, note, or a future object type.

It also resolves an internal mismatch where `QueueManager` erroneously saved the `queueItem.id` as the notification target for document generations, which caused the document tree locator to fail silently.

---
*PR created automatically by Jules for task [12251800619731384790](https://jules.google.com/task/12251800619731384790) started by @arran4*