### PR TITLE
Fix inconsistent queue states

### DIFF
--- a/src/BookDatabase.cpp
+++ b/src/BookDatabase.cpp
@@ -64,42 +64,56 @@ void BookDatabase::cleanupDeadProcessingItems() {
     if (!m_isOpen) return;
 
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, "SELECT id, processing_id FROM queue WHERE processing_id > 0 OR state = 'processing';", -1, &stmt,
-                           nullptr) == SQLITE_OK) {
-        QList<int> idsToReset;
+    if (sqlite3_prepare_v2((sqlite3*)m_db,
+                           "SELECT id, processing_id, last_error FROM queue WHERE processing_id > 0 OR state = "
+                           "'processing' OR (last_error IS NOT NULL AND last_error != '' AND state != 'error');",
+                           -1, &stmt, nullptr) == SQLITE_OK) {
+        struct ItemToReset {
+            int id;
+            QString error;
+        };
+        QList<ItemToReset> itemsToReset;
+
         while (sqlite3_step(stmt) == SQLITE_ROW) {
             int id = sqlite3_column_int(stmt, 0);
             int pid = sqlite3_column_int(stmt, 1);
+            const unsigned char* errText = sqlite3_column_text(stmt, 2);
+            QString lastError = errText ? QString::fromUtf8((const char*)errText) : QString();
+
             if (pid <= 0) {
-                idsToReset.append(id);
+                itemsToReset.append({id, lastError});
             } else {
 #ifdef Q_OS_UNIX
                 if (kill(pid, 0) != 0 && errno == ESRCH) {
-                    idsToReset.append(id);
+                    itemsToReset.append({id, lastError});
                 } else {
                     // Process exists, check if it's kllamabooks
                     QFile commFile(QString("/proc/%1/comm").arg(pid));
                     if (commFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
                         QString comm = QString(commFile.readAll()).trimmed();
                         if (!comm.contains("kllamabooks", Qt::CaseInsensitive)) {
-                            idsToReset.append(id);
+                            itemsToReset.append({id, lastError});
                         }
                     } else {
                         // Could not read comm file, assume dead
-                        idsToReset.append(id);
+                        itemsToReset.append({id, lastError});
                     }
                 }
 #else
                 // Simple fallback for non-Unix if needed, though KllamaBooks is KDE/Linux targeted.
-                idsToReset.append(id);
+                itemsToReset.append({id, lastError});
 #endif
             }
         }
         sqlite3_finalize(stmt);
 
-        for (int id : idsToReset) {
-            updateQueueProcessingId(id, 0);
-            updateQueueItemState(id, "pending");
+        for (const auto& item : itemsToReset) {
+            if (!item.error.isEmpty()) {
+                updateQueueError(item.id, item.error);
+            } else {
+                updateQueueProcessingId(item.id, 0);
+                updateQueueItemState(item.id, "pending");
+            }
         }
     }
 }
@@ -1172,9 +1186,14 @@ bool BookDatabase::updateQueueItemState(int id, const QString& state, const QStr
     // If response is empty, maybe don't overwrite an existing response unless explicitly asked?
     // Wait, the prompt said response has a default of "". When we just update state to 'processing',
     // it will overwrite response with "". This is fine because when it starts processing, response is empty anyway.
-    const char* sql = "UPDATE queue SET state = ?, response = ? WHERE id = ?;";
+    QString sqlStr = "UPDATE queue SET state = ?, response = ?";
+    if (state != "error") {
+        sqlStr += ", last_error = ''";
+    }
+    sqlStr += " WHERE id = ?;";
+
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2((sqlite3*)m_db, sqlStr.toUtf8().constData(), -1, &stmt, nullptr) != SQLITE_OK) return false;
 
     sqlite3_bind_text(stmt, 1, state.toUtf8().constData(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 2, response.toUtf8().constData(), -1, SQLITE_TRANSIENT);


### PR DESCRIPTION
I've updated `cleanupDeadProcessingItems` to correctly identify and recover items with existing errors that got stuck due to application crashes or incorrect state transitions. Now, it explicitly checks `last_error IS NOT NULL AND last_error != '' AND state != 'error'`, and resets such items into the error state via `updateQueueError` so that the user sees them.

I've also modified `updateQueueItemState` to automatically clear `last_error` whenever the queue item's state transitions to something else (e.g., `'processing'` or `'pending'`). This ensures that stale error messages aren't left behind on tasks that are retried.

---
*PR created automatically by Jules for task [11355314796705618593](https://jules.google.com/task/11355314796705618593) started by @arran4*