### PR TITLE
Fix kf.xmlgui shortcut warning for zoom actions

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -600,18 +600,18 @@ void MainWindow::setupUi() {
     splitter->setStretchFactor(1, 1);
 
     QAction* zoomInAction = new QAction(QIcon::fromTheme("zoom-in"), tr("Zoom In"), this);
-    zoomInAction->setShortcut(QKeySequence::ZoomIn);
     actionCollection()->addAction(QStringLiteral("zoom_in"), zoomInAction);
+    actionCollection()->setDefaultShortcut(zoomInAction, QKeySequence::ZoomIn);
     connect(zoomInAction, &QAction::triggered, this, &MainWindow::zoomIn);
 
     QAction* zoomOutAction = new QAction(QIcon::fromTheme("zoom-out"), tr("Zoom Out"), this);
-    zoomOutAction->setShortcut(QKeySequence::ZoomOut);
     actionCollection()->addAction(QStringLiteral("zoom_out"), zoomOutAction);
+    actionCollection()->setDefaultShortcut(zoomOutAction, QKeySequence::ZoomOut);
     connect(zoomOutAction, &QAction::triggered, this, &MainWindow::zoomOut);
 
     QAction* resetZoomAction = new QAction(QIcon::fromTheme("zoom-original"), tr("Reset Zoom"), this);
-    resetZoomAction->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_0));
     actionCollection()->addAction(QStringLiteral("reset_zoom"), resetZoomAction);
+    actionCollection()->setDefaultShortcut(resetZoomAction, QKeySequence(Qt::CTRL | Qt::Key_0));
     connect(resetZoomAction, &QAction::triggered, this, &MainWindow::resetZoom);
 
     QAction* newBookAction = new QAction(QIcon::fromTheme("document-new"), tr("New Book"), this);


### PR DESCRIPTION
The warnings output from KDE XMLGUI components specifically complain about manual assignment of shortcuts to `QAction` objects that are meant to be controlled by the framework's own `KActionCollection`. When `KActionCollection` is in charge of an action via `addAction()`, shortcuts should be provided via `actionCollection()->setDefaultShortcut()`. This ensures that user configurations relating to shortcuts (e.g. key reassignments in preferences dialogs) operate correctly and reliably without framework warnings.

This PR addresses the warnings:
```
kf.xmlgui: Shortcut for action  "zoom_in" "Zoom In" set with QAction::setShortcut()! Use KActionCollection::setDefaultShortcut(s) instead.
kf.xmlgui: Shortcut for action  "zoom_out" "Zoom Out" set with QAction::setShortcut()! Use KActionCollection::setDefaultShortcut(s) instead.
kf.xmlgui: Shortcut for action  "reset_zoom" "Reset Zoom" set with QAction::setShortcut()! Use KActionCollection::setDefaultShortcut(s) instead.
```
By simply altering how the application initializes these three zoom controls in `MainWindow::setupUi()`.

---
*PR created automatically by Jules for task [984832582714120354](https://jules.google.com/task/984832582714120354) started by @arran4*