### PR TITLE
feat: Add Regenerate Merge feature

### DIFF
--- a/.jules/Dockerfile
+++ b/.jules/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:testing
+FROM docker.io/library/debian:testing
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \

--- a/src/BookDatabase.cpp
+++ b/src/BookDatabase.cpp
@@ -825,6 +825,34 @@ bool BookDatabase::updateDocument(int id, const QString& newTitle, const QString
     return rc == SQLITE_DONE;
 }
 
+std::optional<DocumentNode> BookDatabase::getDocument(int id) const {
+    if (!m_isOpen) return std::nullopt;
+
+    QString sqlStr = "SELECT id, folder_id, title, content, timestamp, parent_id FROM documents WHERE id = ?;";
+    sqlite3_stmt* stmt;
+    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sqlStr.toUtf8().constData(), -1, &stmt, nullptr);
+    if (rc != SQLITE_OK) return std::nullopt;
+
+    sqlite3_bind_int(stmt, 1, id);
+
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        DocumentNode node;
+        node.id = sqlite3_column_int(stmt, 0);
+        node.folderId = sqlite3_column_int(stmt, 1);
+        node.title = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
+        node.content = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
+        QString ts = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
+        node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
+        node.parentId = sqlite3_column_int(stmt, 5);
+        node.metadata = getSetting("document", node.id, "metadata");
+
+        sqlite3_finalize(stmt);
+        return node;
+    }
+    sqlite3_finalize(stmt);
+    return std::nullopt;
+}
+
 QList<DocumentNode> BookDatabase::getDocuments(int folderId) const {
     QList<DocumentNode> nodes;
     if (!m_isOpen) return nodes;
@@ -848,6 +876,7 @@ QList<DocumentNode> BookDatabase::getDocuments(int folderId) const {
         QString ts = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         node.parentId = sqlite3_column_int(stmt, 5);
+        node.metadata = getSetting("document", node.id, "metadata");
         node.isFolder = false;
         nodes.append(node);
     }

--- a/src/BookDatabase.cpp
+++ b/src/BookDatabase.cpp
@@ -1366,6 +1366,24 @@ bool BookDatabase::updateQueueItemState(int id, const QString& state, const QStr
     return rc == SQLITE_DONE;
 }
 
+bool BookDatabase::isGenerating(int targetId, const QString& targetType, const QString& targetAction) const {
+    if (!m_isOpen) return false;
+    const char* sql = "SELECT COUNT(*) FROM queue WHERE message_id = ? AND target_type = ? AND target_action = ? AND state IN ('pending', 'processing');";
+    sqlite3_stmt* stmt;
+    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+
+    sqlite3_bind_int(stmt, 1, targetId);
+    sqlite3_bind_text(stmt, 2, targetType.toUtf8().constData(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 3, targetAction.toUtf8().constData(), -1, SQLITE_TRANSIENT);
+
+    bool result = false;
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        result = sqlite3_column_int(stmt, 0) > 0;
+    }
+    sqlite3_finalize(stmt);
+    return result;
+}
+
 QList<QueueItem> BookDatabase::getQueue() const {
     QList<QueueItem> items;
     if (!m_isOpen) return items;

--- a/src/BookDatabase.cpp
+++ b/src/BookDatabase.cpp
@@ -508,6 +508,24 @@ bool BookDatabase::initSchema() {
         userVersion = 18;
     }
 
+    if (userVersion < 19) {
+        const char* sql_merges =
+            "CREATE TABLE IF NOT EXISTS document_merges ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "document_id INTEGER, "
+            "source_document_ids TEXT, "
+            "prompt TEXT, "
+            "model TEXT, "
+            "timestamp DATETIME DEFAULT CURRENT_TIMESTAMP, "
+            "version_history_id INTEGER DEFAULT 0"
+            ");";
+        sqlite3_exec((sqlite3*)m_db, sql_merges, nullptr, nullptr, nullptr);
+
+        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (19);", nullptr, nullptr, nullptr);
+        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 19;", nullptr, nullptr, nullptr);
+        userVersion = 19;
+    }
+
     return true;
 }
 
@@ -608,20 +626,82 @@ int BookDatabase::addMessage(int parentId, const QString& content, const QString
     return id;
 }
 
-bool BookDatabase::addDocumentHistory(int documentId, const QString& actionType, const QString& content) {
+int BookDatabase::addDocumentMerge(int documentId, const QString& sourceDocumentIds, const QString& prompt, const QString& model, int versionHistoryId) {
+    if (!m_isOpen) return -1;
+    const char* sql = "INSERT INTO document_merges (document_id, source_document_ids, prompt, model, version_history_id) VALUES (?, ?, ?, ?, ?);";
+    sqlite3_stmt* stmt;
+    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return -1;
+
+    sqlite3_bind_int(stmt, 1, documentId);
+    sqlite3_bind_text(stmt, 2, sourceDocumentIds.toUtf8().constData(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 3, prompt.toUtf8().constData(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 4, model.toUtf8().constData(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 5, versionHistoryId);
+
+    int rc = sqlite3_step(stmt);
+    int id = (rc == SQLITE_DONE) ? sqlite3_last_insert_rowid((sqlite3*)m_db) : -1;
+    sqlite3_finalize(stmt);
+    return id;
+}
+
+std::optional<BookDatabase::DocumentMergeEntry> BookDatabase::getDocumentMerge(int documentId) const {
+    if (!m_isOpen) return std::nullopt;
+
+    QString sqlStr = "SELECT id, document_id, source_document_ids, prompt, model, timestamp, version_history_id FROM document_merges WHERE document_id = ? ORDER BY timestamp DESC LIMIT 1;";
+    sqlite3_stmt* stmt;
+    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sqlStr.toUtf8().constData(), -1, &stmt, nullptr);
+    if (rc != SQLITE_OK) return std::nullopt;
+
+    sqlite3_bind_int(stmt, 1, documentId);
+
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        DocumentMergeEntry entry;
+        entry.id = sqlite3_column_int(stmt, 0);
+        entry.documentId = sqlite3_column_int(stmt, 1);
+        entry.sourceDocumentIds = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
+        entry.prompt = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
+        entry.model = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
+        entry.timestamp = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 5));
+        entry.versionHistoryId = sqlite3_column_int(stmt, 6);
+
+        sqlite3_finalize(stmt);
+        return entry;
+    }
+    sqlite3_finalize(stmt);
+    return std::nullopt;
+}
+
+bool BookDatabase::updateDocumentMergeVersion(int mergeId, int versionHistoryId) {
     if (!m_isOpen) return false;
+    const char* sql = "UPDATE document_merges SET version_history_id = ? WHERE id = ?;";
+    sqlite3_stmt* stmt;
+    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    sqlite3_bind_int(stmt, 1, versionHistoryId);
+    sqlite3_bind_int(stmt, 2, mergeId);
+    int rc = sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    return rc == SQLITE_DONE;
+}
+
+bool BookDatabase::addDocumentHistory(int documentId, const QString& actionType, const QString& content) {
+    return addDocumentHistoryReturningId(documentId, actionType, content) != -1;
+}
+
+int BookDatabase::addDocumentHistoryReturningId(int documentId, const QString& actionType, const QString& content) {
+    if (!m_isOpen) return -1;
 
     const char* sql = "INSERT INTO document_history (document_id, action_type, content) VALUES (?, ?, ?);";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return -1;
 
     sqlite3_bind_int(stmt, 1, documentId);
     sqlite3_bind_text(stmt, 2, actionType.toUtf8().constData(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 3, content.toUtf8().constData(), -1, SQLITE_TRANSIENT);
 
     int rc = sqlite3_step(stmt);
+    int id = (rc == SQLITE_DONE) ? sqlite3_last_insert_rowid((sqlite3*)m_db) : -1;
     sqlite3_finalize(stmt);
-    return rc == SQLITE_DONE;
+    return id;
 }
 
 QList<BookDatabase::DocumentHistoryEntry> BookDatabase::getDocumentHistory(int documentId) const {

--- a/src/BookDatabase.h
+++ b/src/BookDatabase.h
@@ -187,6 +187,7 @@ class BookDatabase {
     int enqueuePrompt(int messageId, const QString& model, const QString& prompt, int priority = 0,
                       const QString& targetType = "message", int parentId = 0, const QString& targetAction = "");
     QList<QueueItem> getQueue() const;
+    bool isGenerating(int targetId, const QString& targetType, const QString& targetAction) const;
     bool updateQueueProcessingId(int id, int processingId);
     bool updateQueueError(int id, const QString& error);
     bool updateQueueItemPrompt(int id, const QString& prompt);

--- a/src/BookDatabase.h
+++ b/src/BookDatabase.h
@@ -138,6 +138,21 @@ class BookDatabase {
         QString timestamp;
     };
     QList<DocumentHistoryEntry> getDocumentHistory(int documentId) const;
+    int addDocumentHistoryReturningId(int documentId, const QString& actionType, const QString& content);
+
+    // Merges
+    struct DocumentMergeEntry {
+        int id;
+        int documentId;
+        QString sourceDocumentIds; // comma separated or JSON array
+        QString prompt;
+        QString model;
+        QString timestamp;
+        int versionHistoryId;
+    };
+    int addDocumentMerge(int documentId, const QString& sourceDocumentIds, const QString& prompt, const QString& model, int versionHistoryId = 0);
+    std::optional<DocumentMergeEntry> getDocumentMerge(int documentId) const;
+    bool updateDocumentMergeVersion(int mergeId, int versionHistoryId);
 
     // Templates
     int addTemplate(int folderId, const QString& title, const QString& content);

--- a/src/BookDatabase.h
+++ b/src/BookDatabase.h
@@ -127,6 +127,7 @@ class BookDatabase {
     int addDocument(int folderId, const QString& title, const QString& content, int parentId = 0, const QString& metadata = "");
     bool updateDocument(int id, const QString& newTitle, const QString& newContent, const QString& metadata = "");
     QList<DocumentNode> getDocuments(int folderId = -1) const;  // -1 for all, 0 for root
+    std::optional<DocumentNode> getDocument(int id) const;
     bool deleteDocument(int id);
     bool addDocumentHistory(int documentId, const QString& actionType, const QString& content);
 

--- a/src/DocumentEditWindow.cpp
+++ b/src/DocumentEditWindow.cpp
@@ -19,6 +19,8 @@
 #include <QStatusBar>
 #include <QTextEdit>
 #include <QVBoxLayout>
+#include <KActionCollection>
+#include <KStandardAction>
 
 DocumentEditWindow::DocumentEditWindow(std::shared_ptr<BookDatabase> db, int documentId, const QString& title,
                                        const QString& targetType, QWidget* parent)

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -294,7 +294,7 @@ void MainWindow::setupUi() {
     QPushButton* docHistoryBtn = new QPushButton(QIcon::fromTheme("view-history"), "History", this);
     connect(docHistoryBtn, &QPushButton::clicked, this, &MainWindow::onDocumentHistory);
 
-    regenerateMergeBtn = new QPushButton(QIcon::fromTheme("view-refresh"), "Regenerate Merge", this);
+    regenerateMergeBtn = new QPushButton(QIcon::fromTheme("view-refresh"), tr("Regenerate Merge"), this);
     connect(regenerateMergeBtn, &QPushButton::clicked, this, &MainWindow::onRegenerateMerge);
     regenerateMergeBtn->hide();
 
@@ -4610,7 +4610,7 @@ void MainWindow::updateNotificationStatus() {
 
                     if (n.type == "finished_generation" && n.targetType == "document") {
                         if (db->getDocumentMerge(n.targetId).has_value()) {
-                            tryAgainBtn = new QPushButton(tr("Try Again"), &dialog);
+                            tryAgainBtn = new QPushButton(tr("Regenerate"), &dialog);
                         }
                     }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -63,6 +63,8 @@
 #include "QueueWindow.h"
 #include "WalletManager.h"
 
+static const QString GENERATING_MERGE_TEXT = QStringLiteral("*Generating merge...*");
+
 CustomItemModel::CustomItemModel(QObject* parent) : QStandardItemModel(parent), m_mainWindow(nullptr) {}
 
 /** * @brief Executes logic for mimeTypes. This function manages component initialization and handles state transitions
@@ -2168,11 +2170,11 @@ void MainWindow::onMergeDocumentsSelected() {
         if (selectedModels.size() > 1) {
             int newFolderId = currentDb->addFolder(targetFolderId, baseTitle + " (Models)", "docs_folder");
             for (const QString& model : selectedModels) {
-                int newDocId = currentDb->addDocument(newFolderId, model + " Generation", "*Generating merge...*", 0, metaStr);
+                int newDocId = currentDb->addDocument(newFolderId, model + " Generation", GENERATING_MERGE_TEXT, 0, metaStr);
                 currentDb->enqueuePrompt(newDocId, model, finalPrompt, 0, "document", 0, "replace_direct");
             }
         } else {
-            int newDocId = currentDb->addDocument(targetFolderId, baseTitle, "*Generating merge...*", 0, metaStr);
+            int newDocId = currentDb->addDocument(targetFolderId, baseTitle, GENERATING_MERGE_TEXT, 0, metaStr);
             currentDb->enqueuePrompt(newDocId, selectedModels.first(), finalPrompt, 0, "document", 0, "replace_direct");
         }
 
@@ -3352,7 +3354,7 @@ void MainWindow::onQueueChunk(std::shared_ptr<BookDatabase> db, int messageId, c
         if (targetType == "document" && currentDocumentId == messageId) {
             documentEditorView->blockSignals(true);
             QString text = documentEditorView->toPlainText();
-            if (text == "*Generating merge...*") {
+            if (text == GENERATING_MERGE_TEXT) {
                 documentEditorView->setPlainText("");
             }
             QTextCursor cursor = documentEditorView->textCursor();
@@ -4020,18 +4022,7 @@ void MainWindow::onOpenBooksSelectionChanged(const QItemSelection& selected, con
                         documentEditorView->setPlainText(doc.content);
                         mainContentStack->setCurrentWidget(docContainer);
 
-                        // Check if it's a merge document to show regenerate button
-                        if (type == "document") {
-                            QJsonDocument docMeta = QJsonDocument::fromJson(doc.metadata.toUtf8());
-                            if (!docMeta.isNull() && docMeta.isObject()) {
-                                QJsonObject obj = docMeta.object();
-                                if (obj.value("type").toString() == "merge") {
-                                    if (!doc.content.contains("*Generating merge...*")) {
-                                        regenerateMergeBtn->show();
-                                    }
-                                }
-                            }
-                        }
+                        updateRegenerateButtonVisibility(doc, type);
 
                         break;
                     }
@@ -5122,11 +5113,11 @@ void MainWindow::onRegenerateMerge() {
     currentDb->addDocumentHistory(currentDocumentId, "replace_pre", doc.content);
 
     // Set generating text
-    currentDb->updateDocument(currentDocumentId, doc.title, "*Generating merge...*", doc.metadata);
+    currentDb->updateDocument(currentDocumentId, doc.title, GENERATING_MERGE_TEXT, doc.metadata);
 
     if (documentEditorView && mainContentStack->currentWidget() == docContainer) {
         documentEditorView->blockSignals(true);
-        documentEditorView->setPlainText("*Generating merge...*");
+        documentEditorView->setPlainText(GENERATING_MERGE_TEXT);
         documentEditorView->blockSignals(false);
     }
 
@@ -5181,17 +5172,7 @@ void MainWindow::onOpenBooksTreeDoubleClicked(const QModelIndex& index) {
                 documentEditorView->setPlainText(doc.content);
                 mainContentStack->setCurrentWidget(docContainer);
 
-                if (type == "document") {
-                    QJsonDocument docMeta = QJsonDocument::fromJson(doc.metadata.toUtf8());
-                    if (!docMeta.isNull() && docMeta.isObject()) {
-                        QJsonObject obj = docMeta.object();
-                        if (obj.value("type").toString() == "merge") {
-                            if (!doc.content.contains("*Generating merge...*")) {
-                                regenerateMergeBtn->show();
-                            }
-                        }
-                    }
-                }
+                updateRegenerateButtonVisibility(doc, type);
                 break;
             }
         }
@@ -5349,6 +5330,20 @@ void MainWindow::handleNewDocumentCreation(int defaultFolderId) {
 
                 if (dialog.getDocumentType() == NewDocumentDialog::ResumeDraft) {
                     onEditDocument();
+                }
+            }
+        }
+    }
+}
+
+void MainWindow::updateRegenerateButtonVisibility(const DocumentNode& doc, const QString& type) {
+    if (type == "document") {
+        QJsonDocument docMeta = QJsonDocument::fromJson(doc.metadata.toUtf8());
+        if (!docMeta.isNull() && docMeta.isObject()) {
+            QJsonObject obj = docMeta.object();
+            if (obj.value("type").toString() == "merge") {
+                if (!doc.content.contains(GENERATING_MERGE_TEXT)) {
+                    regenerateMergeBtn->show();
                 }
             }
         }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -5358,15 +5358,7 @@ void MainWindow::updateRegenerateButtonVisibility(const DocumentNode& doc, const
     viewMergeSourcesBtn->show();
 
     // Check if the document is currently regenerating
-    bool isGenerating = false;
-    for (const auto& qi : currentDb->getQueue()) {
-        if (qi.messageId == doc.id && qi.targetType == "document" &&
-            qi.targetAction == "replace_direct" &&
-            (qi.state == "pending" || qi.state == "processing")) {
-            isGenerating = true;
-            break;
-        }
-    }
+    bool isGenerating = currentDb->isGenerating(doc.id, "document", "replace_direct");
 
     if (!isGenerating && !doc.content.contains(GENERATING_MERGE_TEXT)) {
         regenerateMergeBtn->show();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -292,11 +292,16 @@ void MainWindow::setupUi() {
     QPushButton* docHistoryBtn = new QPushButton(QIcon::fromTheme("view-history"), "History", this);
     connect(docHistoryBtn, &QPushButton::clicked, this, &MainWindow::onDocumentHistory);
 
+    regenerateMergeBtn = new QPushButton(QIcon::fromTheme("view-refresh"), "Regenerate Merge", this);
+    connect(regenerateMergeBtn, &QPushButton::clicked, this, &MainWindow::onRegenerateMerge);
+    regenerateMergeBtn->hide();
+
     docToolbar->addWidget(backToDocsBtn);
     docToolbar->addWidget(editDocBtn);
     docToolbar->addWidget(previewDocBtn);
     docToolbar->addWidget(docHistoryBtn);
     docToolbar->addWidget(aiOperationsBtn);
+    docToolbar->addWidget(regenerateMergeBtn);
     docLayout->addWidget(docToolbar);
 
     documentStack = new QStackedWidget(this);
@@ -3998,6 +4003,7 @@ void MainWindow::onOpenBooksSelectionChanged(const QItemSelection& selected, con
         if (type == "document" || type == "template" || type == "draft") {
             currentDocumentId = nodeId;
             isCreatingNewDoc = (nodeId == 0);
+            regenerateMergeBtn->hide();
             if (isCreatingNewDoc) {
                 documentEditorView->clear();
                 mainContentStack->setCurrentWidget(docContainer);
@@ -4013,6 +4019,20 @@ void MainWindow::onOpenBooksSelectionChanged(const QItemSelection& selected, con
                     if (doc.id == currentDocumentId) {
                         documentEditorView->setPlainText(doc.content);
                         mainContentStack->setCurrentWidget(docContainer);
+
+                        // Check if it's a merge document to show regenerate button
+                        if (type == "document") {
+                            QJsonDocument docMeta = QJsonDocument::fromJson(doc.metadata.toUtf8());
+                            if (!docMeta.isNull() && docMeta.isObject()) {
+                                QJsonObject obj = docMeta.object();
+                                if (obj.value("type").toString() == "merge") {
+                                    if (!doc.content.contains("*Generating merge...*")) {
+                                        regenerateMergeBtn->show();
+                                    }
+                                }
+                            }
+                        }
+
                         break;
                     }
                 }
@@ -4567,9 +4587,47 @@ void MainWindow::updateNotificationStatus() {
                     layout->addWidget(summary);
 
                     QHBoxLayout* btnLayout = new QHBoxLayout();
+                    QPushButton* tryAgainBtn = nullptr;
+
+                    if (n.type == "finished_generation" && n.targetType == "document") {
+                        auto docs = db->getDocuments();
+                        DocumentNode docNode;
+                        docNode.id = -1;
+                        for (const auto& d : docs) {
+                            if (d.id == n.targetId) {
+                                docNode = d;
+                                break;
+                            }
+                        }
+                        if (docNode.id != -1) {
+                            QJsonDocument docMeta = QJsonDocument::fromJson(docNode.metadata.toUtf8());
+                            if (!docMeta.isNull() && docMeta.isObject()) {
+                                QJsonObject obj = docMeta.object();
+                                if (obj.value("type").toString() == "merge") {
+                                    tryAgainBtn = new QPushButton(tr("Try Again"), &dialog);
+                                }
+                            }
+                        }
+                    }
+
                     QPushButton* gotoBtn = new QPushButton(tr("Goto Item"), &dialog);
                     QPushButton* dismissBtn = new QPushButton(tr("Dismiss"), &dialog);
                     QPushButton* closeBtn = new QPushButton(tr("Close"), &dialog);
+
+                    if (tryAgainBtn) {
+                        btnLayout->addWidget(tryAgainBtn);
+                        int tId = n.targetId;
+                        int nId = n.id;
+                        connect(tryAgainBtn, &QPushButton::clicked, [this, db, tId, nId, &dialog]() {
+                            // First, navigate to the item so the UI state is synchronized
+                            onQueueItemClicked(db, tId, "document");
+                            // Then trigger the regeneration
+                            onRegenerateMerge();
+                            db->dismissNotification(nId);
+                            updateNotificationStatus();
+                            dialog.accept();
+                        });
+                    }
 
                     btnLayout->addWidget(gotoBtn);
                     btnLayout->addWidget(dismissBtn);
@@ -5028,6 +5086,56 @@ void MainWindow::onDocumentAIOperations() {
     }
 }
 
+void MainWindow::onRegenerateMerge() {
+    if (!currentDb || currentDocumentId == 0) return;
+
+    auto docs = currentDb->getDocuments();
+    DocumentNode doc;
+    doc.id = -1;
+    for (const auto& d : docs) {
+        if (d.id == currentDocumentId) {
+            doc = d;
+            break;
+        }
+    }
+    if (doc.id == -1) return;
+
+    QJsonDocument docMeta = QJsonDocument::fromJson(doc.metadata.toUtf8());
+    if (docMeta.isNull() || !docMeta.isObject()) return;
+
+    QJsonObject metaObj = docMeta.object();
+    if (metaObj.value("type").toString() != "merge") return;
+
+    QString prompt = metaObj.value("prompt").toString();
+    if (prompt.isEmpty()) return;
+
+    QString model = currentDb->getSetting("document", currentDocumentId, "model");
+    if (model.isEmpty()) {
+        if (!m_selectedModels.isEmpty()) {
+            model = m_selectedModels.first();
+        } else {
+            model = "llama3:latest"; // Fallback
+        }
+    }
+
+    // Save previous version in history
+    currentDb->addDocumentHistory(currentDocumentId, "replace_pre", doc.content);
+
+    // Set generating text
+    currentDb->updateDocument(currentDocumentId, doc.title, "*Generating merge...*", doc.metadata);
+
+    if (documentEditorView && mainContentStack->currentWidget() == docContainer) {
+        documentEditorView->blockSignals(true);
+        documentEditorView->setPlainText("*Generating merge...*");
+        documentEditorView->blockSignals(false);
+    }
+
+    regenerateMergeBtn->hide();
+
+    // Enqueue the job again
+    currentDb->enqueuePrompt(currentDocumentId, model, prompt, 0, "document", 0, "replace_direct");
+}
+
 void MainWindow::onDocumentHistory() {
     if (!currentDb || currentDocumentId == 0) return;
     DocumentHistoryDialog dialog(currentDb, currentDocumentId, this);
@@ -5066,11 +5174,24 @@ void MainWindow::onOpenBooksTreeDoubleClicked(const QModelIndex& index) {
         else if (type == "draft")
             docs = currentDb->getDrafts();
 
+        regenerateMergeBtn->hide();
         for (const auto& doc : docs) {
             if (doc.id == docId) {
                 currentDocumentId = docId;
                 documentEditorView->setPlainText(doc.content);
                 mainContentStack->setCurrentWidget(docContainer);
+
+                if (type == "document") {
+                    QJsonDocument docMeta = QJsonDocument::fromJson(doc.metadata.toUtf8());
+                    if (!docMeta.isNull() && docMeta.isObject()) {
+                        QJsonObject obj = docMeta.object();
+                        if (obj.value("type").toString() == "merge") {
+                            if (!doc.content.contains("*Generating merge...*")) {
+                                regenerateMergeBtn->show();
+                            }
+                        }
+                    }
+                }
                 break;
             }
         }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -4032,8 +4032,8 @@ void MainWindow::onOpenBooksSelectionChanged(const QItemSelection& selected, con
         if (type == "document" || type == "template" || type == "draft") {
             currentDocumentId = nodeId;
             isCreatingNewDoc = (nodeId == 0);
-            regenerateMergeBtn->hide();
-            viewMergeSourcesBtn->hide();
+            regenerateMergeBtn->setVisible(false);
+            viewMergeSourcesBtn->setVisible(false);
             if (isCreatingNewDoc) {
                 documentEditorView->clear();
                 mainContentStack->setCurrentWidget(docContainer);
@@ -5175,8 +5175,8 @@ void MainWindow::onOpenBooksTreeDoubleClicked(const QModelIndex& index) {
         else if (type == "draft")
             docs = currentDb->getDrafts();
 
-        regenerateMergeBtn->hide();
-        viewMergeSourcesBtn->hide();
+        regenerateMergeBtn->setVisible(false);
+        viewMergeSourcesBtn->setVisible(false);
         for (const auto& doc : docs) {
             if (doc.id == docId) {
                 currentDocumentId = docId;
@@ -5348,21 +5348,21 @@ void MainWindow::handleNewDocumentCreation(int defaultFolderId) {
 }
 
 void MainWindow::updateRegenerateButtonVisibility(const DocumentNode& doc, const QString& type) {
-    regenerateMergeBtn->hide();
-    viewMergeSourcesBtn->hide();
+    bool showRegenerate = false;
+    bool showSources = false;
 
-    if (type != "document" || !currentDb) return;
-
-    if (!currentDb->getDocumentMerge(doc.id).has_value()) return;
-
-    viewMergeSourcesBtn->show();
-
-    // Check if the document is currently regenerating
-    bool isGenerating = currentDb->isGenerating(doc.id, "document", "replace_direct");
-
-    if (!isGenerating && !doc.content.contains(GENERATING_MERGE_TEXT)) {
-        regenerateMergeBtn->show();
+    if (type == "document" && currentDb) {
+        if (currentDb->getDocumentMerge(doc.id).has_value()) {
+            showSources = true;
+            bool isGenerating = currentDb->isGenerating(doc.id, "document", "replace_direct");
+            if (!isGenerating && !doc.content.contains(GENERATING_MERGE_TEXT)) {
+                showRegenerate = true;
+            }
+        }
     }
+
+    regenerateMergeBtn->setVisible(showRegenerate);
+    viewMergeSourcesBtn->setVisible(showSources);
 }
 
 void MainWindow::onViewMergeSources() {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -291,12 +291,12 @@ void MainWindow::setupUi() {
     QPushButton* aiOperationsBtn = new QPushButton(QIcon::fromTheme("tools-wizard"), "AI Operations", this);
     connect(aiOperationsBtn, &QPushButton::clicked, this, &MainWindow::onDocumentAIOperations);
 
-    QPushButton* docHistoryBtn = new QPushButton(QIcon::fromTheme("view-history"), "History", this);
-    connect(docHistoryBtn, &QPushButton::clicked, this, &MainWindow::onDocumentHistory);
-
-    regenerateMergeBtn = new QPushButton(QIcon::fromTheme("view-refresh"), tr("Regenerate Merge"), this);
+    regenerateMergeBtn = new QPushButton(QIcon::fromTheme("view-refresh"), tr("Regenerate"), this);
     connect(regenerateMergeBtn, &QPushButton::clicked, this, &MainWindow::onRegenerateMerge);
     regenerateMergeBtn->hide();
+
+    QPushButton* docHistoryBtn = new QPushButton(QIcon::fromTheme("view-history"), "History", this);
+    connect(docHistoryBtn, &QPushButton::clicked, this, &MainWindow::onDocumentHistory);
 
     viewMergeSourcesBtn = new QPushButton(QIcon::fromTheme("document-multiple"), "View Merge Sources", this);
     connect(viewMergeSourcesBtn, &QPushButton::clicked, this, &MainWindow::onViewMergeSources);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -5348,21 +5348,28 @@ void MainWindow::handleNewDocumentCreation(int defaultFolderId) {
 }
 
 void MainWindow::updateRegenerateButtonVisibility(const DocumentNode& doc, const QString& type) {
-    if (type == "document" && currentDb) {
-        if (currentDb->getDocumentMerge(doc.id).has_value()) {
-            if (!doc.content.contains(GENERATING_MERGE_TEXT)) {
-                regenerateMergeBtn->show();
-            } else {
-                regenerateMergeBtn->hide();
-            }
-            viewMergeSourcesBtn->show();
-        } else {
-            regenerateMergeBtn->hide();
-            viewMergeSourcesBtn->hide();
+    regenerateMergeBtn->hide();
+    viewMergeSourcesBtn->hide();
+
+    if (type != "document" || !currentDb) return;
+
+    if (!currentDb->getDocumentMerge(doc.id).has_value()) return;
+
+    viewMergeSourcesBtn->show();
+
+    // Check if the document is currently regenerating
+    bool isGenerating = false;
+    for (const auto& qi : currentDb->getQueue()) {
+        if (qi.messageId == doc.id && qi.targetType == "document" &&
+            qi.targetAction == "replace_direct" &&
+            (qi.state == "pending" || qi.state == "processing")) {
+            isGenerating = true;
+            break;
         }
-    } else {
-        regenerateMergeBtn->hide();
-        viewMergeSourcesBtn->hide();
+    }
+
+    if (!isGenerating && !doc.content.contains(GENERATING_MERGE_TEXT)) {
+        regenerateMergeBtn->show();
     }
 }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -5352,9 +5352,17 @@ void MainWindow::updateRegenerateButtonVisibility(const DocumentNode& doc, const
         if (currentDb->getDocumentMerge(doc.id).has_value()) {
             if (!doc.content.contains(GENERATING_MERGE_TEXT)) {
                 regenerateMergeBtn->show();
+            } else {
+                regenerateMergeBtn->hide();
             }
             viewMergeSourcesBtn->show();
+        } else {
+            regenerateMergeBtn->hide();
+            viewMergeSourcesBtn->hide();
         }
+    } else {
+        regenerateMergeBtn->hide();
+        viewMergeSourcesBtn->hide();
     }
 }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -298,12 +298,17 @@ void MainWindow::setupUi() {
     connect(regenerateMergeBtn, &QPushButton::clicked, this, &MainWindow::onRegenerateMerge);
     regenerateMergeBtn->hide();
 
+    viewMergeSourcesBtn = new QPushButton(QIcon::fromTheme("document-multiple"), "View Merge Sources", this);
+    connect(viewMergeSourcesBtn, &QPushButton::clicked, this, &MainWindow::onViewMergeSources);
+    viewMergeSourcesBtn->hide();
+
     docToolbar->addWidget(backToDocsBtn);
     docToolbar->addWidget(editDocBtn);
     docToolbar->addWidget(previewDocBtn);
     docToolbar->addWidget(docHistoryBtn);
     docToolbar->addWidget(aiOperationsBtn);
     docToolbar->addWidget(regenerateMergeBtn);
+    docToolbar->addWidget(viewMergeSourcesBtn);
     docLayout->addWidget(docToolbar);
 
     documentStack = new QStackedWidget(this);
@@ -1898,6 +1903,16 @@ void MainWindow::showItemContextMenu(QStandardItem* item, const QPoint& globalPo
             aiAction = menu.addAction(QIcon::fromTheme("tools-wizard"), "AI Operations");
         }
 
+        QAction* regenerateMergeAction = nullptr;
+        QAction* viewMergeSourcesAction = nullptr;
+        if (type == "document" && currentDb) {
+            int id = item->data(Qt::UserRole).toInt();
+            if (currentDb->getDocumentMerge(id).has_value()) {
+                regenerateMergeAction = menu.addAction(QIcon::fromTheme("view-refresh"), "Regenerate Merge");
+                viewMergeSourcesAction = menu.addAction(QIcon::fromTheme("document-multiple"), "View Merge Sources");
+            }
+        }
+
         menu.addSeparator();
 
         QAction* exportAction = nullptr;
@@ -1972,6 +1987,10 @@ void MainWindow::showItemContextMenu(QStandardItem* item, const QPoint& globalPo
             onDocumentHistory();
         } else if (aiAction && selectedAction == aiAction) {
             onDocumentAIOperations();
+        } else if (regenerateMergeAction && selectedAction == regenerateMergeAction) {
+            onRegenerateMerge();
+        } else if (viewMergeSourcesAction && selectedAction == viewMergeSourcesAction) {
+            onViewMergeSources();
         } else if (selectedAction == deleteAction) {
             int answer =
                 QMessageBox::question(this, "Delete", tr("Are you sure you want to delete this %1?").arg(type));
@@ -2159,10 +2178,15 @@ void MainWindow::onMergeDocumentsSelected() {
         QJsonObject metaObj;
         metaObj["type"] = "merge";
         QJsonArray sourcesArr;
-        for (int id : sourceDocumentIds) sourcesArr.append(id);
+        QStringList sourceIdsStrs;
+        for (int id : sourceDocumentIds) {
+            sourcesArr.append(id);
+            sourceIdsStrs.append(QString::number(id));
+        }
         metaObj["source_documents"] = sourcesArr;
         metaObj["prompt"] = finalPrompt;
         QString metaStr = QString::fromUtf8(QJsonDocument(metaObj).toJson(QJsonDocument::Compact));
+        QString sourceIdsStr = sourceIdsStrs.join(",");
 
         QString baseTitle = "Merged: " + sourceTitles.join(", ");
         if (baseTitle.length() > 50) baseTitle = baseTitle.left(47) + "...";
@@ -2171,11 +2195,14 @@ void MainWindow::onMergeDocumentsSelected() {
             int newFolderId = currentDb->addFolder(targetFolderId, baseTitle + " (Models)", "docs_folder");
             for (const QString& model : selectedModels) {
                 int newDocId = currentDb->addDocument(newFolderId, model + " Generation", GENERATING_MERGE_TEXT, 0, metaStr);
+                currentDb->addDocumentMerge(newDocId, sourceIdsStr, finalPrompt, model, 0);
                 currentDb->enqueuePrompt(newDocId, model, finalPrompt, 0, "document", 0, "replace_direct");
             }
         } else {
+            QString model = selectedModels.first();
             int newDocId = currentDb->addDocument(targetFolderId, baseTitle, GENERATING_MERGE_TEXT, 0, metaStr);
-            currentDb->enqueuePrompt(newDocId, selectedModels.first(), finalPrompt, 0, "document", 0, "replace_direct");
+            currentDb->addDocumentMerge(newDocId, sourceIdsStr, finalPrompt, model, 0);
+            currentDb->enqueuePrompt(newDocId, model, finalPrompt, 0, "document", 0, "replace_direct");
         }
 
         loadDocumentsAndNotes();
@@ -4006,6 +4033,7 @@ void MainWindow::onOpenBooksSelectionChanged(const QItemSelection& selected, con
             currentDocumentId = nodeId;
             isCreatingNewDoc = (nodeId == 0);
             regenerateMergeBtn->hide();
+            viewMergeSourcesBtn->hide();
             if (isCreatingNewDoc) {
                 documentEditorView->clear();
                 mainContentStack->setCurrentWidget(docContainer);
@@ -4581,23 +4609,8 @@ void MainWindow::updateNotificationStatus() {
                     QPushButton* tryAgainBtn = nullptr;
 
                     if (n.type == "finished_generation" && n.targetType == "document") {
-                        auto docs = db->getDocuments();
-                        DocumentNode docNode;
-                        docNode.id = -1;
-                        for (const auto& d : docs) {
-                            if (d.id == n.targetId) {
-                                docNode = d;
-                                break;
-                            }
-                        }
-                        if (docNode.id != -1) {
-                            QJsonDocument docMeta = QJsonDocument::fromJson(docNode.metadata.toUtf8());
-                            if (!docMeta.isNull() && docMeta.isObject()) {
-                                QJsonObject obj = docMeta.object();
-                                if (obj.value("type").toString() == "merge") {
-                                    tryAgainBtn = new QPushButton(tr("Try Again"), &dialog);
-                                }
-                            }
+                        if (db->getDocumentMerge(n.targetId).has_value()) {
+                            tryAgainBtn = new QPushButton(tr("Try Again"), &dialog);
                         }
                     }
 
@@ -5080,27 +5093,18 @@ void MainWindow::onDocumentAIOperations() {
 void MainWindow::onRegenerateMerge() {
     if (!currentDb || currentDocumentId == 0) return;
 
-    auto docs = currentDb->getDocuments();
-    DocumentNode doc;
-    doc.id = -1;
-    for (const auto& d : docs) {
-        if (d.id == currentDocumentId) {
-            doc = d;
-            break;
-        }
-    }
-    if (doc.id == -1) return;
+    auto docOpt = currentDb->getDocument(currentDocumentId);
+    if (!docOpt) return;
+    const auto& doc = *docOpt;
 
-    QJsonDocument docMeta = QJsonDocument::fromJson(doc.metadata.toUtf8());
-    if (docMeta.isNull() || !docMeta.isObject()) return;
+    auto mergeOpt = currentDb->getDocumentMerge(currentDocumentId);
+    if (!mergeOpt) return;
+    const auto& merge = *mergeOpt;
 
-    QJsonObject metaObj = docMeta.object();
-    if (metaObj.value("type").toString() != "merge") return;
-
-    QString prompt = metaObj.value("prompt").toString();
+    QString prompt = merge.prompt;
     if (prompt.isEmpty()) return;
 
-    QString model = currentDb->getSetting("document", currentDocumentId, "model");
+    QString model = merge.model;
     if (model.isEmpty()) {
         if (!m_selectedModels.isEmpty()) {
             model = m_selectedModels.first();
@@ -5109,8 +5113,14 @@ void MainWindow::onRegenerateMerge() {
         }
     }
 
-    // Save previous version in history
-    currentDb->addDocumentHistory(currentDocumentId, "replace_pre", doc.content);
+    // Save previous version in history and get the history ID
+    int historyId = currentDb->addDocumentHistoryReturningId(currentDocumentId, "replace_pre", doc.content);
+
+    // Update the existing merge row to point to this history ID
+    currentDb->updateDocumentMergeVersion(merge.id, historyId);
+
+    // Add a new row for the new generation
+    currentDb->addDocumentMerge(currentDocumentId, merge.sourceDocumentIds, prompt, model, 0);
 
     // Set generating text
     currentDb->updateDocument(currentDocumentId, doc.title, GENERATING_MERGE_TEXT, doc.metadata);
@@ -5166,6 +5176,7 @@ void MainWindow::onOpenBooksTreeDoubleClicked(const QModelIndex& index) {
             docs = currentDb->getDrafts();
 
         regenerateMergeBtn->hide();
+        viewMergeSourcesBtn->hide();
         for (const auto& doc : docs) {
             if (doc.id == docId) {
                 currentDocumentId = docId;
@@ -5337,17 +5348,72 @@ void MainWindow::handleNewDocumentCreation(int defaultFolderId) {
 }
 
 void MainWindow::updateRegenerateButtonVisibility(const DocumentNode& doc, const QString& type) {
-    if (type == "document") {
-        QJsonDocument docMeta = QJsonDocument::fromJson(doc.metadata.toUtf8());
-        if (!docMeta.isNull() && docMeta.isObject()) {
-            QJsonObject obj = docMeta.object();
-            if (obj.value("type").toString() == "merge") {
-                if (!doc.content.contains(GENERATING_MERGE_TEXT)) {
-                    regenerateMergeBtn->show();
-                }
+    if (type == "document" && currentDb) {
+        if (currentDb->getDocumentMerge(doc.id).has_value()) {
+            if (!doc.content.contains(GENERATING_MERGE_TEXT)) {
+                regenerateMergeBtn->show();
             }
+            viewMergeSourcesBtn->show();
         }
     }
+}
+
+void MainWindow::onViewMergeSources() {
+    if (!currentDb || currentDocumentId == 0) return;
+
+    auto mergeOpt = currentDb->getDocumentMerge(currentDocumentId);
+    if (!mergeOpt) return;
+    const auto& merge = *mergeOpt;
+
+    QStringList idsStr = merge.sourceDocumentIds.split(",");
+
+    QDialog dialog(this);
+    dialog.setWindowTitle(tr("Merge Sources"));
+    dialog.resize(600, 400);
+    QVBoxLayout* layout = new QVBoxLayout(&dialog);
+
+    QListWidget* list = new QListWidget(&dialog);
+    layout->addWidget(list);
+
+    for (const QString& idStr : idsStr) {
+        int srcId = idStr.toInt();
+        if (auto srcDocOpt = currentDb->getDocument(srcId)) {
+            const auto& srcDoc = *srcDocOpt;
+            QListWidgetItem* item = new QListWidgetItem(srcDoc.title);
+            item->setData(Qt::UserRole, srcId);
+            list->addItem(item);
+        }
+    }
+
+    QHBoxLayout* btnLayout = new QHBoxLayout();
+    QPushButton* closeBtn = new QPushButton(tr("Close"), &dialog);
+    btnLayout->addStretch();
+    btnLayout->addWidget(closeBtn);
+    layout->addLayout(btnLayout);
+
+    connect(closeBtn, &QPushButton::clicked, &dialog, &QDialog::reject);
+
+    connect(list, &QListWidget::itemDoubleClicked, this, [&dialog, this](QListWidgetItem* item) {
+        int srcId = item->data(Qt::UserRole).toInt();
+        dialog.accept();
+        onQueueItemClicked(currentDb, srcId, "document");
+    });
+
+    QHBoxLayout* actionBtnLayout = new QHBoxLayout();
+    QPushButton* gotoBtn = new QPushButton(tr("Go To Selected"), &dialog);
+    actionBtnLayout->addWidget(gotoBtn);
+    layout->insertLayout(1, actionBtnLayout);
+
+    connect(gotoBtn, &QPushButton::clicked, this, [&dialog, this, list]() {
+        QListWidgetItem* item = list->currentItem();
+        if (item) {
+            int srcId = item->data(Qt::UserRole).toInt();
+            dialog.accept();
+            onQueueItemClicked(currentDb, srcId, "document");
+        }
+    });
+
+    dialog.exec();
 }
 
 void MainWindow::onEditDocument() {

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -99,6 +99,7 @@ class MainWindow : public KXmlGuiWindow {
     void onDocumentAIOperations();
     void onDocumentHistory();
     void onEditDocument();
+    void onRegenerateMerge();
     void handleNewDocumentCreation(int defaultFolderId = 0);
     void showItemContextMenu(QStandardItem* item, const QPoint& globalPos);
     void showOpenBookContextMenu(const QPoint& pos);
@@ -182,6 +183,7 @@ class MainWindow : public KXmlGuiWindow {
     QPushButton* saveDocBtn;
     QPushButton* previewDocBtn;
     QPushButton* editDocBtn;
+    QPushButton* regenerateMergeBtn;
 
     QWidget* noteContainer;
     QTextEdit* noteEditorView;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -100,6 +100,7 @@ class MainWindow : public KXmlGuiWindow {
     void onDocumentHistory();
     void onEditDocument();
     void onRegenerateMerge();
+    void updateRegenerateButtonVisibility(const DocumentNode& doc, const QString& type);
     void handleNewDocumentCreation(int defaultFolderId = 0);
     void showItemContextMenu(QStandardItem* item, const QPoint& globalPos);
     void showOpenBookContextMenu(const QPoint& pos);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -100,6 +100,7 @@ class MainWindow : public KXmlGuiWindow {
     void onDocumentHistory();
     void onEditDocument();
     void onRegenerateMerge();
+    void onViewMergeSources();
     void updateRegenerateButtonVisibility(const DocumentNode& doc, const QString& type);
     void handleNewDocumentCreation(int defaultFolderId = 0);
     void showItemContextMenu(QStandardItem* item, const QPoint& globalPos);
@@ -185,6 +186,7 @@ class MainWindow : public KXmlGuiWindow {
     QPushButton* previewDocBtn;
     QPushButton* editDocBtn;
     QPushButton* regenerateMergeBtn;
+    QPushButton* viewMergeSourcesBtn;
 
     QWidget* noteContainer;
     QTextEdit* noteEditorView;

--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -428,7 +428,7 @@ void QueueManager::processNext() {
                             for (const auto& d : docs) {
                                 if (d.id == act.item.messageId) {
                                     currentContent = d.content;
-                                    if (currentContent == "*Generating merge...*") currentContent = "";
+                                    if (currentContent == QStringLiteral("*Generating merge...*")) currentContent = "";
                                     title = d.title;
                                     metadata = d.metadata;
                                     break;


### PR DESCRIPTION
Implements the ability to regenerate merged documents.

- **UI Addition:** Added a hidden `regenerateMergeBtn` to `docToolbar` in `MainWindow`.
- **Visibility Logic:** The button dynamically shows up if the currently selected document's metadata indicates `type: merge`.
- **Notification Dialog:** Added a "Try Again" button to the notification summary dialog specifically for finished generation events of merge documents.
- **Regeneration Logic:**
  - `onRegenerateMerge()` reads the prompt from the document metadata and the model from document settings.
  - Automatically saves the current content to history (`replace_pre`).
  - Sets the document's content to `*Generating merge...*` while keeping its original metadata intact.
  - Enqueues a new `replace_direct` prompt task so the text updates directly without manual review.
- **State Synchronization:** Clicking "Try Again" from the notification dialog ensures the background tree selection and `currentDocumentId` correctly switch to the target document before generating to avoid applying updates to the wrong active editor pane.

---
*PR created automatically by Jules for task [12316785460964060356](https://jules.google.com/task/12316785460964060356) started by @arran4*