### PR TITLE
feat: implement layered document templates with empty document default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,10 @@ add_executable(kllamabooks
     src/AIOperationsManager.h
     src/AIOperationsEditorWidget.cpp
     src/AIOperationsEditorWidget.h
+    src/DocumentTemplatesManager.cpp
+    src/DocumentTemplatesManager.h
+    src/DocumentTemplatesEditorWidget.cpp
+    src/DocumentTemplatesEditorWidget.h
     src/DocumentEditWindow.cpp
     src/DocumentEditWindow.h
     src/DocumentReviewDialog.cpp

--- a/src/DocumentEditWindow.cpp
+++ b/src/DocumentEditWindow.cpp
@@ -57,6 +57,9 @@ void DocumentEditWindow::setupWindow() {
     QAction* renameAction = new QAction(QIcon::fromTheme("edit-rename"), tr("Rename"), this);
     connect(renameAction, &QAction::triggered, this, &DocumentEditWindow::onRenameClicked);
 
+    QAction* saveAsTemplateAction = new QAction(QIcon::fromTheme("document-save-as"), tr("Save as Template"), this);
+    connect(saveAsTemplateAction, &QAction::triggered, this, &DocumentEditWindow::onSaveAsTemplateClicked);
+
     QAction* jumpAction = new QAction(QIcon::fromTheme("go-jump"), tr("Jump to Document"), this);
     connect(jumpAction, &QAction::triggered, this, &DocumentEditWindow::onJumpClicked);
 
@@ -67,6 +70,7 @@ void DocumentEditWindow::setupWindow() {
     mainToolBar->addAction(saveAction);
     mainToolBar->addAction(saveAsAction);
     mainToolBar->addAction(saveAsDraftAction);
+    mainToolBar->addAction(saveAsTemplateAction);
     mainToolBar->addAction(renameAction);
     mainToolBar->addAction(jumpAction);
     mainToolBar->addAction(closeAction);
@@ -76,6 +80,7 @@ void DocumentEditWindow::setupWindow() {
     fileMenu->addAction(saveAction);
     fileMenu->addAction(saveAsAction);
     fileMenu->addAction(saveAsDraftAction);
+    fileMenu->addAction(saveAsTemplateAction);
     fileMenu->addSeparator();
     fileMenu->addAction(renameAction);
     fileMenu->addAction(jumpAction);
@@ -191,6 +196,21 @@ void DocumentEditWindow::onSaveAsClicked() {
             m_statusLabel->setText(tr("Saved as new document"));
             updateStatusBar();
             emit newDocumentCreated(m_documentId);
+        }
+    }
+}
+
+void DocumentEditWindow::onSaveAsTemplateClicked() {
+    bool ok;
+    QString newTitle = QInputDialog::getText(this, tr("Save As Template"), tr("Template Title:"), QLineEdit::Normal,
+                                             m_title + " (Template)", &ok);
+    if (ok && !newTitle.isEmpty()) {
+        if (m_db && m_db->isOpen()) {
+            int newId = m_db->addTemplate(0, newTitle, m_editor->toPlainText());
+            if (newId > 0) {
+                m_statusLabel->setText(tr("Saved to templates"));
+                emit newDocumentCreated(newId);
+            }
         }
     }
 }

--- a/src/DocumentEditWindow.h
+++ b/src/DocumentEditWindow.h
@@ -31,6 +31,7 @@ class DocumentEditWindow : public KXmlGuiWindow {
     void onJumpClicked();
     void onSaveAsClicked();
     void onSaveAsDraftClicked();
+    void onSaveAsTemplateClicked();
     void onRenameClicked();
     void onContentChanged();
 

--- a/src/DocumentTemplatesEditorWidget.cpp
+++ b/src/DocumentTemplatesEditorWidget.cpp
@@ -104,7 +104,12 @@ void DocumentTemplatesEditorWidget::setTemplates(const QList<DocumentTemplate>& 
         QTableWidgetItem* nameItem = new QTableWidgetItem(tpl.name);
         nameItem->setData(Qt::UserRole, tpl.id);
         m_table->setItem(row, 0, nameItem);
-        m_table->setItem(row, 1, new QTableWidgetItem(tpl.content.split('\n').first() + "..."));
+
+        QString preview = tpl.content.section('\n', 0, 0);
+        if (tpl.content.contains('\n') || tpl.content.length() > preview.length()) {
+            preview += "...";
+        }
+        m_table->setItem(row, 1, new QTableWidgetItem(preview));
         m_table->setItem(row, 2, new QTableWidgetItem(m_level));
 
         // Store full content in hidden data
@@ -119,7 +124,11 @@ void DocumentTemplatesEditorWidget::setTemplates(const QList<DocumentTemplate>& 
         nameItem->setForeground(QBrush(Qt::gray));
         m_table->setItem(row, 0, nameItem);
 
-        QTableWidgetItem* contentItem = new QTableWidgetItem(tpl.content.split('\n').first() + "...");
+        QString preview = tpl.content.section('\n', 0, 0);
+        if (tpl.content.contains('\n') || tpl.content.length() > preview.length()) {
+            preview += "...";
+        }
+        QTableWidgetItem* contentItem = new QTableWidgetItem(preview);
         contentItem->setForeground(QBrush(Qt::gray));
         m_table->setItem(row, 1, contentItem);
 
@@ -152,7 +161,12 @@ void DocumentTemplatesEditorWidget::onAdd() {
         nameItem->setData(Qt::UserRole, tpl.id);
         nameItem->setData(Qt::UserRole + 1, tpl.content);
         m_table->setItem(row, 0, nameItem);
-        m_table->setItem(row, 1, new QTableWidgetItem(tpl.content.split('\n').first() + "..."));
+
+        QString preview = tpl.content.section('\n', 0, 0);
+        if (tpl.content.contains('\n') || tpl.content.length() > preview.length()) {
+            preview += "...";
+        }
+        m_table->setItem(row, 1, new QTableWidgetItem(preview));
         m_table->setItem(row, 2, new QTableWidgetItem(m_level));
     }
 }
@@ -172,7 +186,12 @@ void DocumentTemplatesEditorWidget::onEdit() {
         DocumentTemplate newTpl = dlg.getTemplate();
         m_table->item(row, 0)->setText(newTpl.name);
         m_table->item(row, 0)->setData(Qt::UserRole + 1, newTpl.content);
-        m_table->item(row, 1)->setText(newTpl.content.split('\n').first() + "...");
+
+        QString preview = newTpl.content.section('\n', 0, 0);
+        if (newTpl.content.contains('\n') || newTpl.content.length() > preview.length()) {
+            preview += "...";
+        }
+        m_table->item(row, 1)->setText(preview);
     }
 }
 

--- a/src/DocumentTemplatesEditorWidget.cpp
+++ b/src/DocumentTemplatesEditorWidget.cpp
@@ -1,0 +1,191 @@
+#include "DocumentTemplatesEditorWidget.h"
+
+#include <QDialog>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QTextEdit>
+#include <QUuid>
+#include <QVBoxLayout>
+
+class EditDocumentTemplateDialog : public QDialog {
+   public:
+    EditDocumentTemplateDialog(const DocumentTemplate& tpl, QWidget* parent = nullptr) : QDialog(parent) {
+        setWindowTitle(tpl.id.isEmpty() ? tr("Add Document Template") : tr("Edit Document Template"));
+        resize(500, 400);
+
+        QVBoxLayout* layout = new QVBoxLayout(this);
+        QFormLayout* form = new QFormLayout();
+
+        m_idEdit = new QLineEdit(this);
+        m_idEdit->setText(tpl.id);
+        if (tpl.id.isEmpty()) {
+            m_idEdit->setText("global:" + QUuid::createUuid().toString(QUuid::WithoutBraces));
+        }
+        m_idEdit->setReadOnly(true);
+        form->addRow(tr("ID:"), m_idEdit);
+
+        m_nameEdit = new QLineEdit(this);
+        m_nameEdit->setText(tpl.name);
+        form->addRow(tr("Name:"), m_nameEdit);
+
+        m_contentEdit = new QTextEdit(this);
+        m_contentEdit->setPlainText(tpl.content);
+        form->addRow(tr("Content:"), m_contentEdit);
+
+        layout->addLayout(form);
+
+        QHBoxLayout* btnLayout = new QHBoxLayout();
+        QPushButton* cancelBtn = new QPushButton(tr("Cancel"), this);
+        QPushButton* saveBtn = new QPushButton(tr("Save"), this);
+        btnLayout->addStretch();
+        btnLayout->addWidget(cancelBtn);
+        btnLayout->addWidget(saveBtn);
+
+        layout->addLayout(btnLayout);
+
+        connect(cancelBtn, &QPushButton::clicked, this, &QDialog::reject);
+        connect(saveBtn, &QPushButton::clicked, this, &QDialog::accept);
+    }
+
+    DocumentTemplate getTemplate() const { return {m_idEdit->text(), m_nameEdit->text(), m_contentEdit->toPlainText(), ""}; }
+
+   private:
+    QLineEdit* m_idEdit;
+    QLineEdit* m_nameEdit;
+    QTextEdit* m_contentEdit;
+};
+
+DocumentTemplatesEditorWidget::DocumentTemplatesEditorWidget(const QString& level, QWidget* parent)
+    : QWidget(parent), m_level(level) {
+    QVBoxLayout* layout = new QVBoxLayout(this);
+
+    m_table = new QTableWidget(this);
+    m_table->setColumnCount(3);
+    m_table->setHorizontalHeaderLabels({tr("Name"), tr("Content"), tr("Source")});
+    m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    m_table->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+    m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_table->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    layout->addWidget(m_table);
+
+    QHBoxLayout* btnLayout = new QHBoxLayout();
+    m_addBtn = new QPushButton(tr("Add"), this);
+    m_editBtn = new QPushButton(tr("Edit"), this);
+    m_removeBtn = new QPushButton(tr("Remove"), this);
+    m_editBtn->setEnabled(false);
+    m_removeBtn->setEnabled(false);
+
+    btnLayout->addWidget(m_addBtn);
+    btnLayout->addWidget(m_editBtn);
+    btnLayout->addWidget(m_removeBtn);
+    btnLayout->addStretch();
+    layout->addLayout(btnLayout);
+
+    connect(m_addBtn, &QPushButton::clicked, this, &DocumentTemplatesEditorWidget::onAdd);
+    connect(m_editBtn, &QPushButton::clicked, this, &DocumentTemplatesEditorWidget::onEdit);
+    connect(m_removeBtn, &QPushButton::clicked, this, &DocumentTemplatesEditorWidget::onRemove);
+    connect(m_table, &QTableWidget::itemSelectionChanged, this, &DocumentTemplatesEditorWidget::onSelectionChanged);
+}
+
+void DocumentTemplatesEditorWidget::setTemplates(const QList<DocumentTemplate>& editableTpls,
+                                             const QList<DocumentTemplate>& inheritedTpls) {
+    m_table->setRowCount(0);
+
+    for (const DocumentTemplate& tpl : editableTpls) {
+        int row = m_table->rowCount();
+        m_table->insertRow(row);
+        QTableWidgetItem* nameItem = new QTableWidgetItem(tpl.name);
+        nameItem->setData(Qt::UserRole, tpl.id);
+        m_table->setItem(row, 0, nameItem);
+        m_table->setItem(row, 1, new QTableWidgetItem(tpl.content.split('\n').first() + "..."));
+        m_table->setItem(row, 2, new QTableWidgetItem(m_level));
+
+        // Store full content in hidden data
+        nameItem->setData(Qt::UserRole + 1, tpl.content);
+    }
+
+    for (const DocumentTemplate& tpl : inheritedTpls) {
+        int row = m_table->rowCount();
+        m_table->insertRow(row);
+        QTableWidgetItem* nameItem = new QTableWidgetItem(tpl.name);
+        nameItem->setData(Qt::UserRole, tpl.id);
+        nameItem->setForeground(QBrush(Qt::gray));
+        m_table->setItem(row, 0, nameItem);
+
+        QTableWidgetItem* contentItem = new QTableWidgetItem(tpl.content.split('\n').first() + "...");
+        contentItem->setForeground(QBrush(Qt::gray));
+        m_table->setItem(row, 1, contentItem);
+
+        QTableWidgetItem* sourceItem = new QTableWidgetItem(tpl.source);
+        sourceItem->setForeground(QBrush(Qt::gray));
+        m_table->setItem(row, 2, sourceItem);
+
+        nameItem->setData(Qt::UserRole + 1, tpl.content);
+    }
+}
+
+QList<DocumentTemplate> DocumentTemplatesEditorWidget::getTemplates() const {
+    QList<DocumentTemplate> tpls;
+    for (int i = 0; i < m_table->rowCount(); ++i) {
+        if (m_table->item(i, 2)->text() == m_level) {
+            tpls.append({m_table->item(i, 0)->data(Qt::UserRole).toString(), m_table->item(i, 0)->text(),
+                        m_table->item(i, 0)->data(Qt::UserRole + 1).toString(), m_level});
+        }
+    }
+    return tpls;
+}
+
+void DocumentTemplatesEditorWidget::onAdd() {
+    EditDocumentTemplateDialog dlg(DocumentTemplate{"", "", "", m_level}, this);
+    if (dlg.exec() == QDialog::Accepted) {
+        DocumentTemplate tpl = dlg.getTemplate();
+        int row = 0;  // Add to top of editable list (before inherited ones)
+        m_table->insertRow(row);
+        QTableWidgetItem* nameItem = new QTableWidgetItem(tpl.name);
+        nameItem->setData(Qt::UserRole, tpl.id);
+        nameItem->setData(Qt::UserRole + 1, tpl.content);
+        m_table->setItem(row, 0, nameItem);
+        m_table->setItem(row, 1, new QTableWidgetItem(tpl.content.split('\n').first() + "..."));
+        m_table->setItem(row, 2, new QTableWidgetItem(m_level));
+    }
+}
+
+void DocumentTemplatesEditorWidget::onEdit() {
+    int row = m_table->currentRow();
+    if (row < 0 || m_table->item(row, 2)->text() != m_level) return;
+
+    DocumentTemplate tpl;
+    tpl.id = m_table->item(row, 0)->data(Qt::UserRole).toString();
+    tpl.name = m_table->item(row, 0)->text();
+    tpl.content = m_table->item(row, 0)->data(Qt::UserRole + 1).toString();
+    tpl.source = m_level;
+
+    EditDocumentTemplateDialog dlg(tpl, this);
+    if (dlg.exec() == QDialog::Accepted) {
+        DocumentTemplate newTpl = dlg.getTemplate();
+        m_table->item(row, 0)->setText(newTpl.name);
+        m_table->item(row, 0)->setData(Qt::UserRole + 1, newTpl.content);
+        m_table->item(row, 1)->setText(newTpl.content.split('\n').first() + "...");
+    }
+}
+
+void DocumentTemplatesEditorWidget::onRemove() {
+    int row = m_table->currentRow();
+    if (row >= 0 && m_table->item(row, 2)->text() == m_level) {
+        m_table->removeRow(row);
+    }
+}
+
+void DocumentTemplatesEditorWidget::onSelectionChanged() {
+    int row = m_table->currentRow();
+    bool isEditable = (row >= 0 && m_table->item(row, 2)->text() == m_level);
+    m_editBtn->setEnabled(isEditable);
+    m_removeBtn->setEnabled(isEditable);
+}

--- a/src/DocumentTemplatesEditorWidget.h
+++ b/src/DocumentTemplatesEditorWidget.h
@@ -1,0 +1,33 @@
+#ifndef DOCUMENTTEMPLATESEDITORWIDGET_H
+#define DOCUMENTTEMPLATESEDITORWIDGET_H
+
+#include <QPushButton>
+#include <QTableWidget>
+#include <QWidget>
+
+#include "DocumentTemplatesManager.h"
+
+class DocumentTemplatesEditorWidget : public QWidget {
+    Q_OBJECT
+   public:
+    explicit DocumentTemplatesEditorWidget(const QString& level, QWidget* parent = nullptr);
+    ~DocumentTemplatesEditorWidget() override = default;
+
+    void setTemplates(const QList<DocumentTemplate>& editableTpls, const QList<DocumentTemplate>& inheritedTpls);
+    QList<DocumentTemplate> getTemplates() const;
+
+   private slots:
+    void onAdd();
+    void onEdit();
+    void onRemove();
+    void onSelectionChanged();
+
+   private:
+    QString m_level;  // "global"
+    QTableWidget* m_table;
+    QPushButton* m_addBtn;
+    QPushButton* m_editBtn;
+    QPushButton* m_removeBtn;
+};
+
+#endif  // DOCUMENTTEMPLATESEDITORWIDGET_H

--- a/src/DocumentTemplatesManager.cpp
+++ b/src/DocumentTemplatesManager.cpp
@@ -1,0 +1,51 @@
+#include "DocumentTemplatesManager.h"
+#include <QCoreApplication>
+
+QList<DocumentTemplate> DocumentTemplatesManager::getBuiltInTemplates() {
+    QList<DocumentTemplate> templates;
+    templates.append({"builtin:empty", QCoreApplication::translate("DocumentTemplatesManager", "Empty Document"), "", "built-in"});
+    return templates;
+}
+
+QList<DocumentTemplate> DocumentTemplatesManager::getGlobalTemplates() {
+    QList<DocumentTemplate> templates;
+    QSettings settings;
+    QVariantList list = settings.value("globalDocumentTemplates").toList();
+    for (const QVariant& v : list) {
+        QVariantMap map = v.toMap();
+        templates.append({map["id"].toString(), map["name"].toString(), map["content"].toString(), "global"});
+    }
+    return templates;
+}
+
+void DocumentTemplatesManager::setGlobalTemplates(const QList<DocumentTemplate>& templates) {
+    QSettings settings;
+    QVariantList list;
+    for (const DocumentTemplate& tpl : templates) {
+        QVariantMap map;
+        map["id"] = tpl.id;
+        map["name"] = tpl.name;
+        map["content"] = tpl.content;
+        list.append(map);
+    }
+    settings.setValue("globalDocumentTemplates", list);
+}
+
+QList<DocumentTemplate> DocumentTemplatesManager::getDatabaseTemplates(BookDatabase* db) {
+    QList<DocumentTemplate> templates;
+    if (!db) return templates;
+    QList<DocumentNode> dbTpls = db->getTemplates(-1);
+    for (const DocumentNode& doc : dbTpls) {
+        templates.append({"db:" + QString::number(doc.id), doc.title, doc.content, "database"});
+    }
+    return templates;
+}
+
+QList<DocumentTemplate> DocumentTemplatesManager::getMergedTemplates(BookDatabase* db) {
+    QList<DocumentTemplate> templates = getBuiltInTemplates();
+    templates.append(getGlobalTemplates());
+    if (db) {
+        templates.append(getDatabaseTemplates(db));
+    }
+    return templates;
+}

--- a/src/DocumentTemplatesManager.h
+++ b/src/DocumentTemplatesManager.h
@@ -1,0 +1,28 @@
+#ifndef DOCUMENTTEMPLATESMANAGER_H
+#define DOCUMENTTEMPLATESMANAGER_H
+
+#include <QList>
+#include <QSettings>
+#include <QString>
+
+#include "BookDatabase.h"
+
+struct DocumentTemplate {
+    QString id;
+    QString name;
+    QString content;
+    QString source;  // "built-in", "global", "database"
+};
+
+class DocumentTemplatesManager {
+   public:
+    static QList<DocumentTemplate> getBuiltInTemplates();
+    static QList<DocumentTemplate> getGlobalTemplates();
+    static void setGlobalTemplates(const QList<DocumentTemplate>& templates);
+
+    static QList<DocumentTemplate> getDatabaseTemplates(BookDatabase* db);
+
+    static QList<DocumentTemplate> getMergedTemplates(BookDatabase* db);
+};
+
+#endif  // DOCUMENTTEMPLATESMANAGER_H

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -54,6 +54,7 @@
 #include "DocumentHistoryDialog.h"
 #include "DocumentReviewDialog.h"
 #include "ModelSelectionDialog.h"
+#include "DocumentTemplatesManager.h"
 #include "NewDocumentDialog.h"
 #include "NotificationDelegate.h"
 #include "QueueManager.h"
@@ -4856,11 +4857,7 @@ void MainWindow::handleNewDocumentCreation(int defaultFolderId) {
         int newDocId = -1;
         bool shouldNavigate = false;
 
-        if (dialog.getDocumentType() == NewDocumentDialog::Empty) {
-            newDocId = currentDb->addDocument(folderId, title, "");
-            shouldNavigate = true;
-            loadDocumentsAndNotes();
-        } else if (dialog.getDocumentType() == NewDocumentDialog::FromPrompt) {
+        if (dialog.getDocumentType() == NewDocumentDialog::FromPrompt) {
             QString prompt = dialog.getPrompt();
 
             QStringList models = m_selectedModels;
@@ -4883,10 +4880,10 @@ void MainWindow::handleNewDocumentCreation(int defaultFolderId) {
             }
             loadDocumentsAndNotes();
         } else if (dialog.getDocumentType() == NewDocumentDialog::FromTemplate) {
-            int tplId = dialog.getSelectedTemplateId();
+            QString tplId = dialog.getSelectedTemplateId();
             QString content = "";
-            if (tplId != -1) {
-                QList<DocumentNode> templates = currentDb->getTemplates(-1);
+            if (!tplId.isEmpty()) {
+                QList<DocumentTemplate> templates = DocumentTemplatesManager::getMergedTemplates(currentDb.get());
                 for (const auto& t : templates) {
                     if (t.id == tplId) {
                         content = t.content;

--- a/src/NewDocumentDialog.cpp
+++ b/src/NewDocumentDialog.cpp
@@ -11,6 +11,7 @@
 #include <QVBoxLayout>
 
 #include "BookDatabase.h"
+#include "DocumentTemplatesManager.h"
 
 NewDocumentDialog::NewDocumentDialog(std::shared_ptr<BookDatabase> db, int defaultFolderId, QWidget* parent)
     : QDialog(parent), m_db(db), m_defaultFolderId(defaultFolderId) {
@@ -22,9 +23,8 @@ NewDocumentDialog::NewDocumentDialog(std::shared_ptr<BookDatabase> db, int defau
     // Document Type
     mainLayout->addWidget(new QLabel(tr("Document Type:"), this));
     m_typeCombo = new QComboBox(this);
-    m_typeCombo->addItem(tr("Empty Document"), Empty);
+    m_typeCombo->addItem(tr("Standard Document"), FromTemplate);
     m_typeCombo->addItem(tr("From AI Prompt"), FromPrompt);
-    m_typeCombo->addItem(tr("From Template"), FromTemplate);
     m_typeCombo->addItem(tr("Resume a Draft"), ResumeDraft);
     mainLayout->addWidget(m_typeCombo);
 
@@ -43,7 +43,7 @@ NewDocumentDialog::NewDocumentDialog(std::shared_ptr<BookDatabase> db, int defau
     mainLayout->addWidget(m_promptWidget);
     m_promptWidget->hide();
 
-    // Template Widget (Hidden by default)
+    // Template Widget
     m_templateWidget = new QWidget(this);
     QVBoxLayout* templateLayout = new QVBoxLayout(m_templateWidget);
     templateLayout->setContentsMargins(0, 0, 0, 0);
@@ -51,7 +51,6 @@ NewDocumentDialog::NewDocumentDialog(std::shared_ptr<BookDatabase> db, int defau
     m_templateCombo = new QComboBox(m_templateWidget);
     templateLayout->addWidget(m_templateCombo);
     mainLayout->addWidget(m_templateWidget);
-    m_templateWidget->hide();
 
     // Draft Widget (Hidden by default)
     m_draftWidget = new QWidget(this);
@@ -122,13 +121,12 @@ void NewDocumentDialog::populateFolders(QTreeWidgetItem* parentItem, int parentI
 }
 
 void NewDocumentDialog::populateTemplates() {
-    if (!m_db) return;
-    QList<DocumentNode> templates = m_db->getTemplates(-1);  // Get all templates
+    QList<DocumentTemplate> templates = DocumentTemplatesManager::getMergedTemplates(m_db.get());
     for (const auto& tpl : templates) {
-        m_templateCombo->addItem(tpl.title, tpl.id);
+        m_templateCombo->addItem(tpl.name, tpl.id);
     }
     if (m_templateCombo->count() == 0) {
-        m_templateCombo->addItem(tr("No templates available"), -1);
+        m_templateCombo->addItem(tr("No templates available"), "");
         m_templateCombo->setEnabled(false);
     }
 }
@@ -170,23 +168,15 @@ void NewDocumentDialog::onTypeChanged(int index) {
     m_draftWidget->setVisible(type == ResumeDraft);
 
     if (type == FromPrompt) {
-        if (m_titleEdit->text() == tr("New Document") || m_titleEdit->text() == tr("Document from Template") ||
-            m_titleEdit->text() == tr("Document from Draft")) {
+        if (m_titleEdit->text() == tr("New Document") || m_titleEdit->text() == tr("Document from Draft")) {
             m_titleEdit->setText(tr("AI Generated Document"));
         }
-    } else if (type == Empty) {
-        if (m_titleEdit->text() == tr("AI Generated Document") || m_titleEdit->text() == tr("Document from Template") ||
-            m_titleEdit->text() == tr("Document from Draft")) {
+    } else if (type == FromTemplate) {
+        if (m_titleEdit->text() == tr("AI Generated Document") || m_titleEdit->text() == tr("Document from Draft")) {
             m_titleEdit->setText(tr("New Document"));
         }
-    } else if (type == FromTemplate) {
-        if (m_titleEdit->text() == tr("New Document") || m_titleEdit->text() == tr("AI Generated Document") ||
-            m_titleEdit->text() == tr("Document from Draft")) {
-            m_titleEdit->setText(tr("Document from Template"));
-        }
     } else if (type == ResumeDraft) {
-        if (m_titleEdit->text() == tr("New Document") || m_titleEdit->text() == tr("AI Generated Document") ||
-            m_titleEdit->text() == tr("Document from Template")) {
+        if (m_titleEdit->text() == tr("New Document") || m_titleEdit->text() == tr("AI Generated Document")) {
             m_titleEdit->setText(tr("Document from Draft"));
         }
     }
@@ -208,7 +198,7 @@ int NewDocumentDialog::getSelectedFolderId() const {
 
 QString NewDocumentDialog::getPrompt() const { return m_promptEdit->toPlainText(); }
 
-int NewDocumentDialog::getSelectedTemplateId() const { return m_templateCombo->currentData().toInt(); }
+QString NewDocumentDialog::getSelectedTemplateId() const { return m_templateCombo->currentData().toString(); }
 
 int NewDocumentDialog::getSelectedDraftId() const { return m_draftCombo->currentData().toInt(); }
 

--- a/src/NewDocumentDialog.h
+++ b/src/NewDocumentDialog.h
@@ -15,7 +15,7 @@ class BookDatabase;
 class NewDocumentDialog : public QDialog {
     Q_OBJECT
    public:
-    enum DocumentType { Empty, FromPrompt, FromTemplate, ResumeDraft };
+    enum DocumentType { FromTemplate, FromPrompt, ResumeDraft };
 
     explicit NewDocumentDialog(std::shared_ptr<BookDatabase> db, int defaultFolderId, QWidget* parent = nullptr);
 
@@ -23,7 +23,7 @@ class NewDocumentDialog : public QDialog {
     QString getTitle() const;
     int getSelectedFolderId() const;
     QString getPrompt() const;
-    int getSelectedTemplateId() const;
+    QString getSelectedTemplateId() const;
     int getSelectedDraftId() const;
     bool isOverwriteDocument() const;
     int getOverwriteDocumentId() const;

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -202,6 +202,12 @@ SettingsDialog::SettingsDialog(QWidget* parent) : QDialog(parent) {
                                         AIOperationsManager::getBuiltInOperations());
     tabWidget->addTab(m_aiOperationsEditor, tr("AI Operations"));
 
+    // Document Templates Tab
+    m_documentTemplatesEditor = new DocumentTemplatesEditorWidget("global", this);
+    m_documentTemplatesEditor->setTemplates(DocumentTemplatesManager::getGlobalTemplates(),
+                                            DocumentTemplatesManager::getBuiltInTemplates());
+    tabWidget->addTab(m_documentTemplatesEditor, tr("Document Templates"));
+
     mainLayout->addWidget(tabWidget);
 
     // Dialog buttons
@@ -372,6 +378,7 @@ void SettingsDialog::onApply() {
     m_settings.setValue("prioritizeSameModel", m_prioritizeSameModelCheck->isChecked());
 
     AIOperationsManager::setGlobalOperations(m_aiOperationsEditor->getOperations());
+    DocumentTemplatesManager::setGlobalTemplates(m_documentTemplatesEditor->getTemplates());
 
     emit settingsApplied();
     accept();

--- a/src/SettingsDialog.h
+++ b/src/SettingsDialog.h
@@ -19,6 +19,7 @@
 #include <QVariantMap>
 
 #include "AIOperationsEditorWidget.h"
+#include "DocumentTemplatesEditorWidget.h"
 
 class ConnectionDialog : public QDialog {
     Q_OBJECT
@@ -81,6 +82,7 @@ class SettingsDialog : public QDialog {
     QCheckBox* m_prioritizeSameModelCheck;
 
     AIOperationsEditorWidget* m_aiOperationsEditor;
+    DocumentTemplatesEditorWidget* m_documentTemplatesEditor;
 };
 
 #endif  // SETTINGSDIALOG_H


### PR DESCRIPTION
This PR implements a layered document template system, similar to the AI Operations approach. It removes the hard-coded "Empty Document" option and replaces it with a robust `DocumentTemplatesManager` that aggregates built-in templates (which now include "Empty Document"), user-configured global templates (saved to `QSettings`), and database-specific templates.

Key additions:
- `DocumentTemplatesManager`: Aggregates built-in, global, and database templates using `QString` identifiers.
- `DocumentTemplatesEditorWidget`: A settings UI widget allowing users to add, edit, or remove global templates.
- Updates `NewDocumentDialog` to parse and utilize these templates by default.
- Refactors `MainWindow::handleNewDocumentCreation` to process string-based template IDs seamlessly.

---
*PR created automatically by Jules for task [1204317834747893872](https://jules.google.com/task/1204317834747893872) started by @arran4*