### PR TITLE
Add DraftSelectionDialog and associated schema migrations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,9 @@ add_executable(kllamabooks
     src/AIOperationsEditorWidget.cpp
     src/AIOperationsEditorWidget.h
     src/DocumentEditWindow.cpp
+    src/DraftSelectionDialog.cpp
     src/DocumentEditWindow.h
+    src/DraftSelectionDialog.h
     src/DocumentReviewDialog.cpp
     src/DocumentReviewDialog.h
     src/DocumentHistoryDialog.cpp

--- a/src/BookDatabase.cpp
+++ b/src/BookDatabase.cpp
@@ -482,6 +482,14 @@ bool BookDatabase::initSchema() {
         userVersion = 15;
     }
 
+    if (userVersion < 16) {
+        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE drafts ADD COLUMN parent_id INTEGER DEFAULT 0;", nullptr, nullptr, nullptr);
+        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE drafts ADD COLUMN target_type TEXT DEFAULT 'document';", nullptr, nullptr, nullptr);
+        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (16);", nullptr, nullptr, nullptr);
+        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 16;", nullptr, nullptr, nullptr);
+        userVersion = 16;
+    }
+
     return true;
 }
 
@@ -985,10 +993,10 @@ QList<DocumentNode> BookDatabase::getTemplates(int folderId) const {
     return nodes;
 }
 
-int BookDatabase::addDraft(int folderId, const QString& title, const QString& content) {
+int BookDatabase::addDraft(int folderId, const QString& title, const QString& content, int parentId, const QString& targetType) {
     if (!m_isOpen) return -1;
 
-    const char* sql = "INSERT INTO drafts (folder_id, title, content) VALUES (?, ?, ?);";
+    const char* sql = "INSERT INTO drafts (folder_id, title, content, parent_id, target_type) VALUES (?, ?, ?, ?, ?);";
     sqlite3_stmt* stmt;
     int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return -1;
@@ -996,6 +1004,8 @@ int BookDatabase::addDraft(int folderId, const QString& title, const QString& co
     sqlite3_bind_int(stmt, 1, folderId);
     sqlite3_bind_text(stmt, 2, title.toUtf8().constData(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 3, content.toUtf8().constData(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 4, parentId);
+    sqlite3_bind_text(stmt, 5, targetType.toUtf8().constData(), -1, SQLITE_TRANSIENT);
 
     rc = sqlite3_step(stmt);
     if (rc != SQLITE_DONE) {
@@ -1029,7 +1039,7 @@ QList<DocumentNode> BookDatabase::getDrafts(int folderId) const {
     QList<DocumentNode> nodes;
     if (!m_isOpen) return nodes;
 
-    QString sqlStr = "SELECT id, folder_id, title, content, timestamp FROM drafts";
+    QString sqlStr = "SELECT id, folder_id, title, content, timestamp, parent_id, target_type FROM drafts";
     if (folderId != -1) sqlStr += " WHERE folder_id = ?";
     sqlStr += " ORDER BY timestamp ASC;";
 
@@ -1047,6 +1057,8 @@ QList<DocumentNode> BookDatabase::getDrafts(int folderId) const {
         node.content = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
         QString ts = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
+        node.parentId = sqlite3_column_int(stmt, 5);
+        node.targetType = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 6));
         node.isFolder = false;
         nodes.append(node);
     }

--- a/src/BookDatabase.h
+++ b/src/BookDatabase.h
@@ -24,6 +24,7 @@ struct DocumentNode {
     QString content;
     QDateTime timestamp;
     bool isFolder;  // Deprecated, but keeping for compatibility during migration if needed
+    QString targetType; // Optional, e.g., 'document', 'note', 'template'
 };
 
 struct ChatNode {
@@ -141,7 +142,7 @@ class BookDatabase {
     bool deleteTemplate(int id);
 
     // Drafts
-    int addDraft(int folderId, const QString& title, const QString& content);
+    int addDraft(int folderId, const QString& title, const QString& content, int parentId = 0, const QString& targetType = "document");
     bool updateDraft(int id, const QString& newTitle, const QString& newContent);
     QList<DocumentNode> getDrafts(int folderId = -1) const;
     bool deleteDraft(int id);

--- a/src/DocumentEditWindow.cpp
+++ b/src/DocumentEditWindow.cpp
@@ -120,6 +120,39 @@ void DocumentEditWindow::setupWindow() {
         });
     }
 
+    QAction* addCommentAction = nullptr;
+    if (m_targetType == "draft") {
+        addCommentAction = new QAction(QIcon::fromTheme("view-pim-notes"), tr("Edit Draft Description"), this);
+        connect(addCommentAction, &QAction::triggered, this, [this]() {
+            if (!m_db || !m_db->isOpen()) return;
+
+            QString existingComment = "";
+            int commentId = -1;
+            QList<CommentNode> comments = m_db->getComments("draft", m_documentId);
+            if (!comments.isEmpty()) {
+                existingComment = comments.first().content;
+                commentId = comments.first().id;
+            }
+
+            bool ok;
+            QString desc = QInputDialog::getMultiLineText(this, tr("Draft Description"),
+                                                          tr("Enter a description to help identify this draft:"),
+                                                          existingComment, &ok);
+            if (ok) {
+                if (commentId == -1 && !desc.isEmpty()) {
+                    m_db->addComment("draft", m_documentId, desc);
+                } else if (commentId != -1) {
+                    if (desc.isEmpty()) {
+                        m_db->deleteComment(commentId);
+                    } else {
+                        m_db->updateComment(commentId, desc);
+                    }
+                }
+                emit documentModified(m_documentId); // Force UI refresh
+            }
+        });
+    }
+
     QAction* renameAction = new QAction(QIcon::fromTheme("edit-rename"), tr("Rename"), this);
     connect(renameAction, &QAction::triggered, this, &DocumentEditWindow::onRenameClicked);
 
@@ -156,6 +189,7 @@ void DocumentEditWindow::setupWindow() {
         if (replaceOriginalAction) mainToolBar->addAction(replaceOriginalAction);
         if (viewOriginalAction) mainToolBar->addAction(viewOriginalAction);
         if (dismissDraftAction) mainToolBar->addAction(dismissDraftAction);
+        if (addCommentAction) mainToolBar->addAction(addCommentAction);
     }
     mainToolBar->addAction(renameAction);
     mainToolBar->addAction(jumpAction);
@@ -171,6 +205,7 @@ void DocumentEditWindow::setupWindow() {
         if (replaceOriginalAction) fileMenu->addAction(replaceOriginalAction);
         if (viewOriginalAction) fileMenu->addAction(viewOriginalAction);
         if (dismissDraftAction) fileMenu->addAction(dismissDraftAction);
+        if (addCommentAction) fileMenu->addAction(addCommentAction);
     }
     fileMenu->addSeparator();
     fileMenu->addAction(renameAction);

--- a/src/DocumentEditWindow.cpp
+++ b/src/DocumentEditWindow.cpp
@@ -96,6 +96,7 @@ void DocumentEditWindow::onContentChanged() {
     QString text = m_editor->toPlainText();
     int words = text.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts).size();
     m_wordCountLabel->setText(tr("Words: %1").arg(words));
+    updateStatusBar();
 }
 
 void DocumentEditWindow::setInitialContent(const QString& content) {
@@ -103,10 +104,19 @@ void DocumentEditWindow::setInitialContent(const QString& content) {
 }
 
 void DocumentEditWindow::updateStatusBar() {
+    if (m_targetType == "draft") {
+        m_statusLabel->setText(tr("Viewing Draft"));
+        m_statusLabel->setStyleSheet("color: #FF8C00; font-weight: bold;"); // Dark Orange
+        return;
+    }
+
     QDateTime currentDbTimestamp = getLatestDbTimestamp();
     if (currentDbTimestamp > m_openTimestamp) {
         m_statusLabel->setText(tr("⚠️ Must Fork - Document was modified externally"));
         m_statusLabel->setStyleSheet("color: red; font-weight: bold;");
+    } else if (m_editor->toPlainText() != m_initialContent) {
+        m_statusLabel->setText(tr("Modified"));
+        m_statusLabel->setStyleSheet("color: blue;");
     } else {
         m_statusLabel->setText(tr("Ready"));
         m_statusLabel->setStyleSheet("");
@@ -311,7 +321,10 @@ bool DocumentEditWindow::saveToDb() {
     QDateTime currentDbTimestamp = getLatestDbTimestamp();
     // Sometimes timestamps match exactly due to seconds resolution. We consider it modified if strictly >
     // m_openTimestamp Wait, let's just do a strict greater check
-    if (currentDbTimestamp > m_openTimestamp) {
+
+    // Ignore conflict checking if this is just a draft we are editing,
+    // since the target's modifications shouldn't prevent saving the draft itself
+    if (currentDbTimestamp > m_openTimestamp && m_targetType != "draft") {
         // Conflict
         QMessageBox msgBox(this);
         msgBox.setWindowTitle(tr("Conflict Detected"));
@@ -362,6 +375,31 @@ void DocumentEditWindow::closeEvent(QCloseEvent* event) {
     if (m_editor->toPlainText() != m_initialContent) {
         QMessageBox msgBox(this);
         msgBox.setWindowTitle(tr("Unsaved Changes"));
+
+        // If it's already a draft, they can just save it or discard
+        if (m_targetType == "draft") {
+            msgBox.setText(tr("You have unsaved changes to this draft.\nWould you like to Save, Discard, or Cancel?"));
+            QPushButton* saveBtn = msgBox.addButton(tr("Save"), QMessageBox::AcceptRole);
+            QPushButton* discardBtn = msgBox.addButton(tr("Discard"), QMessageBox::DestructiveRole);
+            QPushButton* cancelBtn = msgBox.addButton(tr("Cancel"), QMessageBox::RejectRole);
+
+            msgBox.exec();
+
+            if (msgBox.clickedButton() == saveBtn) {
+                if (saveToDb()) {
+                    emit documentModified(m_documentId);
+                    event->accept();
+                } else {
+                    event->ignore();
+                }
+            } else if (msgBox.clickedButton() == discardBtn) {
+                event->accept();
+            } else {
+                event->ignore();
+            }
+            return;
+        }
+
         msgBox.setText(tr("You have unsaved changes.\nWould you like to Save to Drafts, Discard, or Cancel?"));
 
         QPushButton* saveDraftBtn = msgBox.addButton(tr("Save to Drafts"), QMessageBox::AcceptRole);

--- a/src/DocumentEditWindow.cpp
+++ b/src/DocumentEditWindow.cpp
@@ -79,6 +79,82 @@ void DocumentEditWindow::setupWindow() {
                 return;
             }
 
+            QDateTime originalTimestamp;
+            QList<DocumentNode> originals;
+            if (targetType == "document") originals = m_db->getDocuments(-1);
+            else if (targetType == "template") originals = m_db->getTemplates(-1);
+            else if (targetType == "note") {
+                auto notes = m_db->getNotes(-1);
+                for (const auto& n : notes) {
+                    if (n.id == parentId) {
+                        originalTimestamp = n.timestamp;
+                        break;
+                    }
+                }
+            }
+            if (targetType != "note") {
+                for (const auto& doc : originals) {
+                    if (doc.id == parentId) {
+                        originalTimestamp = doc.timestamp;
+                        break;
+                    }
+                }
+            }
+
+            if (originalTimestamp > m_openTimestamp) {
+                QMessageBox msgBox(this);
+                msgBox.setWindowTitle(tr("Conflict Detected"));
+                msgBox.setText(tr("Warning: The original document has drifted (been modified) since this draft was opened.\nWhat would you like to do?"));
+
+                QPushButton* continueBtn = msgBox.addButton(tr("Continue & Replace"), QMessageBox::AcceptRole);
+                QPushButton* forkBtn = msgBox.addButton(tr("Create New Forked Document"), QMessageBox::AcceptRole);
+                QPushButton* deleteDraftBtn = msgBox.addButton(tr("Delete Draft & Cancel"), QMessageBox::DestructiveRole);
+                QPushButton* cancelBtn = msgBox.addButton(tr("Cancel"), QMessageBox::RejectRole);
+
+                msgBox.exec();
+
+                if (msgBox.clickedButton() == continueBtn) {
+                    // fallthrough to regular replace logic
+                } else if (msgBox.clickedButton() == forkBtn) {
+                    bool ok;
+                    QString newTitle = QInputDialog::getText(this, tr("Create Fork"), tr("New Title:"), QLineEdit::Normal, m_title + " (Fork)", &ok);
+                    if (ok && !newTitle.isEmpty()) {
+                        int folderId = 0;
+                        for (const auto& doc : originals) {
+                            if (doc.id == parentId) {
+                                folderId = doc.folderId;
+                                break;
+                            }
+                        }
+                        if (targetType == "note") {
+                            auto notes = m_db->getNotes(-1);
+                            for (const auto& n : notes) {
+                                if (n.id == parentId) {
+                                    folderId = n.folderId;
+                                    break;
+                                }
+                            }
+                            m_db->addNote(folderId, newTitle, m_editor->toPlainText());
+                        } else if (targetType == "document") {
+                            m_db->addDocument(folderId, newTitle, m_editor->toPlainText());
+                        } else if (targetType == "template") {
+                            m_db->addTemplate(folderId, newTitle, m_editor->toPlainText());
+                        }
+                        m_db->deleteDraft(m_documentId);
+                        emit documentModified(m_documentId);
+                        close();
+                    }
+                    return;
+                } else if (msgBox.clickedButton() == deleteDraftBtn) {
+                    m_db->deleteDraft(m_documentId);
+                    emit documentModified(m_documentId);
+                    close();
+                    return;
+                } else {
+                    return; // Cancel
+                }
+            }
+
             if (targetType == "document") {
                 m_db->updateDocument(parentId, m_title, m_editor->toPlainText());
                 QMessageBox::information(this, tr("Success"), tr("Original document replaced successfully."));

--- a/src/DocumentEditWindow.cpp
+++ b/src/DocumentEditWindow.cpp
@@ -21,8 +21,8 @@
 #include <QVBoxLayout>
 
 DocumentEditWindow::DocumentEditWindow(std::shared_ptr<BookDatabase> db, int documentId, const QString& title,
-                                       const QString& itemType, QWidget* parent)
-    : KXmlGuiWindow(parent, Qt::Window), m_db(db), m_documentId(documentId), m_title(title), m_itemType(itemType) {
+                                       const QString& targetType, QWidget* parent)
+    : KXmlGuiWindow(parent, Qt::Window), m_db(db), m_documentId(documentId), m_title(title), m_targetType(targetType) {
     setWindowTitle(tr("Editing: %1").arg(title));
     resize(800, 600);
     setAttribute(Qt::WA_DeleteOnClose);
@@ -98,6 +98,10 @@ void DocumentEditWindow::onContentChanged() {
     m_wordCountLabel->setText(tr("Words: %1").arg(words));
 }
 
+void DocumentEditWindow::setInitialContent(const QString& content) {
+    m_editor->setPlainText(content);
+}
+
 void DocumentEditWindow::updateStatusBar() {
     QDateTime currentDbTimestamp = getLatestDbTimestamp();
     if (currentDbTimestamp > m_openTimestamp) {
@@ -113,9 +117,9 @@ void DocumentEditWindow::loadDocument() {
     if (!m_db || !m_db->isOpen()) return;
 
     QList<DocumentNode> docs;
-    if (m_itemType == "document") docs = m_db->getDocuments();
-    else if (m_itemType == "draft") docs = m_db->getDrafts();
-    else if (m_itemType == "template") docs = m_db->getTemplates();
+    if (m_targetType == "document") docs = m_db->getDocuments();
+    else if (m_targetType == "draft") docs = m_db->getDrafts();
+    else if (m_targetType == "template") docs = m_db->getTemplates();
 
     for (const auto& d : docs) {
         if (d.id == m_documentId) {
@@ -133,18 +137,29 @@ QDateTime DocumentEditWindow::getLatestDbTimestamp() const {
 
     QDateTime latest;
     QList<DocumentNode> docs;
-    if (m_itemType == "document") docs = m_db->getDocuments();
-    else if (m_itemType == "draft") docs = m_db->getDrafts();
-    else if (m_itemType == "template") docs = m_db->getTemplates();
-
-    for (const auto& d : docs) {
-        if (d.id == m_documentId) {
-            latest = d.timestamp;
-            break;
+    if (m_targetType == "document") docs = m_db->getDocuments();
+    else if (m_targetType == "draft") docs = m_db->getDrafts();
+    else if (m_targetType == "template") docs = m_db->getTemplates();
+    else if (m_targetType == "note") {
+        auto notes = m_db->getNotes();
+        for (const auto& n : notes) {
+            if (n.id == m_documentId) {
+                latest = n.timestamp;
+                break;
+            }
         }
     }
 
-    if (m_itemType == "document") {
+    if (m_targetType != "note") {
+        for (const auto& d : docs) {
+            if (d.id == m_documentId) {
+                latest = d.timestamp;
+                break;
+            }
+        }
+    }
+
+    if (m_targetType == "document") {
         auto history = m_db->getDocumentHistory(m_documentId);
         if (!history.isEmpty()) {
             QDateTime histTs = QDateTime::fromString(history.first().timestamp, Qt::ISODate);
@@ -226,9 +241,20 @@ int DocumentEditWindow::forkDocument(const QString& newTitle) {
     if (!m_db || !m_db->isOpen()) return 0;
 
     QList<DocumentNode> docs;
-    if (m_itemType == "document") docs = m_db->getDocuments();
-    else if (m_itemType == "draft") docs = m_db->getDrafts();
-    else if (m_itemType == "template") docs = m_db->getTemplates();
+    if (m_targetType == "document") docs = m_db->getDocuments();
+    else if (m_targetType == "draft") docs = m_db->getDrafts();
+    else if (m_targetType == "template") docs = m_db->getTemplates();
+    else if (m_targetType == "note") {
+        auto notes = m_db->getNotes();
+        int folderId = 0;
+        for (const auto& n : notes) {
+            if (n.id == m_documentId) {
+                folderId = n.folderId;
+                break;
+            }
+        }
+        return m_db->addNote(folderId, newTitle, m_editor->toPlainText());
+    }
 
     int folderId = 0;
     for (const auto& d : docs) {
@@ -238,11 +264,11 @@ int DocumentEditWindow::forkDocument(const QString& newTitle) {
         }
     }
 
-    if (m_itemType == "document") {
+    if (m_targetType == "document") {
         return m_db->addDocument(folderId, newTitle, m_editor->toPlainText(), m_documentId);
-    } else if (m_itemType == "draft") {
+    } else if (m_targetType == "draft") {
         return m_db->addDraft(folderId, newTitle, m_editor->toPlainText());
-    } else if (m_itemType == "template") {
+    } else if (m_targetType == "template") {
         return m_db->addTemplate(folderId, newTitle, m_editor->toPlainText());
     }
     return 0;
@@ -252,9 +278,20 @@ int DocumentEditWindow::saveToDraft(const QString& newTitle) {
     if (!m_db || !m_db->isOpen()) return 0;
 
     QList<DocumentNode> docs;
-    if (m_itemType == "document") docs = m_db->getDocuments();
-    else if (m_itemType == "draft") docs = m_db->getDrafts();
-    else if (m_itemType == "template") docs = m_db->getTemplates();
+    if (m_targetType == "document") docs = m_db->getDocuments();
+    else if (m_targetType == "draft") docs = m_db->getDrafts();
+    else if (m_targetType == "template") docs = m_db->getTemplates();
+    else if (m_targetType == "note") {
+        auto notes = m_db->getNotes();
+        int folderId = 0;
+        for (const auto& n : notes) {
+            if (n.id == m_documentId) {
+                folderId = n.folderId;
+                break;
+            }
+        }
+        return m_db->addDraft(folderId, newTitle, m_editor->toPlainText(), m_documentId, m_targetType);
+    }
 
     int folderId = 0;
     for (const auto& d : docs) {
@@ -264,7 +301,7 @@ int DocumentEditWindow::saveToDraft(const QString& newTitle) {
         }
     }
 
-    return m_db->addDraft(folderId, newTitle, m_editor->toPlainText());
+    return m_db->addDraft(folderId, newTitle, m_editor->toPlainText(), m_documentId, m_targetType);
 }
 
 bool DocumentEditWindow::saveToDb() {
@@ -307,13 +344,15 @@ bool DocumentEditWindow::saveToDb() {
         }
     } else {
         // No conflict, save normally
-        if (m_itemType == "document") {
+        if (m_targetType == "document") {
             m_db->addDocumentHistory(m_documentId, "manual_edit_pre", m_initialContent);
             m_db->updateDocument(m_documentId, m_title, m_editor->toPlainText());
-        } else if (m_itemType == "draft") {
+        } else if (m_targetType == "draft") {
             m_db->updateDraft(m_documentId, m_title, m_editor->toPlainText());
-        } else if (m_itemType == "template") {
+        } else if (m_targetType == "template") {
             m_db->updateTemplate(m_documentId, m_title, m_editor->toPlainText());
+        } else if (m_targetType == "note") {
+            m_db->updateNote(m_documentId, m_title, m_editor->toPlainText());
         }
         return true;
     }

--- a/src/DocumentEditWindow.cpp
+++ b/src/DocumentEditWindow.cpp
@@ -694,7 +694,10 @@ void DocumentEditWindow::closeEvent(QCloseEvent* event) {
         msgBox.exec();
 
         if (msgBox.clickedButton() == saveDraftBtn) {
-            saveToDraft(m_title + " (Draft)");
+            int newId = saveToDraft(m_title);
+            if (newId > 0) {
+                emit newDocumentCreated(newId);
+            }
             event->accept();
         } else if (msgBox.clickedButton() == discardBtn) {
             event->accept();

--- a/src/DocumentEditWindow.cpp
+++ b/src/DocumentEditWindow.cpp
@@ -474,6 +474,64 @@ void DocumentEditWindow::closeEvent(QCloseEvent* event) {
 
         // If it's already a draft, they can just save it or discard
         if (m_targetType == "draft") {
+            // First check if the original document has changed
+            int originalId = -1;
+            QString targetType = "";
+            QDateTime originalTimestamp;
+            QList<DocumentNode> drafts = m_db->getDrafts(-1);
+            for (const auto& d : drafts) {
+                if (d.id == m_documentId) {
+                    originalId = d.parentId;
+                    targetType = d.targetType;
+                    break;
+                }
+            }
+
+            if (originalId > 0) {
+                // Fetch the original's current timestamp
+                QList<DocumentNode> originals;
+                if (targetType == "document") originals = m_db->getDocuments(-1);
+                else if (targetType == "template") originals = m_db->getTemplates(-1);
+
+                for (const auto& doc : originals) {
+                    if (doc.id == originalId) {
+                        originalTimestamp = doc.timestamp;
+                        break;
+                    }
+                }
+
+                // If the original has changed since this draft was created, we should warn them.
+                // We use m_openTimestamp as a proxy, as we load it when the draft is opened.
+                // Wait, m_openTimestamp tracks when the *draft* was opened. We should really
+                // compare against when the draft was created/last updated, but since we don't have
+                // the original's timestamp at draft creation easily accessible without joining history,
+                // we'll just check if the original changed since we opened the draft window.
+                // It's a best-effort check given the schema.
+
+                if (originalTimestamp > m_openTimestamp) {
+                    msgBox.setText(tr("Warning: The original document has been modified since you started editing this draft.\nWould you still like to Save this draft, Discard your current edits, or Cancel?"));
+                    QPushButton* saveBtn = msgBox.addButton(tr("Save Draft"), QMessageBox::AcceptRole);
+                    QPushButton* discardBtn = msgBox.addButton(tr("Discard Edits"), QMessageBox::DestructiveRole);
+                    QPushButton* cancelBtn = msgBox.addButton(tr("Cancel"), QMessageBox::RejectRole);
+
+                    msgBox.exec();
+
+                    if (msgBox.clickedButton() == saveBtn) {
+                        if (saveToDb()) {
+                            emit documentModified(m_documentId);
+                            event->accept();
+                        } else {
+                            event->ignore();
+                        }
+                    } else if (msgBox.clickedButton() == discardBtn) {
+                        event->accept();
+                    } else {
+                        event->ignore();
+                    }
+                    return;
+                }
+            }
+
             msgBox.setText(tr("You have unsaved changes to this draft.\nWould you like to Save, Discard, or Cancel?"));
             QPushButton* saveBtn = msgBox.addButton(tr("Save"), QMessageBox::AcceptRole);
             QPushButton* discardBtn = msgBox.addButton(tr("Discard"), QMessageBox::DestructiveRole);

--- a/src/DocumentEditWindow.cpp
+++ b/src/DocumentEditWindow.cpp
@@ -226,11 +226,26 @@ void DocumentEditWindow::loadDocument() {
     if (m_targetType == "document") docs = m_db->getDocuments();
     else if (m_targetType == "draft") docs = m_db->getDrafts();
     else if (m_targetType == "template") docs = m_db->getTemplates();
+    else if (m_targetType == "note") {
+        auto notes = m_db->getNotes();
+        for (const auto& n : notes) {
+            if (n.id == m_documentId) {
+                m_initialContent = n.content;
+                if (m_editor->toPlainText().isEmpty()) {
+                    m_editor->setPlainText(m_initialContent);
+                }
+                break;
+            }
+        }
+        return;
+    }
 
     for (const auto& d : docs) {
         if (d.id == m_documentId) {
             m_initialContent = d.content;
-            m_editor->setPlainText(m_initialContent);
+            if (m_editor->toPlainText().isEmpty()) {
+                m_editor->setPlainText(m_initialContent);
+            }
             break;
         }
     }

--- a/src/DocumentEditWindow.cpp
+++ b/src/DocumentEditWindow.cpp
@@ -319,12 +319,13 @@ void DocumentEditWindow::onSaveAsClicked() {
 void DocumentEditWindow::onSaveAsDraftClicked() {
     bool ok;
     QString newTitle = QInputDialog::getText(this, tr("Save As Draft"), tr("Draft Title:"), QLineEdit::Normal,
-                                             m_title + " (Draft)", &ok);
+                                             m_title, &ok);
     if (ok && !newTitle.isEmpty()) {
         int newId = saveToDraft(newTitle);
         if (newId > 0) {
             m_statusLabel->setText(tr("Saved to drafts"));
             emit newDocumentCreated(newId);
+            close(); // Close active window since it was saved as draft
         }
     }
 }

--- a/src/DocumentEditWindow.cpp
+++ b/src/DocumentEditWindow.cpp
@@ -45,7 +45,7 @@ void DocumentEditWindow::setupWindow() {
     connect(m_editor, &QTextEdit::textChanged, this, &DocumentEditWindow::onContentChanged);
 
     // Toolbar actions
-    QAction* saveAction = new QAction(QIcon::fromTheme("document-save"), tr("Save"), this);
+    QAction* saveAction = new QAction(QIcon::fromTheme("document-save"), m_targetType == "draft" ? tr("Update Draft") : tr("Save"), this);
     connect(saveAction, &QAction::triggered, this, &DocumentEditWindow::onSaveClicked);
 
     QAction* saveAsAction = new QAction(QIcon::fromTheme("document-save-as"), tr("Save As..."), this);
@@ -54,10 +54,71 @@ void DocumentEditWindow::setupWindow() {
     QAction* saveAsDraftAction = new QAction(QIcon::fromTheme("document-new"), tr("Save as Draft"), this);
     connect(saveAsDraftAction, &QAction::triggered, this, &DocumentEditWindow::onSaveAsDraftClicked);
 
+    QAction* replaceOriginalAction = nullptr;
+    QAction* viewOriginalAction = nullptr;
+    if (m_targetType == "draft") {
+        saveAsDraftAction->setVisible(false); // Hide "Save as Draft" if it is already a draft.
+
+        replaceOriginalAction = new QAction(QIcon::fromTheme("document-export"), tr("Replace Original Document"), this);
+        connect(replaceOriginalAction, &QAction::triggered, this, [this]() {
+            if (!m_db || !m_db->isOpen()) return;
+
+            QList<DocumentNode> drafts = m_db->getDrafts(-1);
+            int parentId = 0;
+            QString targetType = "";
+            for (const auto& d : drafts) {
+                if (d.id == m_documentId) {
+                    parentId = d.parentId;
+                    targetType = d.targetType;
+                    break;
+                }
+            }
+
+            if (parentId <= 0) {
+                QMessageBox::warning(this, tr("Not Found"), tr("Cannot find original document."));
+                return;
+            }
+
+            if (targetType == "document") {
+                m_db->updateDocument(parentId, m_title, m_editor->toPlainText());
+                QMessageBox::information(this, tr("Success"), tr("Original document replaced successfully."));
+            } else if (targetType == "template") {
+                m_db->updateTemplate(parentId, m_title, m_editor->toPlainText());
+                QMessageBox::information(this, tr("Success"), tr("Original template replaced successfully."));
+            } else if (targetType == "note") {
+                m_db->updateNote(parentId, m_title, m_editor->toPlainText());
+                QMessageBox::information(this, tr("Success"), tr("Original note replaced successfully."));
+            }
+        });
+
+        viewOriginalAction = new QAction(QIcon::fromTheme("view-preview"), tr("View Original Document"), this);
+        connect(viewOriginalAction, &QAction::triggered, this, [this]() {
+            if (!m_db || !m_db->isOpen()) return;
+
+            QList<DocumentNode> drafts = m_db->getDrafts(-1);
+            int parentId = 0;
+            QString targetType = "";
+            for (const auto& d : drafts) {
+                if (d.id == m_documentId) {
+                    parentId = d.parentId;
+                    targetType = d.targetType;
+                    break;
+                }
+            }
+
+            if (parentId <= 0) {
+                QMessageBox::warning(this, tr("Not Found"), tr("Cannot find original document."));
+                return;
+            }
+
+            emit jumpToDocumentRequested(parentId); // Signal MainWindow to jump there, need to update param
+        });
+    }
+
     QAction* renameAction = new QAction(QIcon::fromTheme("edit-rename"), tr("Rename"), this);
     connect(renameAction, &QAction::triggered, this, &DocumentEditWindow::onRenameClicked);
 
-    QAction* jumpAction = new QAction(QIcon::fromTheme("go-jump"), tr("Jump to Document"), this);
+    QAction* jumpAction = new QAction(QIcon::fromTheme("go-jump"), tr("Jump to Item"), this);
     connect(jumpAction, &QAction::triggered, this, &DocumentEditWindow::onJumpClicked);
 
     QAction* closeAction = new QAction(QIcon::fromTheme("window-close"), tr("Close"), this);
@@ -66,7 +127,12 @@ void DocumentEditWindow::setupWindow() {
     KToolBar* mainToolBar = new KToolBar("mainToolBar", this);
     mainToolBar->addAction(saveAction);
     mainToolBar->addAction(saveAsAction);
-    mainToolBar->addAction(saveAsDraftAction);
+    if (m_targetType != "draft") {
+        mainToolBar->addAction(saveAsDraftAction);
+    } else {
+        if (replaceOriginalAction) mainToolBar->addAction(replaceOriginalAction);
+        if (viewOriginalAction) mainToolBar->addAction(viewOriginalAction);
+    }
     mainToolBar->addAction(renameAction);
     mainToolBar->addAction(jumpAction);
     mainToolBar->addAction(closeAction);
@@ -75,7 +141,12 @@ void DocumentEditWindow::setupWindow() {
     QMenu* fileMenu = new QMenu(tr("File"), this);
     fileMenu->addAction(saveAction);
     fileMenu->addAction(saveAsAction);
-    fileMenu->addAction(saveAsDraftAction);
+    if (m_targetType != "draft") {
+        fileMenu->addAction(saveAsDraftAction);
+    } else {
+        if (replaceOriginalAction) fileMenu->addAction(replaceOriginalAction);
+        if (viewOriginalAction) fileMenu->addAction(viewOriginalAction);
+    }
     fileMenu->addSeparator();
     fileMenu->addAction(renameAction);
     fileMenu->addAction(jumpAction);

--- a/src/DocumentEditWindow.cpp
+++ b/src/DocumentEditWindow.cpp
@@ -104,8 +104,9 @@ void DocumentEditWindow::setupWindow() {
             if (originalTimestamp > m_openTimestamp) {
                 QMessageBox msgBox(this);
                 msgBox.setWindowTitle(tr("Conflict Detected"));
-                msgBox.setText(tr("Warning: The original document has drifted (been modified) since this draft was opened.\nWhat would you like to do?"));
+                msgBox.setText(tr("Warning: The original document has drifted (been modified) since this draft was created/opened.\nWhat would you like to do?"));
 
+                QPushButton* viewDiffBtn = msgBox.addButton(tr("View Differences"), QMessageBox::ActionRole);
                 QPushButton* continueBtn = msgBox.addButton(tr("Continue & Replace"), QMessageBox::AcceptRole);
                 QPushButton* forkBtn = msgBox.addButton(tr("Create New Forked Document"), QMessageBox::AcceptRole);
                 QPushButton* deleteDraftBtn = msgBox.addButton(tr("Delete Draft & Cancel"), QMessageBox::DestructiveRole);
@@ -113,7 +114,10 @@ void DocumentEditWindow::setupWindow() {
 
                 msgBox.exec();
 
-                if (msgBox.clickedButton() == continueBtn) {
+                if (msgBox.clickedButton() == viewDiffBtn) {
+                    emit jumpToDocumentRequested(parentId); // Jump to original document
+                    return; // abort replacement for now
+                } else if (msgBox.clickedButton() == continueBtn) {
                     // fallthrough to regular replace logic
                 } else if (msgBox.clickedButton() == forkBtn) {
                     bool ok;

--- a/src/DocumentEditWindow.cpp
+++ b/src/DocumentEditWindow.cpp
@@ -89,6 +89,11 @@ void DocumentEditWindow::setupWindow() {
                 m_db->updateNote(parentId, m_title, m_editor->toPlainText());
                 QMessageBox::information(this, tr("Success"), tr("Original note replaced successfully."));
             }
+
+            // Delete the draft after replacing
+            m_db->deleteDraft(m_documentId);
+            emit documentModified(m_documentId); // Trigger a refresh
+            close();
         });
 
         viewOriginalAction = new QAction(QIcon::fromTheme("view-preview"), tr("View Original Document"), this);
@@ -121,6 +126,24 @@ void DocumentEditWindow::setupWindow() {
     QAction* jumpAction = new QAction(QIcon::fromTheme("go-jump"), tr("Jump to Item"), this);
     connect(jumpAction, &QAction::triggered, this, &DocumentEditWindow::onJumpClicked);
 
+    QAction* dismissDraftAction = nullptr;
+    if (m_targetType == "draft") {
+        dismissDraftAction = new QAction(QIcon::fromTheme("edit-delete"), tr("Dismiss Draft"), this);
+        connect(dismissDraftAction, &QAction::triggered, this, [this]() {
+            if (!m_db || !m_db->isOpen()) return;
+
+            QMessageBox::StandardButton reply;
+            reply = QMessageBox::question(this, tr("Dismiss Draft"), tr("Are you sure you want to dismiss this draft permanently?"),
+                                          QMessageBox::Yes|QMessageBox::No);
+            if (reply == QMessageBox::Yes) {
+                m_db->deleteDraft(m_documentId);
+                m_initialContent = m_editor->toPlainText(); // Prevent save prompt
+                emit documentModified(m_documentId);
+                close();
+            }
+        });
+    }
+
     QAction* closeAction = new QAction(QIcon::fromTheme("window-close"), tr("Close"), this);
     connect(closeAction, &QAction::triggered, this, &QWidget::close);
 
@@ -132,6 +155,7 @@ void DocumentEditWindow::setupWindow() {
     } else {
         if (replaceOriginalAction) mainToolBar->addAction(replaceOriginalAction);
         if (viewOriginalAction) mainToolBar->addAction(viewOriginalAction);
+        if (dismissDraftAction) mainToolBar->addAction(dismissDraftAction);
     }
     mainToolBar->addAction(renameAction);
     mainToolBar->addAction(jumpAction);
@@ -146,6 +170,7 @@ void DocumentEditWindow::setupWindow() {
     } else {
         if (replaceOriginalAction) fileMenu->addAction(replaceOriginalAction);
         if (viewOriginalAction) fileMenu->addAction(viewOriginalAction);
+        if (dismissDraftAction) fileMenu->addAction(dismissDraftAction);
     }
     fileMenu->addSeparator();
     fileMenu->addAction(renameAction);

--- a/src/DocumentEditWindow.h
+++ b/src/DocumentEditWindow.h
@@ -15,8 +15,10 @@ class DocumentEditWindow : public KXmlGuiWindow {
     Q_OBJECT
    public:
     explicit DocumentEditWindow(std::shared_ptr<BookDatabase> db, int documentId, const QString& title,
-                                const QString& itemType = "document", QWidget* parent = nullptr);
+                                const QString& targetType = "document", QWidget* parent = nullptr);
     ~DocumentEditWindow() override;
+
+    void setInitialContent(const QString& content);
 
    signals:
     void documentModified(int documentId);
@@ -40,7 +42,7 @@ class DocumentEditWindow : public KXmlGuiWindow {
     QString m_title;
     QDateTime m_openTimestamp;
     QString m_initialContent;
-    QString m_itemType;
+    QString m_targetType;
 
     QTextEdit* m_editor;
     QLabel* m_statusLabel;

--- a/src/DraftSelectionDialog.cpp
+++ b/src/DraftSelectionDialog.cpp
@@ -41,12 +41,14 @@ DraftSelectionDialog::DraftSelectionDialog(std::shared_ptr<BookDatabase> db, int
     QPushButton* useBtn = new QPushButton(tr("Use This"), this);
     QPushButton* delBtn = new QPushButton(tr("Delete View"), this);
     QPushButton* diffBtn = new QPushButton(tr("Show Differences"), this);
-    QPushButton* cancelBtn = new QPushButton(tr("Ignore Drafts / Cancel"), this);
+    QPushButton* ignoreBtn = new QPushButton(tr("Ignore Drafts"), this);
+    QPushButton* cancelBtn = new QPushButton(tr("Cancel"), this);
 
     btnLayout->addWidget(useBtn);
     btnLayout->addWidget(delBtn);
     btnLayout->addWidget(diffBtn);
     btnLayout->addStretch();
+    btnLayout->addWidget(ignoreBtn);
     btnLayout->addWidget(cancelBtn);
 
     mainLayout->addLayout(btnLayout);
@@ -55,6 +57,7 @@ DraftSelectionDialog::DraftSelectionDialog(std::shared_ptr<BookDatabase> db, int
     connect(useBtn, &QPushButton::clicked, this, &DraftSelectionDialog::onUseThis);
     connect(delBtn, &QPushButton::clicked, this, &DraftSelectionDialog::onDeleteView);
     connect(diffBtn, &QPushButton::clicked, this, &DraftSelectionDialog::onShowDifferences);
+    connect(ignoreBtn, &QPushButton::clicked, this, &DraftSelectionDialog::onIgnoreDrafts);
     connect(cancelBtn, &QPushButton::clicked, this, &QDialog::reject);
 
     refreshDraftsList();
@@ -80,6 +83,12 @@ void DraftSelectionDialog::refreshDraftsList() {
 
 void DraftSelectionDialog::onSelectionChanged() {
     onPreview();
+}
+
+void DraftSelectionDialog::onIgnoreDrafts() {
+    // If we just want to ignore drafts, we accept the dialog without selecting a draft content
+    m_draftSelected = false;
+    accept();
 }
 
 void DraftSelectionDialog::onUseThis() {

--- a/src/DraftSelectionDialog.cpp
+++ b/src/DraftSelectionDialog.cpp
@@ -89,7 +89,24 @@ void DraftSelectionDialog::refreshDraftsList() {
     for (const auto& d : m_drafts) {
         QString displayTime = d.timestamp.toString("yyyy-MM-dd HH:mm:ss");
         QString title = d.title.isEmpty() ? tr("Untitled Draft") : d.title;
-        m_draftsList->addItem(QString("%1\n%2").arg(title, displayTime));
+
+        QString desc = "";
+        if (m_db && m_db->isOpen()) {
+            QList<CommentNode> existing = m_db->getComments("draft", d.id);
+            if (!existing.isEmpty()) {
+                desc = existing.first().content;
+                if (desc.length() > 30) {
+                    desc = desc.left(27) + "...";
+                }
+            }
+        }
+
+        QListWidgetItem* item = new QListWidgetItem(QString("%1\n%2").arg(title, displayTime));
+        if (!desc.isEmpty()) {
+            item->setToolTip(desc);
+            item->setText(item->text() + QString("\n[%1]").arg(desc));
+        }
+        m_draftsList->addItem(item);
     }
     if (m_draftsList->count() > 0) {
         m_draftsList->setCurrentRow(0);

--- a/src/DraftSelectionDialog.cpp
+++ b/src/DraftSelectionDialog.cpp
@@ -54,11 +54,26 @@ DraftSelectionDialog::DraftSelectionDialog(std::shared_ptr<BookDatabase> db, int
     mainLayout->addLayout(btnLayout);
 
     connect(m_draftsList, &QListWidget::itemSelectionChanged, this, &DraftSelectionDialog::onSelectionChanged);
+    QPushButton* previewBtn = new QPushButton(tr("Back to Drafts"), this);
+    connect(previewBtn, &QPushButton::clicked, this, &DraftSelectionDialog::onPreview);
+    btnLayout->insertWidget(3, previewBtn);
+
+    QPushButton* navigateOrigBtn = new QPushButton(tr("Navigate to Original Document"), this);
+    btnLayout->insertWidget(0, navigateOrigBtn);
+
+    connect(m_draftsList, &QListWidget::itemSelectionChanged, this, &DraftSelectionDialog::onSelectionChanged);
     connect(useBtn, &QPushButton::clicked, this, &DraftSelectionDialog::onUseThis);
     connect(delBtn, &QPushButton::clicked, this, &DraftSelectionDialog::onDeleteView);
     connect(diffBtn, &QPushButton::clicked, this, &DraftSelectionDialog::onShowDifferences);
     connect(ignoreBtn, &QPushButton::clicked, this, &DraftSelectionDialog::onIgnoreDrafts);
     connect(cancelBtn, &QPushButton::clicked, this, &QDialog::reject);
+    connect(navigateOrigBtn, &QPushButton::clicked, this, [this]() {
+        // Find the original document ID
+        if (m_db && m_db->isOpen() && m_drafts.size() > 0) {
+            // Signal navigation externally (MainWindow handles the jump logic best). We'll set m_draftSelected to false and a specific exit code.
+            done(QDialog::Accepted + 10);
+        }
+    });
 
     refreshDraftsList();
 }

--- a/src/DraftSelectionDialog.cpp
+++ b/src/DraftSelectionDialog.cpp
@@ -1,0 +1,220 @@
+#include "DraftSelectionDialog.h"
+
+#include <QDateTime>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QSplitter>
+#include <QTextBrowser>
+#include <QTextEdit>
+#include <QVBoxLayout>
+
+DraftSelectionDialog::DraftSelectionDialog(std::shared_ptr<BookDatabase> db, int documentId,
+                                           const QList<DocumentNode>& drafts, const QString& targetType, QWidget* parent)
+    : QDialog(parent), m_db(db), m_documentId(documentId), m_drafts(drafts), m_targetType(targetType), m_draftSelected(false) {
+    setWindowTitle(tr("Drafts Available"));
+    resize(800, 600);
+
+    QVBoxLayout* mainLayout = new QVBoxLayout(this);
+    QLabel* infoLabel = new QLabel(tr("There are drafts associated with this document. Select one to proceed:"));
+    mainLayout->addWidget(infoLabel);
+
+    m_mainSplitter = new QSplitter(Qt::Horizontal, this);
+
+    QWidget* listWidgetContainer = new QWidget(this);
+    QVBoxLayout* listLayout = new QVBoxLayout(listWidgetContainer);
+    listLayout->setContentsMargins(0, 0, 0, 0);
+
+    m_draftsList = new QListWidget(this);
+    listLayout->addWidget(m_draftsList);
+    m_mainSplitter->addWidget(listWidgetContainer);
+
+    m_previewBrowser = new QTextBrowser(this);
+    m_mainSplitter->addWidget(m_previewBrowser);
+
+    m_mainSplitter->setSizes({250, 550});
+    mainLayout->addWidget(m_mainSplitter, 1);
+
+    QHBoxLayout* btnLayout = new QHBoxLayout();
+    QPushButton* useBtn = new QPushButton(tr("Use This"), this);
+    QPushButton* delBtn = new QPushButton(tr("Delete View"), this);
+    QPushButton* diffBtn = new QPushButton(tr("Show Differences"), this);
+    QPushButton* cancelBtn = new QPushButton(tr("Ignore Drafts / Cancel"), this);
+
+    btnLayout->addWidget(useBtn);
+    btnLayout->addWidget(delBtn);
+    btnLayout->addWidget(diffBtn);
+    btnLayout->addStretch();
+    btnLayout->addWidget(cancelBtn);
+
+    mainLayout->addLayout(btnLayout);
+
+    connect(m_draftsList, &QListWidget::itemSelectionChanged, this, &DraftSelectionDialog::onSelectionChanged);
+    connect(useBtn, &QPushButton::clicked, this, &DraftSelectionDialog::onUseThis);
+    connect(delBtn, &QPushButton::clicked, this, &DraftSelectionDialog::onDeleteView);
+    connect(diffBtn, &QPushButton::clicked, this, &DraftSelectionDialog::onShowDifferences);
+    connect(cancelBtn, &QPushButton::clicked, this, &QDialog::reject);
+
+    refreshDraftsList();
+}
+
+DraftSelectionDialog::~DraftSelectionDialog() {}
+
+QString DraftSelectionDialog::getSelectedDraftContent() const { return m_selectedContent; }
+
+bool DraftSelectionDialog::didSelectDraft() const { return m_draftSelected; }
+
+void DraftSelectionDialog::refreshDraftsList() {
+    m_draftsList->clear();
+    for (const auto& d : m_drafts) {
+        QString displayTime = d.timestamp.toString("yyyy-MM-dd HH:mm:ss");
+        QString title = d.title.isEmpty() ? tr("Untitled Draft") : d.title;
+        m_draftsList->addItem(QString("%1\n%2").arg(title, displayTime));
+    }
+    if (m_draftsList->count() > 0) {
+        m_draftsList->setCurrentRow(0);
+    }
+}
+
+void DraftSelectionDialog::onSelectionChanged() {
+    onPreview();
+}
+
+void DraftSelectionDialog::onUseThis() {
+    int idx = m_draftsList->currentRow();
+    if (idx >= 0 && idx < m_drafts.size()) {
+        m_selectedContent = m_drafts[idx].content;
+        m_draftSelected = true;
+        accept();
+    }
+}
+
+void DraftSelectionDialog::onDeleteView() {
+    int idx = m_draftsList->currentRow();
+    if (idx >= 0 && idx < m_drafts.size()) {
+        int draftId = m_drafts[idx].id;
+        if (m_db && m_db->isOpen()) {
+            m_db->deleteDraft(draftId);
+            m_drafts.removeAt(idx);
+            refreshDraftsList();
+        }
+    }
+}
+
+void DraftSelectionDialog::onPreview() {
+    int idx = m_draftsList->currentRow();
+    if (idx >= 0 && idx < m_drafts.size()) {
+        // Just show markdown in preview browser
+        m_previewBrowser->setMarkdown(m_drafts[idx].content);
+
+        // Remove 3-way view widgets if they exist
+        while (m_mainSplitter->count() > 2) {
+            QWidget* w = m_mainSplitter->widget(2);
+            if (w) {
+                w->hide();
+                w->deleteLater();
+            }
+        }
+        m_previewBrowser->show();
+    } else {
+        m_previewBrowser->clear();
+    }
+}
+
+QString DraftSelectionDialog::getOriginalContent() const {
+    if (!m_db || !m_db->isOpen()) return "";
+    auto history = m_db->getDocumentHistory(m_documentId);
+    if (!history.isEmpty()) {
+        // Assume history is ordered by timestamp ASC, so the first is the oldest (original)
+        return history.first().content;
+    }
+    return "";
+}
+
+QString DraftSelectionDialog::getCurrentDocumentContent() const {
+    if (!m_db || !m_db->isOpen()) return "";
+
+    QList<DocumentNode> docs;
+    if (m_targetType == "template" || m_targetType == "templates") {
+        docs = m_db->getTemplates(-1);
+    } else if (m_targetType == "note" || m_targetType == "notes") {
+        auto notes = m_db->getNotes(-1);
+        for (const auto& n : notes) {
+            if (n.id == m_documentId) return n.content;
+        }
+        return "";
+    } else {
+        docs = m_db->getDocuments(-1);
+    }
+
+    for (const auto& d : docs) {
+        if (d.id == m_documentId) {
+            return d.content;
+        }
+    }
+    return "";
+}
+
+void DraftSelectionDialog::onShowDifferences() {
+    int idx = m_draftsList->currentRow();
+    if (idx < 0 || idx >= m_drafts.size()) return;
+
+    QString originalContent = getOriginalContent();
+    QString currentContent = getCurrentDocumentContent();
+    QString draftContent = m_drafts[idx].content;
+
+    // Hide the standard preview browser
+    m_previewBrowser->hide();
+
+    // Remove any existing 3-way view widgets
+    while (m_mainSplitter->count() > 2) {
+        QWidget* w = m_mainSplitter->widget(2);
+        if (w) {
+            w->hide();
+            w->deleteLater();
+        }
+    }
+
+    QWidget* threeWayWidget = new QWidget(m_mainSplitter);
+    QHBoxLayout* threeWayLayout = new QHBoxLayout(threeWayWidget);
+    threeWayLayout->setContentsMargins(0, 0, 0, 0);
+
+    QSplitter* innerSplitter = new QSplitter(Qt::Horizontal, threeWayWidget);
+
+    QWidget* col1 = new QWidget(innerSplitter);
+    QVBoxLayout* lay1 = new QVBoxLayout(col1);
+    lay1->setContentsMargins(0,0,0,0);
+    lay1->addWidget(new QLabel(tr("Original (Forked From)")));
+    QTextEdit* text1 = new QTextEdit(col1);
+    text1->setPlainText(originalContent);
+    text1->setReadOnly(true);
+    lay1->addWidget(text1);
+
+    QWidget* col2 = new QWidget(innerSplitter);
+    QVBoxLayout* lay2 = new QVBoxLayout(col2);
+    lay2->setContentsMargins(0,0,0,0);
+    lay2->addWidget(new QLabel(tr("Current Document")));
+    QTextEdit* text2 = new QTextEdit(col2);
+    text2->setPlainText(currentContent);
+    text2->setReadOnly(true);
+    lay2->addWidget(text2);
+
+    QWidget* col3 = new QWidget(innerSplitter);
+    QVBoxLayout* lay3 = new QVBoxLayout(col3);
+    lay3->setContentsMargins(0,0,0,0);
+    lay3->addWidget(new QLabel(tr("Selected Draft")));
+    QTextEdit* text3 = new QTextEdit(col3);
+    text3->setPlainText(draftContent);
+    text3->setReadOnly(true);
+    lay3->addWidget(text3);
+
+    innerSplitter->addWidget(col1);
+    innerSplitter->addWidget(col2);
+    innerSplitter->addWidget(col3);
+
+    threeWayLayout->addWidget(innerSplitter);
+    m_mainSplitter->addWidget(threeWayWidget);
+    threeWayWidget->show();
+}

--- a/src/DraftSelectionDialog.h
+++ b/src/DraftSelectionDialog.h
@@ -1,0 +1,52 @@
+#ifndef DRAFTSELECTIONDIALOG_H
+#define DRAFTSELECTIONDIALOG_H
+
+#include <QDialog>
+#include <QList>
+#include <QString>
+#include <memory>
+
+#include "BookDatabase.h"
+
+class QListWidget;
+class QTextBrowser;
+class QTextEdit;
+class QSplitter;
+
+class DraftSelectionDialog : public QDialog {
+    Q_OBJECT
+   public:
+    explicit DraftSelectionDialog(std::shared_ptr<BookDatabase> db, int documentId, const QList<DocumentNode>& drafts,
+                                  const QString& targetType = "document", QWidget* parent = nullptr);
+    ~DraftSelectionDialog() override;
+
+    QString getSelectedDraftContent() const;
+    bool didSelectDraft() const;
+
+   private slots:
+    void onSelectionChanged();
+    void onUseThis();
+    void onDeleteView();
+    void onPreview();
+    void onShowDifferences();
+    void refreshDraftsList();
+
+   private:
+    std::shared_ptr<BookDatabase> m_db;
+    int m_documentId;
+    QList<DocumentNode> m_drafts;
+    QString m_targetType;
+
+    QListWidget* m_draftsList;
+    QTextBrowser* m_previewBrowser;
+    QSplitter* m_mainSplitter;
+
+    bool m_draftSelected;
+    QString m_selectedContent;
+
+    // Helper functions
+    QString getOriginalContent() const;
+    QString getCurrentDocumentContent() const;
+};
+
+#endif  // DRAFTSELECTIONDIALOG_H

--- a/src/DraftSelectionDialog.h
+++ b/src/DraftSelectionDialog.h
@@ -26,6 +26,7 @@ class DraftSelectionDialog : public QDialog {
    private slots:
     void onSelectionChanged();
     void onUseThis();
+    void onIgnoreDrafts();
     void onDeleteView();
     void onPreview();
     void onShowDifferences();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -5053,6 +5053,19 @@ void MainWindow::onEditDocument() {
                 initialContent = dialog.getSelectedDraftContent();
             } else if (res == QDialog::Rejected) {
                 return;
+            } else if (res == QDialog::Accepted + 10) {
+                // Navigate to original
+                QStandardItem* originalItem = findItemInTree(associatedDrafts.first().parentId, associatedDrafts.first().targetType);
+                if (originalItem) {
+                    openBooksTree->setCurrentIndex(originalItem->index());
+                    openBooksTree->selectionModel()->select(originalItem->index(),
+                                                            QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Current);
+                    openBooksTree->scrollTo(originalItem->index());
+                    onOpenBooksTreeDoubleClicked(originalItem->index());
+                } else {
+                    statusBar->showMessage(tr("Original document not found."), 3000);
+                }
+                return;
             }
         }
     }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1873,7 +1873,10 @@ void MainWindow::showItemContextMenu(QStandardItem* item, const QPoint& globalPo
         QAction* discardAction = nullptr;
         QAction* deleteAction = nullptr;
 
+        QAction* gotoOriginalAction = nullptr;
+
         if (type == "draft") {
+            gotoOriginalAction = menu.addAction(QIcon::fromTheme("go-jump"), "Goto Original");
             discardAction = dangerMenu->addAction(QIcon::fromTheme("edit-delete"), "Discard Draft");
         } else if (type == "document") {
             deleteAction = dangerMenu->addAction(QIcon::fromTheme("edit-delete"), "Delete Document");
@@ -1894,6 +1897,26 @@ void MainWindow::showItemContextMenu(QStandardItem* item, const QPoint& globalPo
             } else if (type == "note") {
                 mainContentStack->setCurrentWidget(noteContainer);
                 noteEditorView->setFocus();
+            }
+        } else if (gotoOriginalAction && selectedAction == gotoOriginalAction) {
+            int docId = item->data(Qt::UserRole).toInt();
+            if (currentDb) {
+                QList<DocumentNode> drafts = currentDb->getDrafts();
+                for (const auto& d : drafts) {
+                    if (d.id == docId) {
+                        QStandardItem* originalItem = findItemInTree(d.parentId, d.targetType);
+                        if (originalItem) {
+                            openBooksTree->setCurrentIndex(originalItem->index());
+                            openBooksTree->selectionModel()->select(originalItem->index(),
+                                                                    QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Current);
+                            openBooksTree->scrollTo(originalItem->index());
+                            onOpenBooksTreeDoubleClicked(originalItem->index());
+                        } else {
+                            statusBar->showMessage(tr("Original document not found."), 3000);
+                        }
+                        break;
+                    }
+                }
             }
         } else if (historyAction && selectedAction == historyAction) {
             onDocumentHistory();
@@ -5029,8 +5052,9 @@ void MainWindow::onEditDocument() {
         int res = dialog.exec();
         if (res == QDialog::Accepted && dialog.didSelectDraft()) {
             initialContent = dialog.getSelectedDraftContent();
+        } else if (res == QDialog::Rejected) {
+            return;
         }
-        // If Rejected, the user clicked "Ignore Drafts / Cancel", so we just proceed without initialContent
     }
 
     DocumentEditWindow* editWin = new DocumentEditWindow(currentDb, currentDocumentId, currentTitle, targetTypeStr);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -53,6 +53,7 @@
 #include "DocumentEditWindow.h"
 #include "DocumentHistoryDialog.h"
 #include "DocumentReviewDialog.h"
+#include "DraftSelectionDialog.h"
 #include "ModelSelectionDialog.h"
 #include "NewDocumentDialog.h"
 #include "NotificationDelegate.h"
@@ -2098,7 +2099,19 @@ void MainWindow::onBookSelected(const QModelIndex& index) {
 
     populateDocumentFolders(docsItem, 0, "documents", dbPtr.get());
     populateDocumentFolders(templatesItem, 0, "templates", dbPtr.get());
-    populateDocumentFolders(draftsItem, 0, "drafts", dbPtr.get());
+
+    // Populate Drafts Folders recursively by type
+    QStringList types = {"documents", "templates", "notes"};
+    for (const QString& tType : types) {
+        QString fName = tType;
+        fName = fName.left(1).toUpper() + fName.mid(1);
+        QStandardItem* tItem = new QStandardItem(QIcon::fromTheme("folder-open"), fName);
+        tItem->setData("drafts_folder", Qt::UserRole + 1);
+        tItem->setData(0, Qt::UserRole);
+        populateDraftsFolders(tItem, 0, tType, dbPtr.get());
+        draftsItem->appendRow(tItem);
+    }
+
     populateDocumentFolders(notesItem, 0, "notes", dbPtr.get());
 
     bookItem->appendRow(chatsItem);
@@ -2116,6 +2129,36 @@ void MainWindow::onBookSelected(const QModelIndex& index) {
     loadSession(0);  // For now, load all as one session
 
     openBooksTree->setCurrentIndex(bookItem->index());
+}
+
+void MainWindow::populateDraftsFolders(QStandardItem* parentItem, int folderId, const QString& underlyingType,
+                                       BookDatabase* db) {
+    if (!db) return;
+
+    // First, add subfolders of the underlying type
+    QList<FolderNode> folders = db->getFolders(underlyingType);
+    for (const auto& folder : folders) {
+        if (folder.parentId == folderId) {
+            QStandardItem* item = new QStandardItem(QIcon::fromTheme("folder-open"), folder.name);
+            item->setData(folder.id, Qt::UserRole);
+            item->setData("drafts_folder", Qt::UserRole + 1);
+
+            parentItem->appendRow(item);
+            populateDraftsFolders(item, folder.id, underlyingType, db);
+        }
+    }
+
+    // Now, add any drafts whose parentId corresponds to an item in this folder.
+    QList<DocumentNode> allDrafts = db->getDrafts(folderId);
+    for (const auto& doc : allDrafts) {
+        // DocumentNode targetType now works
+        if (doc.targetType == underlyingType || doc.targetType == underlyingType.left(underlyingType.length() - 1)) {
+            QStandardItem* docItem = new QStandardItem(QIcon::fromTheme("text-plain"), doc.title);
+            docItem->setData(doc.id, Qt::UserRole);
+            docItem->setData("draft", Qt::UserRole + 1);
+            parentItem->appendRow(docItem);
+        }
+    }
 }
 
 void MainWindow::populateDocumentFolders(QStandardItem* parentItem, int folderId, const QString& type,
@@ -4967,7 +5010,33 @@ void MainWindow::onEditDocument() {
         }
     }
 
-    DocumentEditWindow* editWin = new DocumentEditWindow(currentDb, currentDocumentId, currentTitle, type);
+    QString initialContent = "";
+    QString targetTypeStr = "document";
+    if (item && item->data(Qt::UserRole + 1).toString().startsWith("template")) targetTypeStr = "template";
+    else if (item && item->data(Qt::UserRole + 1).toString().startsWith("note")) targetTypeStr = "note";
+
+    // Check for associated drafts
+    QList<DocumentNode> allDrafts = currentDb->getDrafts();
+    QList<DocumentNode> associatedDrafts;
+    for (const auto& d : allDrafts) {
+        if (d.parentId == currentDocumentId) {
+            associatedDrafts.append(d);
+        }
+    }
+
+    if (!associatedDrafts.isEmpty()) {
+        DraftSelectionDialog dialog(currentDb, currentDocumentId, associatedDrafts, targetTypeStr, this);
+        int res = dialog.exec();
+        if (res == QDialog::Accepted && dialog.didSelectDraft()) {
+            initialContent = dialog.getSelectedDraftContent();
+        }
+        // If Rejected, the user clicked "Ignore Drafts / Cancel", so we just proceed without initialContent
+    }
+
+    DocumentEditWindow* editWin = new DocumentEditWindow(currentDb, currentDocumentId, currentTitle, targetTypeStr);
+    if (!initialContent.isEmpty()) {
+        editWin->setInitialContent(initialContent);
+    }
     m_openDocEditors.insert(editorKey, editWin);
 
     connect(editWin, &DocumentEditWindow::documentModified, this, [this, type](int docId) {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -5034,26 +5034,26 @@ void MainWindow::onEditDocument() {
     }
 
     QString initialContent = "";
-    QString targetTypeStr = "document";
-    if (item && item->data(Qt::UserRole + 1).toString().startsWith("template")) targetTypeStr = "template";
-    else if (item && item->data(Qt::UserRole + 1).toString().startsWith("note")) targetTypeStr = "note";
+    QString targetTypeStr = type;
 
-    // Check for associated drafts
-    QList<DocumentNode> allDrafts = currentDb->getDrafts();
-    QList<DocumentNode> associatedDrafts;
-    for (const auto& d : allDrafts) {
-        if (d.parentId == currentDocumentId) {
-            associatedDrafts.append(d);
+    // Check for associated drafts only if we are NOT currently editing a draft
+    if (targetTypeStr != "draft") {
+        QList<DocumentNode> allDrafts = currentDb->getDrafts();
+        QList<DocumentNode> associatedDrafts;
+        for (const auto& d : allDrafts) {
+            if (d.parentId == currentDocumentId) {
+                associatedDrafts.append(d);
+            }
         }
-    }
 
-    if (!associatedDrafts.isEmpty()) {
-        DraftSelectionDialog dialog(currentDb, currentDocumentId, associatedDrafts, targetTypeStr, this);
-        int res = dialog.exec();
-        if (res == QDialog::Accepted && dialog.didSelectDraft()) {
-            initialContent = dialog.getSelectedDraftContent();
-        } else if (res == QDialog::Rejected) {
-            return;
+        if (!associatedDrafts.isEmpty()) {
+            DraftSelectionDialog dialog(currentDb, currentDocumentId, associatedDrafts, targetTypeStr, this);
+            int res = dialog.exec();
+            if (res == QDialog::Accepted && dialog.didSelectDraft()) {
+                initialContent = dialog.getSelectedDraftContent();
+            } else if (res == QDialog::Rejected) {
+                return;
+            }
         }
     }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -5079,11 +5079,24 @@ void MainWindow::onEditDocument() {
     });
 
     connect(editWin, &DocumentEditWindow::jumpToDocumentRequested, this, [this, type](int docId) {
+        // Find by type but try finding the original target type if it fails
         QStandardItem* item = findItemInTree(docId, type);
+        if (!item && type == "draft" && currentDb) {
+            QList<DocumentNode> drafts = currentDb->getDrafts();
+            for (const auto& d : drafts) {
+                if (d.id == currentDocumentId) {
+                    item = findItemInTree(d.parentId, d.targetType);
+                    break;
+                }
+            }
+        }
+
         if (item) {
+            openBooksTree->setCurrentIndex(item->index());
             openBooksTree->selectionModel()->select(item->index(),
                                                     QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Current);
             openBooksTree->scrollTo(item->index());
+            onOpenBooksTreeDoubleClicked(item->index());
         }
         this->raise();
         this->activateWindow();

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -142,6 +142,7 @@ class MainWindow : public KXmlGuiWindow {
                              BookDatabase* db);
     void populateMessageForks(QStandardItem* parentItem, int parentId, const QList<MessageNode>& allMessages);
     void populateDocumentFolders(QStandardItem* parentItem, int folderId, const QString& type, BookDatabase* db);
+    void populateDraftsFolders(QStandardItem* parentItem, int folderId, const QString& underlyingType, BookDatabase* db);
     void addPhantomItem(QStandardItem* folderItem, const QString& type);
     void updateLinearChatView(int tailNodeId, const QList<MessageNode>& allMessages);
     void getPathToRoot(int nodeId, const QList<MessageNode>& allMessages, QList<MessageNode>& path);


### PR DESCRIPTION
This commit resolves the issue where editing a document with associated drafts should show a selection dialog to let the user use the draft, preview it, delete it, or perform a 3-way diff (forked from, current document, selected draft).

The `target_type` and `parent_id` fields were added to the `drafts` table via an SQLite schema migration to properly associate drafts with their source entity. `DraftSelectionDialog` was added and integrated into the `onEditDocument` flow.

---
*PR created automatically by Jules for task [13706218843097468121](https://jules.google.com/task/13706218843097468121) started by @arran4*