### PR TITLE
feat: Pause and retain queue tasks when endpoint is offline

### DIFF
--- a/src/OllamaClient.cpp
+++ b/src/OllamaClient.cpp
@@ -152,7 +152,7 @@ void OllamaClient::pullModel(const QString& modelName) {
  */
 void OllamaClient::generate(const QString& model, const QString& prompt, std::function<void(const QString&)> onChunk,
                             std::function<void(const QString&)> onComplete,
-                            std::function<void(const QString&)> onError) {
+                            std::function<void(QNetworkReply::NetworkError, const QString&)> onError) {
     QUrl url(m_baseUrl + "/api/generate");
     QNetworkRequest request(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
@@ -215,9 +215,10 @@ void OllamaClient::generate(const QString& model, const QString& prompt, std::fu
         }
     });
 
-    connect(reply, &QNetworkReply::finished, this, [reply, onComplete, onError, fullResponse]() {
+    connect(reply, &QNetworkReply::finished, this, [this, reply, onComplete, onError, fullResponse]() {
         if (reply->error() != QNetworkReply::NoError) {
-            onError(reply->errorString());
+            emit connectionStatusChanged(false);
+            onError(reply->error(), reply->errorString());
         } else {
             onComplete(*fullResponse);
         }
@@ -237,7 +238,7 @@ void OllamaClient::generate(const QString& model, const QString& prompt, std::fu
 void OllamaClient::generateChat(const QString& model, const QJsonArray& messages,
                                 std::function<void(const QString&)> onChunk,
                                 std::function<void(const QString&)> onComplete,
-                                std::function<void(const QString&)> onError) {
+                                std::function<void(QNetworkReply::NetworkError, const QString&)> onError) {
     QUrl url(m_baseUrl + "/api/chat");
     QNetworkRequest request(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
@@ -319,9 +320,10 @@ void OllamaClient::generateChat(const QString& model, const QJsonArray& messages
         }
     });
 
-    connect(reply, &QNetworkReply::finished, this, [reply, onComplete, onError, fullResponse]() {
+    connect(reply, &QNetworkReply::finished, this, [this, reply, onComplete, onError, fullResponse]() {
         if (reply->error() != QNetworkReply::NoError) {
-            onError(reply->errorString());
+            emit connectionStatusChanged(false);
+            onError(reply->error(), reply->errorString());
         } else {
             onComplete(*fullResponse);
         }

--- a/src/OllamaClient.h
+++ b/src/OllamaClient.h
@@ -24,10 +24,12 @@ class OllamaClient : public QObject {
     void setSystemPrompt(const QString& prompt);
 
     void generate(const QString& model, const QString& prompt, std::function<void(const QString&)> onChunk,
-                  std::function<void(const QString&)> onComplete, std::function<void(const QString&)> onError);
+                  std::function<void(const QString&)> onComplete,
+                  std::function<void(QNetworkReply::NetworkError, const QString&)> onError);
 
     void generateChat(const QString& model, const QJsonArray& messages, std::function<void(const QString&)> onChunk,
-                      std::function<void(const QString&)> onComplete, std::function<void(const QString&)> onError);
+                      std::function<void(const QString&)> onComplete,
+                      std::function<void(QNetworkReply::NetworkError, const QString&)> onError);
 
    signals:
     void connectionStatusChanged(bool isOk);

--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -12,9 +12,16 @@ QueueManager& QueueManager::instance() {
     return instance;
 }
 
-QueueManager::QueueManager(QObject* parent) : QObject(parent), m_timer(new QTimer(this)), m_isPaused(false) {
+QueueManager::QueueManager(QObject* parent) : QObject(parent), m_timer(new QTimer(this)), m_isPaused(false), m_probeTimer(new QTimer(this)) {
     connect(m_timer, &QTimer::timeout, this, &QueueManager::checkQueue);
     m_timer->start(1000);  // Check every second
+
+    connect(m_probeTimer, &QTimer::timeout, this, [this]() {
+        if (m_client && totalPendingCount() > 0) {
+            m_client->fetchModels();
+        }
+    });
+    m_probeTimer->setInterval(5000);
 }
 
 void QueueManager::addDatabase(std::shared_ptr<BookDatabase> db) {
@@ -60,7 +67,22 @@ void QueueManager::setActiveDatabase(std::shared_ptr<BookDatabase> db) {
     }
 }
 
-void QueueManager::setClient(OllamaClient* client) { m_client = client; }
+void QueueManager::setClient(OllamaClient* client) {
+    m_client = client;
+    if (m_client) {
+        connect(m_client, &OllamaClient::connectionStatusChanged, this, [this](bool isOk) {
+            m_isEndpointUp = isOk;
+            if (isOk) {
+                m_probeTimer->stop();
+                QTimer::singleShot(0, this, &QueueManager::checkQueue);
+            } else {
+                if (!m_probeTimer->isActive()) {
+                    m_probeTimer->start();
+                }
+            }
+        });
+    }
+}
 
 /**
  * @brief Appends a generation request payload to the processing queue.
@@ -100,6 +122,7 @@ int QueueManager::pendingCount(std::shared_ptr<BookDatabase> db) const {
 
 void QueueManager::checkQueue() {
     if (m_isProcessing || m_isPaused || !m_client || m_databases.isEmpty()) return;
+    if (!m_isEndpointUp) return;
     processNext();
 }
 
@@ -300,12 +323,12 @@ void QueueManager::processNext() {
         m_client->generateChat(
             m_currentItem.model, messagesArray, [this](const QString& chunk) { onChunk(chunk); },
             [this](const QString& response) { onComplete(response); },
-            [this](const QString& error) { onError(error); });
+            [this](QNetworkReply::NetworkError errorCode, const QString& error) { onError(errorCode, error); });
     } else {
         m_client->generate(
             m_currentItem.model, m_currentItem.prompt, [this](const QString& chunk) { onChunk(chunk); },
             [this](const QString& response) { onComplete(response); },
-            [this](const QString& error) { onError(error); });
+            [this](QNetworkReply::NetworkError errorCode, const QString& error) { onError(errorCode, error); });
     }
 }
 
@@ -384,11 +407,18 @@ void QueueManager::onComplete(const QString& response) {
  *
  * @param error The descriptive error message.
  */
-void QueueManager::onError(const QString& error) {
+void QueueManager::onError(QNetworkReply::NetworkError errorCode, const QString& error) {
     if (!m_isProcessing) return;
     if (m_currentDb && m_currentDb->isOpen()) {
-        m_currentDb->updateQueueError(m_currentItem.id, error);
-        m_currentDb->addNotification(m_currentItem.messageId, "error");
+        if (errorCode == QNetworkReply::ConnectionRefusedError ||
+            errorCode == QNetworkReply::HostNotFoundError ||
+            errorCode == QNetworkReply::TimeoutError) {
+            m_currentDb->updateQueueItemState(m_currentItem.id, "pending");
+            m_currentDb->updateQueueError(m_currentItem.id, ""); // also resets processing_id to 0
+        } else {
+            m_currentDb->updateQueueError(m_currentItem.id, error);
+            m_currentDb->addNotification(m_currentItem.messageId, "error");
+        }
     }
     m_isProcessing = false;
     emit processingFinished(m_currentDb, m_currentItem.messageId, false, m_currentItem.targetType);

--- a/src/QueueManager.h
+++ b/src/QueueManager.h
@@ -42,6 +42,8 @@ class QueueManager : public QObject {
     void resumeQueue();
     bool isPaused() const { return m_isPaused; }
 
+    bool isEndpointUp() const { return m_isEndpointUp; }
+
     bool isProcessing() const { return m_isProcessing; }
     QueueItem currentProcessingItem() const { return m_currentItem; }
     std::shared_ptr<BookDatabase> currentProcessingDb() const { return m_currentDb; }
@@ -60,7 +62,7 @@ class QueueManager : public QObject {
    private slots:
     void onChunk(const QString& chunk);
     void onComplete(const QString& response);
-    void onError(const QString& error);
+    void onError(QNetworkReply::NetworkError errorCode, const QString& error);
 
    private:
     explicit QueueManager(QObject* parent = nullptr);
@@ -77,6 +79,8 @@ class QueueManager : public QObject {
     int m_currentIndex = 0;
     bool m_isPaused = false;
     QString m_lastProcessedModel;
+    bool m_isEndpointUp = true;
+    QTimer* m_probeTimer;
 
     void processNext();
 };

--- a/src/QueueWindow.cpp
+++ b/src/QueueWindow.cpp
@@ -126,6 +126,10 @@ void QueueWindow::refresh() {
                 statusStr = "ERROR";
         }
 
+        if (statusStr == "PENDING" && !QueueManager::instance().isEndpointUp()) {
+            statusStr = "ENDPOINT DOWN";
+        }
+
         QString text = QString("[%1] %2: %3 (%4)")
                            .arg(statusStr)
                            .arg(QFileInfo(mi.db->filepath()).fileName())
@@ -142,6 +146,8 @@ void QueueWindow::refresh() {
             listItem->setBackground(Qt::red);
         } else if (statusStr == "COMPLETED") {
             listItem->setBackground(Qt::green);
+        } else if (statusStr == "ENDPOINT DOWN") {
+            listItem->setBackground(Qt::yellow);
         }
     }
     updateButtons();


### PR DESCRIPTION
This PR improves the robustness of the queue system by gracefully handling disconnected endpoints (e.g. Ollama daemon offline). Instead of actively failing queued items, it safely reverts them to a `pending` state, halts processing, and visually alerts the user via the Queue window. It automatically recovers via a background probe timer that resumes processing when the daemon is restarted.

---
*PR created automatically by Jules for task [12513525060503113352](https://jules.google.com/task/12513525060503113352) started by @arran4*