### PR TITLE
Refine notification UI to display target titles instead of just IDs

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -4456,9 +4456,29 @@ void MainWindow::updateNotificationStatus() {
             } else {
                 typeStr = tr("Finished");
             }
-            QAction* action = notificationMenu->addAction(
-                QString("[%1] %2: Msg %3").arg(bookName, typeStr, QString::number(n.targetId)));
-            connect(action, &QAction::triggered, this, [this, db, n, bookName]() {
+
+            QString targetTitle;
+            QString displayTargetType;
+            if (n.targetType == "document") {
+                displayTargetType = tr("Document");
+                auto doc = db->getDocument(n.targetId);
+                if (doc.has_value()) {
+                    targetTitle = doc->title;
+                }
+            } else if (n.targetType == "message") {
+                displayTargetType = tr("Message");
+                auto chat = db->getChat(n.targetId);
+                targetTitle = chat.title;
+            } else {
+                displayTargetType = n.targetType;
+            }
+            if (targetTitle.isEmpty()) {
+                targetTitle = tr("Unknown");
+            }
+
+            QString menuText = QString("[%1] %2: %3 '%4' (%5)").arg(bookName, typeStr, displayTargetType, targetTitle, QString::number(n.targetId));
+            QAction* action = notificationMenu->addAction(menuText);
+            connect(action, &QAction::triggered, this, [this, db, n, bookName, displayTargetType, targetTitle]() {
                 if (n.type == "review_needed") {
                     // For document review, n.targetId is the document ID.
                     // DocumentReviewDialog expects the queueItemId. We need to find the matching completed queue item.
@@ -4493,8 +4513,8 @@ void MainWindow::updateNotificationStatus() {
                     dialog.setWindowTitle(tr("Error: Modify and Retry"));
                     QVBoxLayout* layout = new QVBoxLayout(&dialog);
 
-                    QLabel* summary = new QLabel(QString("<b>Book:</b> %1<br><b>Target ID:</b> %2")
-                                                     .arg(bookName, QString::number(n.targetId)));
+                    QLabel* summary = new QLabel(QString("<b>Book:</b> %1<br><b>%2:</b> %3 (%4)")
+                                                     .arg(bookName, displayTargetType, targetTitle, QString::number(n.targetId)));
                     summary->setWordWrap(true);
                     layout->addWidget(summary);
 
@@ -4574,8 +4594,8 @@ void MainWindow::updateNotificationStatus() {
 
                     QString typeStr = (n.type == "finished_generation") ? tr("Finished Generation") : tr("Finished");
                     QLabel* summary =
-                        new QLabel(QString("<b>Book:</b> %1<br><b>Status:</b> %2<br><b>Target ID:</b> %3")
-                                       .arg(bookName, typeStr, QString::number(n.targetId)));
+                        new QLabel(QString("<b>Book:</b> %1<br><b>Status:</b> %2<br><b>%3:</b> %4 (%5)")
+                                       .arg(bookName, typeStr, displayTargetType, targetTitle, QString::number(n.targetId)));
                     summary->setWordWrap(true);
                     layout->addWidget(summary);
 


### PR DESCRIPTION
This PR makes notifications significantly more user-friendly by retrieving and displaying the target title instead of just the bare ID. It correctly discriminates between 'document' and 'message' target types, fetching the title dynamically from `BookDatabase`, and updates the associated menu items and popup dialog labels.

---
*PR created automatically by Jules for task [14530261793104132006](https://jules.google.com/task/14530261793104132006) started by @arran4*