### PR TITLE
Bypass review prompt for newly generated documents and emit finished generation notification

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -5154,7 +5154,7 @@ void MainWindow::handleNewDocumentCreation(int defaultFolderId) {
             } else {
                 QString model = models.isEmpty() ? "" : models.first();
                 newDocId = currentDb->addDocument(folderId, title, "*Generating...*");
-                currentDb->enqueuePrompt(newDocId, model, prompt, 0, "document", 0, "replace_direct");
+                if (newDocId != -1) currentDb->enqueuePrompt(newDocId, model, prompt, 0, "document", 0, "replace_direct");
                 shouldNavigate = true;
             }
             loadDocumentsAndNotes();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -5149,7 +5149,7 @@ void MainWindow::handleNewDocumentCreation(int defaultFolderId) {
                 for (const QString& model : models) {
                     QString docTitle = title + " (" + model + ")";
                     newDocId = currentDb->addDocument(newFolderId, docTitle, "*Generating...*");
-                    currentDb->enqueuePrompt(newDocId, model, prompt, 0, "document", 0, "replace_direct");
+                    if (newDocId != -1) currentDb->enqueuePrompt(newDocId, model, prompt, 0, "document", 0, "replace_direct");
                 }
             } else {
                 QString model = models.isEmpty() ? "" : models.first();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -4433,8 +4433,16 @@ void MainWindow::updateNotificationStatus() {
         total += notifications.size();
         for (const auto& n : notifications) {
             QString bookName = QFileInfo(db->filepath()).fileName();
-            QString typeStr =
-                (n.type == "error") ? tr("Error") : (n.type == "review_needed" ? tr("Review Needed") : tr("Finished"));
+            QString typeStr;
+            if (n.type == "error") {
+                typeStr = tr("Error");
+            } else if (n.type == "review_needed") {
+                typeStr = tr("Review Needed");
+            } else if (n.type == "finished_generation") {
+                typeStr = tr("Finished Generation");
+            } else {
+                typeStr = tr("Finished");
+            }
             QAction* action = notificationMenu->addAction(
                 QString("[%1] %2: Msg %3").arg(bookName, typeStr, QString::number(n.targetId)));
             connect(action, &QAction::triggered, this, [this, db, n, bookName]() {
@@ -4551,7 +4559,7 @@ void MainWindow::updateNotificationStatus() {
                     dialog.setWindowTitle(tr("Notification Summary"));
                     QVBoxLayout* layout = new QVBoxLayout(&dialog);
 
-                    QString typeStr = tr("Finished");
+                    QString typeStr = (n.type == "finished_generation") ? tr("Finished Generation") : tr("Finished");
                     QLabel* summary =
                         new QLabel(QString("<b>Book:</b> %1<br><b>Status:</b> %2<br><b>Target ID:</b> %3")
                                        .arg(bookName, typeStr, QString::number(n.targetId)));
@@ -5141,12 +5149,12 @@ void MainWindow::handleNewDocumentCreation(int defaultFolderId) {
                 for (const QString& model : models) {
                     QString docTitle = title + " (" + model + ")";
                     newDocId = currentDb->addDocument(newFolderId, docTitle, "*Generating...*");
-                    currentDb->enqueuePrompt(newDocId, model, prompt, 0, "document", 0, "replace");
+                    currentDb->enqueuePrompt(newDocId, model, prompt, 0, "document", 0, "replace_direct");
                 }
             } else {
                 QString model = models.isEmpty() ? "" : models.first();
                 newDocId = currentDb->addDocument(folderId, title, "*Generating...*");
-                currentDb->enqueuePrompt(newDocId, model, prompt, 0, "document", 0, "replace");
+                currentDb->enqueuePrompt(newDocId, model, prompt, 0, "document", 0, "replace_direct");
                 shouldNavigate = true;
             }
             loadDocumentsAndNotes();

--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -458,6 +458,7 @@ void QueueManager::processNext() {
                             }
                             act.db->updateDocument(act.item.messageId, title, response, metadata);
                             act.db->deleteQueueItem(act.item.id);
+                            act.db->addNotification(act.item.messageId, act.item.targetType, "finished_generation");
                         } else {
                             act.db->updateQueueItemState(act.item.id, "completed", response);
                             act.db->addNotification(act.item.messageId, act.item.targetType, "review_needed");


### PR DESCRIPTION
When a document is generated from a prompt, it enters an initial "Generating..." state. Previously, the prompt would complete and trigger a `review_needed` notification, prompting the user with the `DocumentReviewDialog` to append, replace, or fork. This PR changes this flow so that newly generated documents are enqueued with `target_action = replace_direct`, seamlessly applying the generated text once finished and issuing a `finished_generation` notification directly instead.

- Changed target action to `replace_direct` in `MainWindow::handleNewDocumentCreation`.
- Added logic in `QueueManager::processNext` to emit a `finished_generation` notification for `replace_direct` actions upon completion.
- Updated `MainWindow::updateNotificationStatus` to appropriately handle and render the `finished_generation` notification type.

---
*PR created automatically by Jules for task [8686560753299612235](https://jules.google.com/task/8686560753299612235) started by @arran4*