### PR TITLE
Show Merge Configuration on Regenerate Merge

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2172,6 +2172,7 @@ void MainWindow::onMergeDocumentsSelected() {
     MergeDocumentsDialog dlg(currentDb.get(), sourceDocumentIds, m_availableModelInfos, m_availableModels, this);
     if (dlg.exec() == QDialog::Accepted) {
         QString finalPrompt = dlg.getFinalPrompt();
+        QString rawPrompt = dlg.getRawPrompt();
         QStringList selectedModels = dlg.getSelectedModels();
         if (selectedModels.isEmpty() || finalPrompt.isEmpty()) return;
 
@@ -2186,6 +2187,7 @@ void MainWindow::onMergeDocumentsSelected() {
         }
         metaObj["source_documents"] = sourcesArr;
         metaObj["prompt"] = finalPrompt;
+        metaObj["raw_prompt"] = rawPrompt;
         QString metaStr = QString::fromUtf8(QJsonDocument(metaObj).toJson(QJsonDocument::Compact));
         QString sourceIdsStr = sourceIdsStrs.join(",");
 
@@ -5102,40 +5104,88 @@ void MainWindow::onRegenerateMerge() {
     if (!mergeOpt) return;
     const auto& merge = *mergeOpt;
 
-    QString prompt = merge.prompt;
-    if (prompt.isEmpty()) return;
+    QString rawPrompt;
+    QJsonDocument metaDoc = QJsonDocument::fromJson(doc.metadata.toUtf8());
+    QJsonObject metaObj = metaDoc.object();
+    if (metaObj.contains("raw_prompt")) {
+        rawPrompt = metaObj["raw_prompt"].toString();
+    }
 
-    QString model = merge.model;
-    if (model.isEmpty()) {
-        if (!m_selectedModels.isEmpty()) {
-            model = m_selectedModels.first();
-        } else {
-            model = "llama3:latest"; // Fallback
+    QList<int> sourceIds;
+    QStringList idStrs = merge.sourceDocumentIds.split(",", Qt::SkipEmptyParts);
+    for (const QString& idStr : idStrs) {
+        sourceIds.append(idStr.toInt());
+    }
+
+    MergeDocumentsDialog dlg(currentDb.get(), sourceIds, m_availableModelInfos, m_availableModels, this);
+    if (!rawPrompt.isEmpty()) {
+        dlg.setInitialPrompt(rawPrompt);
+    } else {
+        dlg.setInitialPrompt(merge.prompt);
+    }
+
+    QStringList initialModels;
+    if (!merge.model.isEmpty()) {
+        initialModels << merge.model;
+    }
+    dlg.setInitialModels(initialModels);
+
+    if (dlg.exec() == QDialog::Accepted) {
+        QString finalPrompt = dlg.getFinalPrompt();
+        QString newRawPrompt = dlg.getRawPrompt();
+        QStringList selectedModels = dlg.getSelectedModels();
+        if (selectedModels.isEmpty() || finalPrompt.isEmpty()) return;
+
+        // Update metadata for the current document
+        metaObj["prompt"] = finalPrompt;
+        metaObj["raw_prompt"] = newRawPrompt;
+        QString metaStr = QString::fromUtf8(QJsonDocument(metaObj).toJson(QJsonDocument::Compact));
+
+        QString firstModel = selectedModels.first();
+
+        // Save previous version in history and get the history ID
+        int historyId = currentDb->addDocumentHistoryReturningId(currentDocumentId, "replace_pre", doc.content);
+
+        // Update the existing merge row to point to this history ID
+        currentDb->updateDocumentMergeVersion(merge.id, historyId);
+
+        // Add a new row for the new generation
+        currentDb->addDocumentMerge(currentDocumentId, merge.sourceDocumentIds, finalPrompt, firstModel, 0);
+
+        // Set generating text and metadata
+        currentDb->updateDocument(currentDocumentId, doc.title, GENERATING_MERGE_TEXT, metaStr);
+
+        if (documentEditorView && mainContentStack->currentWidget() == docContainer) {
+            documentEditorView->blockSignals(true);
+            documentEditorView->setPlainText(GENERATING_MERGE_TEXT);
+            documentEditorView->blockSignals(false);
         }
+
+        regenerateMergeBtn->hide();
+
+        // Enqueue the job again for the first model on the current document
+        currentDb->enqueuePrompt(currentDocumentId, firstModel, finalPrompt, 0, "document", 0, "replace_direct");
+
+        // If there are additional models selected, create new documents for them
+        if (selectedModels.size() > 1) {
+            int targetFolderId = doc.parentId;
+            QString baseTitle = doc.title;
+
+            // Remove "(Models)" suffix if we are duplicating an already grouped title
+            if (baseTitle.endsWith(" (Models)")) {
+                baseTitle.chop(9); // length of " (Models)"
+            }
+
+            for (int i = 1; i < selectedModels.size(); ++i) {
+                QString model = selectedModels[i];
+                int newDocId = currentDb->addDocument(targetFolderId, baseTitle + " - " + model, GENERATING_MERGE_TEXT, 0, metaStr);
+                currentDb->addDocumentMerge(newDocId, merge.sourceDocumentIds, finalPrompt, model, 0);
+                currentDb->enqueuePrompt(newDocId, model, finalPrompt, 0, "document", 0, "replace_direct");
+            }
+        }
+
+        loadDocumentsAndNotes();
     }
-
-    // Save previous version in history and get the history ID
-    int historyId = currentDb->addDocumentHistoryReturningId(currentDocumentId, "replace_pre", doc.content);
-
-    // Update the existing merge row to point to this history ID
-    currentDb->updateDocumentMergeVersion(merge.id, historyId);
-
-    // Add a new row for the new generation
-    currentDb->addDocumentMerge(currentDocumentId, merge.sourceDocumentIds, prompt, model, 0);
-
-    // Set generating text
-    currentDb->updateDocument(currentDocumentId, doc.title, GENERATING_MERGE_TEXT, doc.metadata);
-
-    if (documentEditorView && mainContentStack->currentWidget() == docContainer) {
-        documentEditorView->blockSignals(true);
-        documentEditorView->setPlainText(GENERATING_MERGE_TEXT);
-        documentEditorView->blockSignals(false);
-    }
-
-    regenerateMergeBtn->hide();
-
-    // Enqueue the job again
-    currentDb->enqueuePrompt(currentDocumentId, model, prompt, 0, "document", 0, "replace_direct");
 }
 
 void MainWindow::onDocumentHistory() {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2176,39 +2176,10 @@ void MainWindow::onMergeDocumentsSelected() {
         QStringList selectedModels = dlg.getSelectedModels();
         if (selectedModels.isEmpty() || finalPrompt.isEmpty()) return;
 
-        // Build metadata
-        QJsonObject metaObj;
-        metaObj["type"] = "merge";
-        QJsonArray sourcesArr;
-        QStringList sourceIdsStrs;
-        for (int id : sourceDocumentIds) {
-            sourcesArr.append(id);
-            sourceIdsStrs.append(QString::number(id));
-        }
-        metaObj["source_documents"] = sourcesArr;
-        metaObj["prompt"] = finalPrompt;
-        metaObj["raw_prompt"] = rawPrompt;
-        QString metaStr = QString::fromUtf8(QJsonDocument(metaObj).toJson(QJsonDocument::Compact));
-        QString sourceIdsStr = sourceIdsStrs.join(",");
-
         QString baseTitle = "Merged: " + sourceTitles.join(", ");
         if (baseTitle.length() > 50) baseTitle = baseTitle.left(47) + "...";
 
-        if (selectedModels.size() > 1) {
-            int newFolderId = currentDb->addFolder(targetFolderId, baseTitle + " (Models)", "docs_folder");
-            for (const QString& model : selectedModels) {
-                int newDocId = currentDb->addDocument(newFolderId, model + " Generation", GENERATING_MERGE_TEXT, 0, metaStr);
-                currentDb->addDocumentMerge(newDocId, sourceIdsStr, finalPrompt, model, 0);
-                currentDb->enqueuePrompt(newDocId, model, finalPrompt, 0, "document", 0, "replace_direct");
-            }
-        } else {
-            QString model = selectedModels.first();
-            int newDocId = currentDb->addDocument(targetFolderId, baseTitle, GENERATING_MERGE_TEXT, 0, metaStr);
-            currentDb->addDocumentMerge(newDocId, sourceIdsStr, finalPrompt, model, 0);
-            currentDb->enqueuePrompt(newDocId, model, finalPrompt, 0, "document", 0, "replace_direct");
-        }
-
-        loadDocumentsAndNotes();
+        processMergeGeneration(finalPrompt, rawPrompt, selectedModels, sourceDocumentIds, baseTitle, targetFolderId);
     }
 }
 
@@ -5136,56 +5107,84 @@ void MainWindow::onRegenerateMerge() {
         QStringList selectedModels = dlg.getSelectedModels();
         if (selectedModels.isEmpty() || finalPrompt.isEmpty()) return;
 
-        // Update metadata for the current document
-        metaObj["prompt"] = finalPrompt;
-        metaObj["raw_prompt"] = newRawPrompt;
-        QString metaStr = QString::fromUtf8(QJsonDocument(metaObj).toJson(QJsonDocument::Compact));
-
-        QString firstModel = selectedModels.first();
-
-        // Save previous version in history and get the history ID
-        int historyId = currentDb->addDocumentHistoryReturningId(currentDocumentId, "replace_pre", doc.content);
-
-        // Update the existing merge row to point to this history ID
-        currentDb->updateDocumentMergeVersion(merge.id, historyId);
-
-        // Add a new row for the new generation
-        currentDb->addDocumentMerge(currentDocumentId, merge.sourceDocumentIds, finalPrompt, firstModel, 0);
-
-        // Set generating text and metadata
-        currentDb->updateDocument(currentDocumentId, doc.title, GENERATING_MERGE_TEXT, metaStr);
-
-        if (documentEditorView && mainContentStack->currentWidget() == docContainer) {
-            documentEditorView->blockSignals(true);
-            documentEditorView->setPlainText(GENERATING_MERGE_TEXT);
-            documentEditorView->blockSignals(false);
+        QString baseTitle = doc.title;
+        if (baseTitle.endsWith(" (Models)")) {
+            baseTitle.chop(9); // length of " (Models)"
         }
 
-        regenerateMergeBtn->hide();
-
-        // Enqueue the job again for the first model on the current document
-        currentDb->enqueuePrompt(currentDocumentId, firstModel, finalPrompt, 0, "document", 0, "replace_direct");
-
-        // If there are additional models selected, create new documents for them
-        if (selectedModels.size() > 1) {
-            int targetFolderId = doc.parentId;
-            QString baseTitle = doc.title;
-
-            // Remove "(Models)" suffix if we are duplicating an already grouped title
-            if (baseTitle.endsWith(" (Models)")) {
-                baseTitle.chop(9); // length of " (Models)"
-            }
-
-            for (int i = 1; i < selectedModels.size(); ++i) {
-                QString model = selectedModels[i];
-                int newDocId = currentDb->addDocument(targetFolderId, baseTitle + " - " + model, GENERATING_MERGE_TEXT, 0, metaStr);
-                currentDb->addDocumentMerge(newDocId, merge.sourceDocumentIds, finalPrompt, model, 0);
-                currentDb->enqueuePrompt(newDocId, model, finalPrompt, 0, "document", 0, "replace_direct");
-            }
-        }
-
-        loadDocumentsAndNotes();
+        processMergeGeneration(finalPrompt, newRawPrompt, selectedModels, sourceIds, baseTitle, doc.parentId, currentDocumentId);
     }
+}
+
+void MainWindow::processMergeGeneration(const QString& finalPrompt, const QString& rawPrompt, const QStringList& selectedModels, const QList<int>& sourceDocumentIds, const QString& baseTitle, int targetFolderId, int existingDocId) {
+    if (!currentDb || selectedModels.isEmpty() || finalPrompt.isEmpty()) return;
+
+    // Build metadata
+    QJsonObject metaObj;
+    metaObj["type"] = "merge";
+    QJsonArray sourcesArr;
+    QStringList sourceIdsStrs;
+    for (int id : sourceDocumentIds) {
+        sourcesArr.append(id);
+        sourceIdsStrs.append(QString::number(id));
+    }
+    metaObj["source_documents"] = sourcesArr;
+    metaObj["prompt"] = finalPrompt;
+    metaObj["raw_prompt"] = rawPrompt;
+    QString metaStr = QString::fromUtf8(QJsonDocument(metaObj).toJson(QJsonDocument::Compact));
+    QString sourceIdsStr = sourceIdsStrs.join(",");
+
+    QString firstModel = selectedModels.first();
+    int currentDocIdToUpdate = existingDocId;
+
+    if (existingDocId > 0) {
+        auto docOpt = currentDb->getDocument(existingDocId);
+        if (docOpt) {
+            auto mergeOpt = currentDb->getDocumentMerge(existingDocId);
+            if (mergeOpt) {
+                // Save previous version in history and get the history ID
+                int historyId = currentDb->addDocumentHistoryReturningId(existingDocId, "replace_pre", docOpt->content);
+
+                // Update the existing merge row to point to this history ID
+                currentDb->updateDocumentMergeVersion(mergeOpt->id, historyId);
+            }
+
+            // Add a new row for the new generation
+            currentDb->addDocumentMerge(existingDocId, sourceIdsStr, finalPrompt, firstModel, 0);
+
+            // Set generating text and metadata
+            currentDb->updateDocument(existingDocId, docOpt->title, GENERATING_MERGE_TEXT, metaStr);
+
+            if (documentEditorView && mainContentStack->currentWidget() == docContainer && currentDocumentId == existingDocId) {
+                documentEditorView->blockSignals(true);
+                documentEditorView->setPlainText(GENERATING_MERGE_TEXT);
+                documentEditorView->blockSignals(false);
+                if (regenerateMergeBtn) {
+                    regenerateMergeBtn->hide();
+                }
+            }
+
+            // Enqueue the job again for the first model on the current document
+            currentDb->enqueuePrompt(existingDocId, firstModel, finalPrompt, 0, "document", 0, "replace_direct");
+        }
+    } else {
+        if (selectedModels.size() > 1) {
+            targetFolderId = currentDb->addFolder(targetFolderId, baseTitle + " (Models)", "docs_folder");
+        }
+        int newDocId = currentDb->addDocument(targetFolderId, selectedModels.size() > 1 ? baseTitle + " - " + firstModel : baseTitle, GENERATING_MERGE_TEXT, 0, metaStr);
+        currentDb->addDocumentMerge(newDocId, sourceIdsStr, finalPrompt, firstModel, 0);
+        currentDb->enqueuePrompt(newDocId, firstModel, finalPrompt, 0, "document", 0, "replace_direct");
+    }
+
+    // If there are additional models selected, create new documents for them
+    for (int i = 1; i < selectedModels.size(); ++i) {
+        QString model = selectedModels[i];
+        int newDocId = currentDb->addDocument(targetFolderId, baseTitle + " - " + model, GENERATING_MERGE_TEXT, 0, metaStr);
+        currentDb->addDocumentMerge(newDocId, sourceIdsStr, finalPrompt, model, 0);
+        currentDb->enqueuePrompt(newDocId, model, finalPrompt, 0, "document", 0, "replace_direct");
+    }
+
+    loadDocumentsAndNotes();
 }
 
 void MainWindow::onDocumentHistory() {

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -107,6 +107,7 @@ class MainWindow : public KXmlGuiWindow {
     void showOpenBookContextMenu(const QPoint& pos);
     void showVfsContextMenu(const QPoint& pos);
     void onMergeDocumentsSelected();
+    void processMergeGeneration(const QString& finalPrompt, const QString& rawPrompt, const QStringList& selectedModels, const QList<int>& sourceDocumentIds, const QString& baseTitle, int targetFolderId, int existingDocId = 0);
     void showInputSettingsMenu();
     void showChatSettingsDialog(int messageId);
     void updateInputBehavior();

--- a/src/MergeDocumentsDialog.cpp
+++ b/src/MergeDocumentsDialog.cpp
@@ -162,6 +162,27 @@ QStringList MergeDocumentsDialog::getSelectedModels() const {
     return m_selectedModels;
 }
 
+QString MergeDocumentsDialog::getRawPrompt() const {
+    return m_instructionEdit->toPlainText();
+}
+
+void MergeDocumentsDialog::setInitialPrompt(const QString& prompt) {
+    if (!prompt.isEmpty()) {
+        m_instructionEdit->setPlainText(prompt);
+    }
+}
+
+void MergeDocumentsDialog::setInitialModels(const QStringList& models) {
+    if (!models.isEmpty()) {
+        m_selectedModels = models;
+        if (m_selectedModels.size() == 1) {
+            m_selectModelsBtn->setText(m_selectedModels.first());
+        } else {
+            m_selectModelsBtn->setText(tr("%1 Models Selected").arg(m_selectedModels.size()));
+        }
+    }
+}
+
 void MergeDocumentsDialog::onSelectModelsClicked() {
     ModelSelectionDialog dlg(m_modelInfos, m_fallbackModels, this);
     if (dlg.exec() == QDialog::Accepted) {

--- a/src/MergeDocumentsDialog.h
+++ b/src/MergeDocumentsDialog.h
@@ -23,6 +23,9 @@ class MergeDocumentsDialog : public QDialog {
 
     QString getFinalPrompt() const;
     QStringList getSelectedModels() const;
+    QString getRawPrompt() const;
+    void setInitialPrompt(const QString& prompt);
+    void setInitialModels(const QStringList& models);
 
    public slots:
     void accept() override;


### PR DESCRIPTION
Fixes the "regenerate merge" feature so that it shows the user their previous merge configuration settings (prompt and selected models), allowing them to make modifications before re-running the generation on top of the document.

---
*PR created automatically by Jules for task [2881126470463559894](https://jules.google.com/task/2881126470463559894) started by @arran4*