### PR TITLE
Fix build error with m_selectedModel references

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -766,15 +766,15 @@ void MainWindow::setupUi() {
                 m_availableModels.append("llama2");  // fallback
             }
         }
-        if (m_selectedModel.isEmpty() && !m_availableModels.isEmpty()) {
+        if (m_selectedModels.isEmpty() && !m_availableModels.isEmpty()) {
             QString systemModel = settings.value("systemModel", "").toString();
             if (!systemModel.isEmpty() && m_availableModels.contains(systemModel)) {
-                m_selectedModel = systemModel;
+                m_selectedModels = QStringList() << systemModel;
             } else {
-                m_selectedModel = m_availableModels.first();
+                m_selectedModels = QStringList() << m_availableModels.first();
             }
-            modelSelectButton->setText(m_selectedModel);
-            modelLabel->setText(tr("Model: %1 (System Selected)").arg(m_selectedModel));
+            modelSelectButton->setText(m_selectedModels.first());
+            modelLabel->setText(tr("Model: %1 (System Selected)").arg(m_selectedModels.first()));
         }
     });
 
@@ -1394,7 +1394,7 @@ void MainWindow::updateInputBehavior() {
                 QSettings settings;
                 QString systemModel = settings.value("systemModel", "").toString();
                 if (!systemModel.isEmpty() && m_availableModels.contains(systemModel)) {
-                    m_selectedModel = systemModel;
+                    m_selectedModels = QStringList() << systemModel;
                 } else if (!m_availableModels.isEmpty()) {
                     m_selectedModels = QStringList() << m_availableModels.first();
                 }
@@ -1653,7 +1653,7 @@ void MainWindow::showItemContextMenu(QStandardItem* item, const QPoint& globalPo
                         QSettings settings;
                         QString systemModel = settings.value("systemModel", "").toString();
                         if (!systemModel.isEmpty() && m_availableModels.contains(systemModel)) {
-                            m_selectedModel = systemModel;
+                            m_selectedModels = QStringList() << systemModel;
                         } else if (!m_availableModels.isEmpty()) {
                             m_selectedModels = QStringList() << m_availableModels.first();
                         }


### PR DESCRIPTION
The `m_selectedModel` was refactored to `m_selectedModels` to support multiple models, but a few occurrences were missed causing a build error. This replaces all instances of `m_selectedModel` with proper references to `m_selectedModels`.

---
*PR created automatically by Jules for task [15857528227170732007](https://jules.google.com/task/15857528227170732007) started by @arran4*