### PR TITLE
Automatically dismiss finished_generation notifications when opening a document

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -4025,6 +4025,7 @@ void MainWindow::onOpenBooksSelectionChanged(const QItemSelection& selected, con
             } else if (currentDb) {
                 // If it was marked as updated via AI notification modifications, dismiss it
                 currentDb->dismissNotificationByTargetAndType(currentDocumentId, "document", "updated");
+                currentDb->dismissNotificationByTargetAndType(currentDocumentId, "document", "finished_generation");
                 updateNotificationStatus();
 
                 QList<DocumentNode> docs =
@@ -5300,6 +5301,7 @@ void MainWindow::onOpenBooksTreeDoubleClicked(const QModelIndex& index) {
         int docId = item->data(Qt::UserRole).toInt();
 
         currentDb->dismissNotificationByTargetAndType(docId, "document", "updated");
+        currentDb->dismissNotificationByTargetAndType(docId, "document", "finished_generation");
         updateNotificationStatus();
 
         QList<DocumentNode> docs;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -4024,9 +4024,7 @@ void MainWindow::onOpenBooksSelectionChanged(const QItemSelection& selected, con
                 mainContentStack->setCurrentWidget(docContainer);
             } else if (currentDb) {
                 // If it was marked as updated via AI notification modifications, dismiss it
-                currentDb->dismissNotificationByTargetAndType(currentDocumentId, "document", "updated");
-                currentDb->dismissNotificationByTargetAndType(currentDocumentId, "document", "finished_generation");
-                updateNotificationStatus();
+                dismissDocumentNotifications(currentDocumentId);
 
                 QList<DocumentNode> docs =
                     (type == "template") ? currentDb->getTemplates()
@@ -4449,6 +4447,15 @@ void MainWindow::updateQueueStatus() {
 /** * @brief Fills the notification tray menu indicating task progress states. *  * This function is an integral
  * component of the MainWindow class structure. * It ensures that side effects map accurately to internal application
  * models. */
+void MainWindow::dismissDocumentNotifications(int docId) {
+    if (!currentDb) {
+        return;
+    }
+    currentDb->dismissNotificationByTargetAndType(docId, "document", "updated");
+    currentDb->dismissNotificationByTargetAndType(docId, "document", "finished_generation");
+    updateNotificationStatus();
+}
+
 void MainWindow::updateNotificationStatus() {
     int total = 0;
     notificationMenu->clear();
@@ -5300,9 +5307,7 @@ void MainWindow::onOpenBooksTreeDoubleClicked(const QModelIndex& index) {
     if (type == "document" || type == "template" || type == "draft") {
         int docId = item->data(Qt::UserRole).toInt();
 
-        currentDb->dismissNotificationByTargetAndType(docId, "document", "updated");
-        currentDb->dismissNotificationByTargetAndType(docId, "document", "finished_generation");
-        updateNotificationStatus();
+        dismissDocumentNotifications(docId);
 
         QList<DocumentNode> docs;
         if (type == "document")

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -122,6 +122,7 @@ class MainWindow : public KXmlGuiWindow {
     void onOpenBooksSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
     void updateQueueStatus();
     void updateNotificationStatus();
+    void dismissDocumentNotifications(int docId);
     void showNotificationMenu();
     void showQueueWindow();
     void showSpyWindow();


### PR DESCRIPTION
Currently, when a user double clicks or selects a document from the tree view, only notifications of type `updated` are automatically dismissed. The user requested that we automatically dismiss the notification if you open a document that has a notification against it (that does not require user action). 

Because `finished_generation` is another background notification type that does not require user interaction (unlike `review_needed` or `error`), we now dismiss both `updated` and `finished_generation` notifications when a document is opened.

---
*PR created automatically by Jules for task [9566028435619854090](https://jules.google.com/task/9566028435619854090) started by @arran4*