### PR TITLE
Fix Status Bar Model Update Logic

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -774,7 +774,7 @@ void MainWindow::setupUi() {
                 m_selectedModel = m_availableModels.first();
             }
             modelSelectButton->setText(m_selectedModel);
-            modelLabel->setText(tr("Model: %1 (System Default)").arg(m_selectedModel));
+            modelLabel->setText(tr("Model: %1 (System Selected)").arg(m_selectedModel));
         }
     });
 
@@ -878,9 +878,6 @@ void MainWindow::setupUi() {
     // Initially hide toggleInputModeBtn since emptyView is default
     toggleInputModeBtn->hide();
 
-    modelLabel = new QLabel(tr("Model: Not Selected"), this);
-    statusBar->addPermanentWidget(modelLabel);
-
     queueStatusBtn = new QToolButton(this);
     queueStatusBtn->setText("Q: 0");
     queueStatusBtn->setToolTip(tr("LLM Request Queue"));
@@ -900,6 +897,10 @@ void MainWindow::setupUi() {
     settingsStatusBarBtn->setToolTip(tr("Settings"));
     connect(settingsStatusBarBtn, &QToolButton::clicked, this, &MainWindow::showSettingsDialog);
     statusBar->addPermanentWidget(settingsStatusBarBtn);
+
+    modelLabel = new QLabel(tr("Model: Not Selected"), this);
+    modelLabel->setMaximumWidth(150);
+    statusBar->addPermanentWidget(modelLabel);
 
     updateEndpointsList();
     loadBooks();
@@ -1390,7 +1391,7 @@ void MainWindow::updateInputBehavior() {
                 } else if (!m_availableModels.isEmpty()) {
                     m_selectedModel = m_availableModels.first();
                 }
-                if (modelLabel) modelLabel->setText(tr("Model: %1 (System Default)").arg(m_selectedModel));
+                if (modelLabel) modelLabel->setText(tr("Model: %1 (System Selected)").arg(m_selectedModel));
                 if (modelSelectButton) modelSelectButton->setText(m_selectedModel);
             }
         }
@@ -1645,7 +1646,7 @@ void MainWindow::showItemContextMenu(QStandardItem* item, const QPoint& globalPo
                         } else if (!m_availableModels.isEmpty()) {
                             m_selectedModel = m_availableModels.first();
                         }
-                        modelLabel->setText(tr("Model: %1 (System Default)").arg(m_selectedModel));
+                        modelLabel->setText(tr("Model: %1 (System Selected)").arg(m_selectedModel));
                     }
                     if (currentLastNodeId != 0 && mainContentStack->currentWidget() == chatWindowView) {
                         updateLinearChatView(currentLastNodeId, currentDb->getMessages());

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -767,9 +767,14 @@ void MainWindow::setupUi() {
             }
         }
         if (m_selectedModel.isEmpty() && !m_availableModels.isEmpty()) {
-            m_selectedModel = m_availableModels.first();
+            QString systemModel = settings.value("systemModel", "").toString();
+            if (!systemModel.isEmpty() && m_availableModels.contains(systemModel)) {
+                m_selectedModel = systemModel;
+            } else {
+                m_selectedModel = m_availableModels.first();
+            }
             modelSelectButton->setText(m_selectedModel);
-            modelLabel->setText(tr("Model: %1 (Default)").arg(m_selectedModel));
+            modelLabel->setText(tr("Model: %1 (System Default)").arg(m_selectedModel));
         }
     });
 
@@ -790,6 +795,9 @@ void MainWindow::setupUi() {
                     } else {
                         m_newChatModel = selected;
                     }
+                } else {
+                    QSettings settings;
+                    settings.setValue("systemModel", selected);
                 }
                 m_selectedModel = selected;
                 modelSelectButton->setText(m_selectedModel);
@@ -1374,9 +1382,15 @@ void MainWindow::updateInputBehavior() {
                 m_selectedModel = dbModel;
                 if (modelLabel) modelLabel->setText(tr("Model: %1 (Book Default)").arg(m_selectedModel));
                 if (modelSelectButton) modelSelectButton->setText(m_selectedModel);
-            } else if (!m_availableModels.isEmpty()) {
-                m_selectedModel = m_availableModels.first();
-                if (modelLabel) modelLabel->setText(tr("Model: %1 (Global Fallback)").arg(m_selectedModel));
+            } else {
+                QSettings settings;
+                QString systemModel = settings.value("systemModel", "").toString();
+                if (!systemModel.isEmpty() && m_availableModels.contains(systemModel)) {
+                    m_selectedModel = systemModel;
+                } else if (!m_availableModels.isEmpty()) {
+                    m_selectedModel = m_availableModels.first();
+                }
+                if (modelLabel) modelLabel->setText(tr("Model: %1 (System Default)").arg(m_selectedModel));
                 if (modelSelectButton) modelSelectButton->setText(m_selectedModel);
             }
         }
@@ -1623,9 +1637,15 @@ void MainWindow::showItemContextMenu(QStandardItem* item, const QPoint& globalPo
                     if (!dbModel.isEmpty()) {
                         m_selectedModel = dbModel;
                         modelLabel->setText(tr("Model: %1 (Book Default)").arg(m_selectedModel));
-                    } else if (!m_availableModels.isEmpty()) {
-                        m_selectedModel = m_availableModels.first();
-                        modelLabel->setText(tr("Model: %1 (Global Fallback)").arg(m_selectedModel));
+                    } else {
+                        QSettings settings;
+                        QString systemModel = settings.value("systemModel", "").toString();
+                        if (!systemModel.isEmpty() && m_availableModels.contains(systemModel)) {
+                            m_selectedModel = systemModel;
+                        } else if (!m_availableModels.isEmpty()) {
+                            m_selectedModel = m_availableModels.first();
+                        }
+                        modelLabel->setText(tr("Model: %1 (System Default)").arg(m_selectedModel));
                     }
                     if (currentLastNodeId != 0 && mainContentStack->currentWidget() == chatWindowView) {
                         updateLinearChatView(currentLastNodeId, currentDb->getMessages());
@@ -3663,6 +3683,7 @@ void MainWindow::onOpenBooksSelectionChanged(const QItemSelection& selected, con
             if (currentDb) {
                 updateLinearChatView(currentLastNodeId, currentDb->getMessages());
                 mainContentStack->setCurrentWidget(chatWindowView);
+                updateInputBehavior();
             }
         }
     }
@@ -4988,6 +5009,7 @@ void MainWindow::onChatTextAreaContextMenu(const QPoint& pos) {
             loadDocumentsAndNotes();
             updateLinearChatView(currentLastNodeId, currentDb->getMessages());
             mainContentStack->setCurrentWidget(chatWindowView);
+            updateInputBehavior();
         }
         if (!toggleInputModeBtn->isChecked()) {
             inputField->setFocus();
@@ -5094,6 +5116,7 @@ void MainWindow::onChatForkExplorerDoubleClicked(const QModelIndex& index) {
         if (currentDb) {
             updateLinearChatView(currentLastNodeId, currentDb->getMessages());
             chatTextArea->setFocus();
+            updateInputBehavior();
         }
     }
 }
@@ -5144,7 +5167,10 @@ void MainWindow::onChatForkExplorerContextMenu(const QPoint& pos) {
             int nodeId = item->data(Qt::UserRole).toInt();
 
             currentLastNodeId = nodeId;
-            if (currentDb) updateLinearChatView(currentLastNodeId, currentDb->getMessages());
+            if (currentDb) {
+                updateLinearChatView(currentLastNodeId, currentDb->getMessages());
+                updateInputBehavior();
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes the UI status bar so it accurately updates and persists the intended execution model logic (including the global system default fallback) across the app when navigating between chats.

---
*PR created automatically by Jules for task [4115929792671769284](https://jules.google.com/task/4115929792671769284) started by @arran4*