### PR TITLE
Fix compilation errors in BookDatabase and MainWindow

### DIFF
--- a/src/BookDatabase.cpp
+++ b/src/BookDatabase.cpp
@@ -977,17 +977,6 @@ QList<DocumentNode> BookDatabase::getTemplates(int folderId) const {
     return nodes;
 }
 
-bool BookDatabase::deleteTemplate(int id) {
-    if (!m_isOpen) return false;
-    const char* sql = "DELETE FROM templates WHERE id = ?;";
-    sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
-    sqlite3_bind_int(stmt, 1, id);
-    int rc = sqlite3_step(stmt);
-    sqlite3_finalize(stmt);
-    return rc == SQLITE_DONE;
-}
-
 int BookDatabase::addDraft(int folderId, const QString& title, const QString& content) {
     if (!m_isOpen) return -1;
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1843,6 +1843,7 @@ void MainWindow::showItemContextMenu(QStandardItem* item, const QPoint& globalPo
         QAction* exportAction = nullptr;
         QAction* replaceAction = nullptr;
         QAction* loadTemplateAction = nullptr;
+        QAction* resumeDraftAction = nullptr;
 
         if (type == "template") {
             loadTemplateAction = menu.addAction(QIcon::fromTheme("document-import"), "Load Template");


### PR DESCRIPTION
Fix compilation errors in BookDatabase and MainWindow

Removed duplicate definition of `BookDatabase::deleteTemplate(int id)` in `src/BookDatabase.cpp` which was causing a compiler redefinition error.
Declared the missing `resumeDraftAction` variable before its usage in `src/MainWindow.cpp`.

---
*PR created automatically by Jules for task [17729923446747567119](https://jules.google.com/task/17729923446747567119) started by @arran4*