### PR TITLE
Add "Jump to Document" action

### DIFF
--- a/src/DocumentEditWindow.cpp
+++ b/src/DocumentEditWindow.cpp
@@ -57,6 +57,9 @@ void DocumentEditWindow::setupWindow() {
     QAction* renameAction = new QAction(QIcon::fromTheme("edit-rename"), tr("Rename"), this);
     connect(renameAction, &QAction::triggered, this, &DocumentEditWindow::onRenameClicked);
 
+    QAction* jumpAction = new QAction(QIcon::fromTheme("go-jump"), tr("Jump to Document"), this);
+    connect(jumpAction, &QAction::triggered, this, &DocumentEditWindow::onJumpClicked);
+
     QAction* closeAction = new QAction(QIcon::fromTheme("window-close"), tr("Close"), this);
     connect(closeAction, &QAction::triggered, this, &QWidget::close);
 
@@ -65,6 +68,7 @@ void DocumentEditWindow::setupWindow() {
     mainToolBar->addAction(saveAsAction);
     mainToolBar->addAction(saveAsDraftAction);
     mainToolBar->addAction(renameAction);
+    mainToolBar->addAction(jumpAction);
     mainToolBar->addAction(closeAction);
     addToolBar(mainToolBar);
 
@@ -74,6 +78,7 @@ void DocumentEditWindow::setupWindow() {
     fileMenu->addAction(saveAsDraftAction);
     fileMenu->addSeparator();
     fileMenu->addAction(renameAction);
+    fileMenu->addAction(jumpAction);
     fileMenu->addSeparator();
     fileMenu->addAction(closeAction);
     menuBar()->addMenu(fileMenu);
@@ -155,6 +160,10 @@ QDateTime DocumentEditWindow::getLatestDbTimestamp() const {
     }
 
     return latest;
+}
+
+void DocumentEditWindow::onJumpClicked() {
+    emit jumpToDocumentRequested(m_documentId);
 }
 
 void DocumentEditWindow::onSaveClicked() {

--- a/src/DocumentEditWindow.h
+++ b/src/DocumentEditWindow.h
@@ -21,12 +21,14 @@ class DocumentEditWindow : public KXmlGuiWindow {
    signals:
     void documentModified(int documentId);
     void newDocumentCreated(int newDocumentId);
+    void jumpToDocumentRequested(int documentId);
 
    protected:
     void closeEvent(QCloseEvent* event) override;
 
    private slots:
     void onSaveClicked();
+    void onJumpClicked();
     void onSaveAsClicked();
     void onSaveAsDraftClicked();
     void onRenameClicked();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -4851,6 +4851,17 @@ void MainWindow::onEditDocument() {
         loadDocumentsAndNotes();  // Refresh tree
     });
 
+    connect(editWin, &DocumentEditWindow::jumpToDocumentRequested, this, [this, type](int docId) {
+        QStandardItem* item = findItemInTree(docId, type);
+        if (item) {
+            openBooksTree->selectionModel()->select(item->index(),
+                                                    QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Current);
+            openBooksTree->scrollTo(item->index());
+        }
+        this->raise();
+        this->activateWindow();
+    });
+
     connect(editWin, &QObject::destroyed, this, [this, editorKey]() { m_openDocEditors.remove(editorKey); });
     editWin->show();
 }


### PR DESCRIPTION
Added "Jump to Document" action to Document Edit Window.
- Added a `jumpToDocumentRequested` signal to `DocumentEditWindow`.
- Added a `QAction` to the toolbar and menu bar to trigger the signal.
- Handled the signal in `MainWindow` to navigate to the document in the tree, scroll to it, and bring the main window to the foreground.

---
*PR created automatically by Jules for task [3537751013515483199](https://jules.google.com/task/3537751013515483199) started by @arran4*