### PR TITLE
feat: Enhance document editing flow with draft management dialog and 3-way diff support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ add_executable(kllamabooks
     src/ChatSettingsDialog.h
     src/MainWindow.cpp
     src/MainWindow.h
+    src/DraftSelectionDialog.cpp
+    src/DraftSelectionDialog.h
     src/QueueManager.cpp
     src/QueueManager.h
     src/QueueWindow.cpp

--- a/src/BookDatabase.cpp
+++ b/src/BookDatabase.cpp
@@ -474,6 +474,20 @@ bool BookDatabase::initSchema() {
         userVersion = 14;
     }
 
+    if (userVersion < 15) {
+        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE drafts ADD COLUMN target_type TEXT DEFAULT '';", nullptr, nullptr,
+                     nullptr);
+        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE drafts ADD COLUMN target_id INTEGER DEFAULT 0;", nullptr, nullptr,
+                     nullptr);
+        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE drafts ADD COLUMN forked_content TEXT DEFAULT '';", nullptr, nullptr,
+                     nullptr);
+
+        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (15);", nullptr, nullptr,
+                     nullptr);
+        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 15;", nullptr, nullptr, nullptr);
+        userVersion = 15;
+    }
+
     return true;
 }
 
@@ -818,6 +832,31 @@ QList<DocumentNode> BookDatabase::getDocuments(int folderId) const {
     return nodes;
 }
 
+DocumentNode BookDatabase::getDocumentById(int id) const {
+    DocumentNode node;
+    node.id = InvalidId;
+    if (!m_isOpen) return node;
+
+    const char* sql = "SELECT id, folder_id, title, content, timestamp, parent_id FROM documents WHERE id = ?;";
+    sqlite3_stmt* stmt;
+    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return node;
+
+    sqlite3_bind_int(stmt, 1, id);
+
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        node.id = sqlite3_column_int(stmt, 0);
+        node.folderId = sqlite3_column_int(stmt, 1);
+        node.title = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
+        node.content = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
+        QString ts = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
+        node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
+        node.parentId = sqlite3_column_int(stmt, 5);
+        node.isFolder = false;
+    }
+    sqlite3_finalize(stmt);
+    return node;
+}
+
 bool BookDatabase::deleteDocument(int id) {
     if (!m_isOpen) return false;
     const char* sql = "DELETE FROM documents WHERE id = ?;";
@@ -977,10 +1016,10 @@ QList<DocumentNode> BookDatabase::getTemplates(int folderId) const {
     return nodes;
 }
 
-int BookDatabase::addDraft(int folderId, const QString& title, const QString& content) {
+int BookDatabase::addDraft(int folderId, const QString& title, const QString& content, const QString& targetType, int targetId, const QString& forkedContent) {
     if (!m_isOpen) return -1;
 
-    const char* sql = "INSERT INTO drafts (folder_id, title, content) VALUES (?, ?, ?);";
+    const char* sql = "INSERT INTO drafts (folder_id, title, content, target_type, target_id, forked_content) VALUES (?, ?, ?, ?, ?, ?);";
     sqlite3_stmt* stmt;
     int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return -1;
@@ -988,6 +1027,9 @@ int BookDatabase::addDraft(int folderId, const QString& title, const QString& co
     sqlite3_bind_int(stmt, 1, folderId);
     sqlite3_bind_text(stmt, 2, title.toUtf8().constData(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 3, content.toUtf8().constData(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 4, targetType.toUtf8().constData(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 5, targetId);
+    sqlite3_bind_text(stmt, 6, forkedContent.toUtf8().constData(), -1, SQLITE_TRANSIENT);
 
     rc = sqlite3_step(stmt);
     if (rc != SQLITE_DONE) {
@@ -1021,7 +1063,7 @@ QList<DocumentNode> BookDatabase::getDrafts(int folderId) const {
     QList<DocumentNode> nodes;
     if (!m_isOpen) return nodes;
 
-    QString sqlStr = "SELECT id, folder_id, title, content, timestamp FROM drafts";
+    QString sqlStr = "SELECT id, folder_id, title, content, timestamp, target_type, target_id, forked_content FROM drafts";
     if (folderId != -1) sqlStr += " WHERE folder_id = ?";
     sqlStr += " ORDER BY timestamp ASC;";
 
@@ -1039,11 +1081,82 @@ QList<DocumentNode> BookDatabase::getDrafts(int folderId) const {
         node.content = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
         QString ts = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
+        if (sqlite3_column_text(stmt, 5)) {
+            node.targetType = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 5));
+        }
+        node.targetId = sqlite3_column_int(stmt, 6);
+        if (sqlite3_column_text(stmt, 7)) {
+            node.forkedContent = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 7));
+        }
         node.isFolder = false;
         nodes.append(node);
     }
     sqlite3_finalize(stmt);
     return nodes;
+}
+
+QList<DocumentNode> BookDatabase::getDraftsByTarget(const QString& targetType, int targetId) const {
+    QList<DocumentNode> nodes;
+    if (!m_isOpen) return nodes;
+
+    const char* sql = "SELECT id, folder_id, title, content, timestamp, target_type, target_id, forked_content FROM drafts WHERE target_type = ? AND target_id = ? ORDER BY timestamp ASC;";
+    sqlite3_stmt* stmt;
+    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return nodes;
+
+    sqlite3_bind_text(stmt, 1, targetType.toUtf8().constData(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 2, targetId);
+
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        DocumentNode node;
+        node.id = sqlite3_column_int(stmt, 0);
+        node.folderId = sqlite3_column_int(stmt, 1);
+        node.title = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
+        node.content = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
+        QString ts = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
+        node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
+        if (sqlite3_column_text(stmt, 5)) {
+            node.targetType = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 5));
+        }
+        node.targetId = sqlite3_column_int(stmt, 6);
+        if (sqlite3_column_text(stmt, 7)) {
+            node.forkedContent = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 7));
+        }
+        node.isFolder = false;
+        nodes.append(node);
+    }
+    sqlite3_finalize(stmt);
+    return nodes;
+}
+
+DocumentNode BookDatabase::getDraftById(int id) const {
+    DocumentNode node;
+    node.id = InvalidId;
+    if (!m_isOpen) return node;
+
+    const char* sql = "SELECT id, folder_id, title, content, timestamp, target_type, target_id, forked_content FROM drafts WHERE id = ?;";
+    sqlite3_stmt* stmt;
+    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return node;
+
+    sqlite3_bind_int(stmt, 1, id);
+
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        node.id = sqlite3_column_int(stmt, 0);
+        node.folderId = sqlite3_column_int(stmt, 1);
+        node.title = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
+        node.content = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
+        QString ts = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
+        node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
+        if (sqlite3_column_text(stmt, 5)) {
+            node.targetType = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 5));
+        }
+        node.targetId = sqlite3_column_int(stmt, 6);
+        if (sqlite3_column_text(stmt, 7)) {
+            node.forkedContent = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 7));
+        }
+        node.isFolder = false;
+    }
+    sqlite3_finalize(stmt);
+    return node;
 }
 
 bool BookDatabase::deleteDraft(int id) {
@@ -1552,6 +1665,30 @@ QSet<int> BookDatabase::getAllChatIds() const {
         sqlite3_finalize(stmt);
     }
     return ids;
+}
+
+DocumentNode BookDatabase::getTemplateById(int id) const {
+    DocumentNode node;
+    node.id = InvalidId;
+    if (!m_isOpen) return node;
+
+    const char* sql = "SELECT id, folder_id, title, content, timestamp FROM templates WHERE id = ?;";
+    sqlite3_stmt* stmt;
+    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return node;
+
+    sqlite3_bind_int(stmt, 1, id);
+
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        node.id = sqlite3_column_int(stmt, 0);
+        node.folderId = sqlite3_column_int(stmt, 1);
+        node.title = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
+        node.content = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
+        QString ts = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
+        node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
+        node.isFolder = false;
+    }
+    sqlite3_finalize(stmt);
+    return node;
 }
 
 bool BookDatabase::deleteTemplate(int id) {

--- a/src/BookDatabase.h
+++ b/src/BookDatabase.h
@@ -24,6 +24,9 @@ struct DocumentNode {
     QString content;
     QDateTime timestamp;
     bool isFolder;  // Deprecated, but keeping for compatibility during migration if needed
+    QString targetType;
+    int targetId = 0;
+    QString forkedContent;
 };
 
 struct ChatNode {
@@ -89,6 +92,8 @@ struct Notification {
 
 class BookDatabase {
    public:
+    static constexpr int InvalidId = -1;
+
     BookDatabase(const QString& filepath);
     ~BookDatabase();
 
@@ -122,6 +127,7 @@ class BookDatabase {
     int addDocument(int folderId, const QString& title, const QString& content, int parentId = 0);
     bool updateDocument(int id, const QString& newTitle, const QString& newContent);
     QList<DocumentNode> getDocuments(int folderId = -1) const;  // -1 for all, 0 for root
+    DocumentNode getDocumentById(int id) const;
     bool deleteDocument(int id);
     bool addDocumentHistory(int documentId, const QString& actionType, const QString& content);
 
@@ -137,12 +143,15 @@ class BookDatabase {
     int addTemplate(int folderId, const QString& title, const QString& content);
     bool updateTemplate(int id, const QString& newTitle, const QString& newContent);
     QList<DocumentNode> getTemplates(int folderId = -1) const;
+    DocumentNode getTemplateById(int id) const;
     bool deleteTemplate(int id);
 
     // Drafts
-    int addDraft(int folderId, const QString& title, const QString& content);
+    int addDraft(int folderId, const QString& title, const QString& content, const QString& targetType = "", int targetId = 0, const QString& forkedContent = "");
     bool updateDraft(int id, const QString& newTitle, const QString& newContent);
     QList<DocumentNode> getDrafts(int folderId = -1) const;
+    QList<DocumentNode> getDraftsByTarget(const QString& targetType, int targetId) const;
+    DocumentNode getDraftById(int id) const;
     bool deleteDraft(int id);
 
     // Notes

--- a/src/DocumentEditWindow.cpp
+++ b/src/DocumentEditWindow.cpp
@@ -33,6 +33,13 @@ DocumentEditWindow::DocumentEditWindow(std::shared_ptr<BookDatabase> db, int doc
 
 DocumentEditWindow::~DocumentEditWindow() {}
 
+void DocumentEditWindow::setContent(const QString& content) {
+    if (m_editor) {
+        m_editor->setPlainText(content);
+        m_statusLabel->setText(tr("Draft content loaded (Unsaved)"));
+    }
+}
+
 void DocumentEditWindow::setupWindow() {
     QWidget* centralWidget = new QWidget(this);
     QVBoxLayout* layout = new QVBoxLayout(centralWidget);
@@ -264,7 +271,26 @@ int DocumentEditWindow::saveToDraft(const QString& newTitle) {
         }
     }
 
-    return m_db->addDraft(folderId, newTitle, m_editor->toPlainText());
+    return m_db->addDraft(folderId, newTitle, m_editor->toPlainText(), m_itemType, m_documentId, getOriginalContent());
+}
+
+QString DocumentEditWindow::getOriginalContent() const {
+    if (!m_db || !m_db->isOpen()) return "";
+
+    DocumentNode doc;
+    if (m_itemType == "document") {
+        doc = m_db->getDocumentById(m_documentId);
+    } else if (m_itemType == "draft") {
+        doc = m_db->getDraftById(m_documentId);
+    } else if (m_itemType == "template") {
+        doc = m_db->getTemplateById(m_documentId);
+    }
+
+    if (doc.id != BookDatabase::InvalidId) {
+        return doc.content;
+    }
+
+    return "";
 }
 
 bool DocumentEditWindow::saveToDb() {

--- a/src/DocumentEditWindow.h
+++ b/src/DocumentEditWindow.h
@@ -18,6 +18,8 @@ class DocumentEditWindow : public KXmlGuiWindow {
                                 const QString& itemType = "document", QWidget* parent = nullptr);
     ~DocumentEditWindow() override;
 
+    void setContent(const QString& content);
+
    signals:
     void documentModified(int documentId);
     void newDocumentCreated(int newDocumentId);
@@ -53,6 +55,7 @@ class DocumentEditWindow : public KXmlGuiWindow {
     bool saveToDb();
     int forkDocument(const QString& newTitle);
     int saveToDraft(const QString& newTitle);
+    QString getOriginalContent() const;
 };
 
 #endif  // DOCUMENTEDITWINDOW_H

--- a/src/DraftSelectionDialog.cpp
+++ b/src/DraftSelectionDialog.cpp
@@ -1,0 +1,213 @@
+#include "DraftSelectionDialog.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QLabel>
+#include <QMessageBox>
+#include <algorithm>
+
+DraftSelectionDialog::DraftSelectionDialog(std::shared_ptr<BookDatabase> db, const QString& originalContent, const QList<DocumentNode>& drafts, QWidget* parent)
+    : QDialog(parent), m_db(db), m_originalContent(originalContent), m_drafts(drafts) {
+
+    setWindowTitle(tr("Drafts Found"));
+    resize(800, 500);
+
+    QVBoxLayout* mainLayout = new QVBoxLayout(this);
+    mainLayout->addWidget(new QLabel(tr("There are existing drafts for this document. What would you like to do?")));
+
+    QSplitter* splitter = new QSplitter(Qt::Horizontal, this);
+
+    // Left pane: list of drafts
+    QWidget* listWidget = new QWidget(splitter);
+    QVBoxLayout* listLayout = new QVBoxLayout(listWidget);
+    listLayout->setContentsMargins(0,0,0,0);
+    m_draftList = new QListWidget(listWidget);
+    for (const auto& draft : m_drafts) {
+        QString itemText = QString("%1 (%2)").arg(draft.title).arg(draft.timestamp.toString("yyyy-MM-dd hh:mm:ss"));
+        QListWidgetItem* item = new QListWidgetItem(itemText, m_draftList);
+        item->setData(Qt::UserRole, draft.id);
+    }
+    listLayout->addWidget(m_draftList);
+
+    // Right pane: preview
+    QWidget* previewWidget = new QWidget(splitter);
+    QVBoxLayout* previewLayout = new QVBoxLayout(previewWidget);
+    previewLayout->setContentsMargins(0,0,0,0);
+    m_previewEdit = new QTextEdit(previewWidget);
+    m_previewEdit->setReadOnly(true);
+    previewLayout->addWidget(new QLabel(tr("Preview:")));
+    previewLayout->addWidget(m_previewEdit);
+
+    splitter->addWidget(listWidget);
+    splitter->addWidget(previewWidget);
+    splitter->setSizes({250, 550});
+    mainLayout->addWidget(splitter);
+
+    // Buttons
+    QHBoxLayout* btnLayout = new QHBoxLayout();
+    m_diffBtn = new QPushButton(tr("Show Differences"), this);
+    m_deleteBtn = new QPushButton(tr("Delete Draft"), this);
+    m_useBtn = new QPushButton(tr("Use Draft"), this);
+    QPushButton* editOriginalBtn = new QPushButton(tr("Edit Original"), this);
+    QPushButton* cancelBtn = new QPushButton(tr("Cancel"), this);
+
+    btnLayout->addWidget(m_diffBtn);
+    btnLayout->addWidget(m_deleteBtn);
+    btnLayout->addStretch();
+    btnLayout->addWidget(m_useBtn);
+    btnLayout->addWidget(editOriginalBtn);
+    btnLayout->addWidget(cancelBtn);
+
+    mainLayout->addLayout(btnLayout);
+
+    connect(m_draftList, &QListWidget::currentItemChanged, this, &DraftSelectionDialog::onDraftSelectionChanged);
+    connect(m_useBtn, &QPushButton::clicked, this, &DraftSelectionDialog::onUseDraft);
+    connect(m_deleteBtn, &QPushButton::clicked, this, &DraftSelectionDialog::onDeleteDraft);
+    connect(editOriginalBtn, &QPushButton::clicked, this, &DraftSelectionDialog::onEditOriginal);
+    connect(cancelBtn, &QPushButton::clicked, this, &QDialog::reject);
+    connect(m_diffBtn, &QPushButton::clicked, this, &DraftSelectionDialog::onShowDifferences);
+
+    if (m_draftList->count() > 0) {
+        m_draftList->setCurrentRow(0);
+    } else {
+        m_useBtn->setEnabled(false);
+        m_deleteBtn->setEnabled(false);
+        m_diffBtn->setEnabled(false);
+    }
+}
+
+DraftSelectionDialog::Action DraftSelectionDialog::getSelectedAction() const {
+    return m_selectedAction;
+}
+
+DocumentNode DraftSelectionDialog::getSelectedDraft() const {
+    return m_selectedDraft;
+}
+
+void DraftSelectionDialog::onDraftSelectionChanged() {
+    QListWidgetItem* item = m_draftList->currentItem();
+    if (!item) {
+        m_previewEdit->clear();
+        m_useBtn->setEnabled(false);
+        m_deleteBtn->setEnabled(false);
+        m_diffBtn->setEnabled(false);
+        return;
+    }
+
+    int draftId = item->data(Qt::UserRole).toInt();
+    for (const auto& draft : m_drafts) {
+        if (draft.id == draftId) {
+            m_previewEdit->setPlainText(draft.content);
+            m_useBtn->setEnabled(true);
+            m_deleteBtn->setEnabled(true);
+            m_diffBtn->setEnabled(true);
+            break;
+        }
+    }
+}
+
+void DraftSelectionDialog::onUseDraft() {
+    QListWidgetItem* item = m_draftList->currentItem();
+    if (!item) return;
+
+    int draftId = item->data(Qt::UserRole).toInt();
+    for (const auto& draft : m_drafts) {
+        if (draft.id == draftId) {
+            m_selectedDraft = draft;
+            m_selectedAction = UseDraft;
+            accept();
+            return;
+        }
+    }
+}
+
+void DraftSelectionDialog::onDeleteDraft() {
+    QListWidgetItem* item = m_draftList->currentItem();
+    if (!item) return;
+
+    int draftId = item->data(Qt::UserRole).toInt();
+
+    QMessageBox::StandardButton reply = QMessageBox::question(this, tr("Delete Draft"),
+        tr("Are you sure you want to delete this draft?"),
+        QMessageBox::Yes | QMessageBox::No);
+
+    if (reply == QMessageBox::Yes) {
+        m_db->deleteDraft(draftId);
+        int row = m_draftList->row(item);
+        m_drafts.erase(std::remove_if(m_drafts.begin(), m_drafts.end(), [draftId](const DocumentNode& d) { return d.id == draftId; }), m_drafts.end());
+        delete m_draftList->takeItem(row);
+
+        if (m_draftList->count() == 0) {
+            m_selectedAction = EditOriginal;
+            accept();
+        }
+    }
+}
+
+void DraftSelectionDialog::onEditOriginal() {
+    m_selectedAction = EditOriginal;
+    accept();
+}
+
+void DraftSelectionDialog::onShowDifferences() {
+    QListWidgetItem* item = m_draftList->currentItem();
+    if (!item) return;
+
+    int draftId = item->data(Qt::UserRole).toInt();
+    QString draftContent;
+    QString forkedContent;
+    for (const auto& draft : m_drafts) {
+        if (draft.id == draftId) {
+            draftContent = draft.content;
+            forkedContent = draft.forkedContent;
+            break;
+        }
+    }
+
+    QDialog diffDialog(this);
+    diffDialog.setWindowTitle(tr("Compare Draft (3-Way View)"));
+    diffDialog.resize(1200, 600);
+    QVBoxLayout* mainLayout = new QVBoxLayout(&diffDialog);
+
+    QSplitter* splitter = new QSplitter(Qt::Horizontal, &diffDialog);
+
+    QWidget* forkedWidget = new QWidget(splitter);
+    QVBoxLayout* forkedLayout = new QVBoxLayout(forkedWidget);
+    forkedLayout->addWidget(new QLabel(tr("State when drafted:")));
+    QTextEdit* forkedEdit = new QTextEdit(forkedWidget);
+    forkedEdit->setReadOnly(true);
+    forkedEdit->setPlainText(forkedContent);
+    forkedLayout->addWidget(forkedEdit);
+
+    QWidget* origWidget = new QWidget(splitter);
+    QVBoxLayout* origLayout = new QVBoxLayout(origWidget);
+    origLayout->addWidget(new QLabel(tr("Current Original Document:")));
+    QTextEdit* origEdit = new QTextEdit(origWidget);
+    origEdit->setReadOnly(true);
+    origEdit->setPlainText(m_originalContent);
+    origLayout->addWidget(origEdit);
+
+    QWidget* draftWidget = new QWidget(splitter);
+    QVBoxLayout* draftLayout = new QVBoxLayout(draftWidget);
+    draftLayout->addWidget(new QLabel(tr("Draft Content:")));
+    QTextEdit* draftEdit = new QTextEdit(draftWidget);
+    draftEdit->setReadOnly(true);
+    draftEdit->setPlainText(draftContent);
+    draftLayout->addWidget(draftEdit);
+
+    splitter->addWidget(forkedWidget);
+    splitter->addWidget(origWidget);
+    splitter->addWidget(draftWidget);
+
+    mainLayout->addWidget(splitter);
+
+    QHBoxLayout* btnLayout = new QHBoxLayout();
+    btnLayout->addStretch();
+    QPushButton* closeBtn = new QPushButton(tr("Close"), &diffDialog);
+    btnLayout->addWidget(closeBtn);
+    mainLayout->addLayout(btnLayout);
+
+    connect(closeBtn, &QPushButton::clicked, &diffDialog, &QDialog::accept);
+
+    diffDialog.exec();
+}

--- a/src/DraftSelectionDialog.h
+++ b/src/DraftSelectionDialog.h
@@ -1,0 +1,42 @@
+#ifndef DRAFTSELECTIONDIALOG_H
+#define DRAFTSELECTIONDIALOG_H
+
+#include <QDialog>
+#include <QListWidget>
+#include <QTextEdit>
+#include <QSplitter>
+#include "BookDatabase.h"
+
+class DraftSelectionDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    enum Action { Cancel, UseDraft, EditOriginal };
+
+    explicit DraftSelectionDialog(std::shared_ptr<BookDatabase> db, const QString& originalContent, const QList<DocumentNode>& drafts, QWidget* parent = nullptr);
+
+    Action getSelectedAction() const;
+    DocumentNode getSelectedDraft() const;
+
+private slots:
+    void onDraftSelectionChanged();
+    void onUseDraft();
+    void onDeleteDraft();
+    void onEditOriginal();
+    void onShowDifferences();
+
+private:
+    std::shared_ptr<BookDatabase> m_db;
+    QString m_originalContent;
+    QList<DocumentNode> m_drafts;
+    Action m_selectedAction = Cancel;
+    DocumentNode m_selectedDraft;
+
+    QListWidget* m_draftList;
+    QTextEdit* m_previewEdit;
+    QPushButton* m_useBtn;
+    QPushButton* m_deleteBtn;
+    QPushButton* m_diffBtn;
+};
+
+#endif // DRAFTSELECTIONDIALOG_H

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1,4 +1,5 @@
 #include "MainWindow.h"
+#include "DraftSelectionDialog.h"
 
 #include <KActionCollection>
 #include <KActionMenu>
@@ -4959,8 +4960,36 @@ void MainWindow::onEditDocument() {
         }
     }
 
+    // Check for existing drafts
+    QList<DocumentNode> associatedDrafts = currentDb->getDraftsByTarget(type, currentDocumentId);
+
+    DocumentNode selectedDraft;
+    bool useDraft = false;
+
+    if (!associatedDrafts.isEmpty()) {
+        QString originalContent;
+        QString outTitle;
+        getDocumentContent(currentDocumentId, type, outTitle, originalContent);
+
+        DraftSelectionDialog dialog(currentDb, originalContent, associatedDrafts, this);
+        if (dialog.exec() == QDialog::Accepted) {
+            if (dialog.getSelectedAction() == DraftSelectionDialog::UseDraft) {
+                useDraft = true;
+                selectedDraft = dialog.getSelectedDraft();
+                // We do NOT delete the draft here.
+                // It remains in the database until the user explicitly saves or deletes it, preventing data loss.
+            }
+        } else {
+            return; // Cancelled
+        }
+    }
+
     DocumentEditWindow* editWin = new DocumentEditWindow(currentDb, currentDocumentId, currentTitle, type);
     m_openDocEditors.insert(editorKey, editWin);
+
+    if (useDraft) {
+        editWin->setContent(selectedDraft.content);
+    }
 
     connect(editWin, &DocumentEditWindow::documentModified, this, [this, type](int docId) {
         loadDocumentsAndNotes();  // Refresh tree


### PR DESCRIPTION
This PR addresses the request to improve the user experience when editing documents that have associated drafts. When a user clicks "Edit document" and drafts exist, they are now presented with a `DraftSelectionDialog` offering options to use the draft, delete it, preview it, or view a 3-way difference comparison (Original State vs. Current Document vs. Draft). 

The draft database schema has been updated (v15) to track `target_type`, `target_id`, and `forked_content` to safely associate drafts with their source entities and enable accurate 3-way differencing without needing O(N) full-table scans. Additionally, selecting "Use Draft" safely populates the editor window rather than permanently deleting the draft to prevent data loss on accidental closure.

---
*PR created automatically by Jules for task [14686783086518038851](https://jules.google.com/task/14686783086518038851) started by @arran4*