### PR TITLE
Fix Ctrl+N shortcut selection behavior and add Ctrl+M for merge

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2424,7 +2424,7 @@ void MainWindow::addPhantomItem(QStandardItem* folderItem, const QString& type) 
     folderItem->appendRow(phantomItem);
 
     openBooksTree->setExpanded(folderItem->index(), true);
-    openBooksTree->setCurrentIndex(phantomItem->index());
+    openBooksTree->selectionModel()->select(phantomItem->index(), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Current);
 }
 
 /** * @brief Executes logic for loadSession. This function manages component initialization and handles state
@@ -3988,6 +3988,7 @@ void MainWindow::onOpenBooksSelectionChanged(const QItemSelection& selected, con
         multiSelectionLayout->addWidget(previewBtn);
 
         QPushButton* mergeBtn = new QPushButton(QIcon::fromTheme("merge"), tr("Merge Documents with AI..."));
+        mergeBtn->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_M));
         connect(mergeBtn, &QPushButton::clicked, this, &MainWindow::onMergeDocumentsSelected);
         multiSelectionLayout->addWidget(mergeBtn);
 


### PR DESCRIPTION
The user reported that pressing `Ctrl+N` while having multiple items selected (or when holding Ctrl) unintentionally opened the Merge Documents view instead of creating a new item. This occurred because `setCurrentIndex` does not clear previous selections in a view with `ExtendedSelection`, causing the UI to think multiple items were selected.

This commit resolves the issue by:
1. Explicitly clearing the selection in `addPhantomItem` when adding a new context item.
2. Assigning the requested `Ctrl+M` shortcut to the Merge button, which is only instantiated when multiple documents are selected.

---
*PR created automatically by Jules for task [14692724397275135953](https://jules.google.com/task/14692724397275135953) started by @arran4*