### PR TITLE
Fix lint issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
           git config --global --add safe.directory /__w/kllamabooks/kllamabooks
       - uses: actions/checkout@v4
       - run: sudo apt-get update
-      - run: sudo apt-get install -y cmake ninja-build build-essential qt6-base-dev qt6-svg-dev qt6-tools-dev qt6-tools-dev-tools libkf6wallet-dev libkf6notifications-dev libkf6coreaddons-dev libkf6xmlgui-dev libkf6configwidgets-dev libkf6i18n-dev clang-format cppcheck
+      - run: sudo apt-get install -y cmake ninja-build build-essential qt6-base-dev qt6-svg-dev qt6-tools-dev qt6-tools-dev-tools libkf6wallet-dev libkf6notifications-dev libkf6coreaddons-dev libkf6xmlgui-dev libkf6configwidgets-dev libkf6i18n-dev clang-format cppcheck pkg-config libsqlcipher-dev
       - name: Lint style and static checks
         run: |
           find src \( -name '*.cpp' -o -name '*.cc' -o -name '*.h' -o -name '*.hpp' \) -print0 | xargs -0 -r clang-format --dry-run --Werror || true

--- a/src/AIOperationsDialog.cpp
+++ b/src/AIOperationsDialog.cpp
@@ -1,16 +1,16 @@
 #include "AIOperationsDialog.h"
 
 #include <QComboBox>
+#include <QDialog>
+#include <QFormLayout>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QLineEdit>
 #include <QPushButton>
+#include <QRegularExpression>
 #include <QSettings>
 #include <QTextEdit>
 #include <QVBoxLayout>
-#include <QRegularExpression>
-#include <QDialog>
-#include <QFormLayout>
-#include <QLineEdit>
 
 #include "AIOperationsManager.h"
 

--- a/src/AIOperationsDialog.h
+++ b/src/AIOperationsDialog.h
@@ -18,9 +18,7 @@ struct DynamicInputInfo {
     bool operator==(const DynamicInputInfo& other) const {
         return fullMatch == other.fullMatch && type == other.type && label == other.label;
     }
-    bool operator!=(const DynamicInputInfo& other) const {
-        return !(*this == other);
-    }
+    bool operator!=(const DynamicInputInfo& other) const { return !(*this == other); }
 };
 
 class AIOperationsDialog : public QDialog {

--- a/src/AIOperationsManager.cpp
+++ b/src/AIOperationsManager.cpp
@@ -3,8 +3,8 @@
 QList<AIOperation> AIOperationsManager::getBuiltInOperations() {
     QList<AIOperation> ops;
     ops.append({"complete", "Complete this text",
-                "Complete the following text naturally. Only output the continuation.\n\nText:\n{context}",
-                "built-in", "single"});
+                "Complete the following text naturally. Only output the continuation.\n\nText:\n{context}", "built-in",
+                "single"});
     ops.append({"replace", "Replace entirely",
                 "Rewrite the following document according to your instructions. Only output the rewritten document, "
                 "nothing else.\n\nInstructions: {textarea}\n\nDocument:\n{context}",
@@ -14,7 +14,8 @@ QList<AIOperation> AIOperationsManager::getBuiltInOperations() {
                 "else.\n\nInstructions: {textarea}\n\nText:\n{context}",
                 "built-in", "single"});
     ops.append({"merge", "Merge Documents",
-                "Merge the following documents into one coherent document:\n\n{foreach contexts}\nDocument:\n{context}\n{between}\n---\n{end}",
+                "Merge the following documents into one coherent document:\n\n{foreach "
+                "contexts}\nDocument:\n{context}\n{between}\n---\n{end}",
                 "built-in", "multiple"});
     return ops;
 }

--- a/src/AIOperationsManager.h
+++ b/src/AIOperationsManager.h
@@ -14,8 +14,8 @@ struct AIOperation {
     QString id;
     QString name;
     QString prompt;
-    QString source;  // "built-in", "global", "database"
-    QString inputType; // "single", "multiple", "any"
+    QString source;     // "built-in", "global", "database"
+    QString inputType;  // "single", "multiple", "any"
 };
 
 class AIOperationsManager {

--- a/src/AiActionDialog.cpp
+++ b/src/AiActionDialog.cpp
@@ -1,13 +1,13 @@
 #include "AiActionDialog.h"
 
 #include <QDialogButtonBox>
+#include <QFormLayout>
 #include <QHBoxLayout>
 #include <QLabel>
-#include <QVBoxLayout>
-#include <QRegularExpression>
-#include <QFormLayout>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QRegularExpression>
+#include <QVBoxLayout>
 
 AiActionDialog::AiActionDialog(const QString& title, const QString& labelText, const QString& defaultTemplate,
                                const QString& contextText, QWidget* parent)
@@ -22,7 +22,8 @@ AiActionDialog::AiActionDialog(const QString& title, const QString& labelText, c
     layout->addWidget(instructionLabel);
 
     m_instructionEdit = new QTextEdit(this);
-    m_instructionEdit->setPlaceholderText("Configure prompt using {context}, {input \"label\"}, or {textarea \"label\"} placeholders...");
+    m_instructionEdit->setPlaceholderText(
+        "Configure prompt using {context}, {input \"label\"}, or {textarea \"label\"} placeholders...");
     m_instructionEdit->setAcceptRichText(false);
     m_instructionEdit->setPlainText(defaultTemplate);
     layout->addWidget(m_instructionEdit);
@@ -51,9 +52,7 @@ AiActionDialog::AiActionDialog(const QString& title, const QString& labelText, c
     updateDynamicInputs();
 }
 
-QString AiActionDialog::getPrompt() const {
-    return m_finalPrompt;
-}
+QString AiActionDialog::getPrompt() const { return m_finalPrompt; }
 
 void AiActionDialog::updateDynamicInputs() {
     QString prompt = m_instructionEdit->toPlainText();

--- a/src/AiActionDialog.h
+++ b/src/AiActionDialog.h
@@ -18,9 +18,7 @@ struct AiDynamicInputInfo {
     bool operator==(const AiDynamicInputInfo& other) const {
         return fullMatch == other.fullMatch && type == other.type && label == other.label;
     }
-    bool operator!=(const AiDynamicInputInfo& other) const {
-        return !(*this == other);
-    }
+    bool operator!=(const AiDynamicInputInfo& other) const { return !(*this == other); }
 };
 
 class AiActionDialog : public QDialog {

--- a/src/BookDatabase.cpp
+++ b/src/BookDatabase.cpp
@@ -574,7 +574,7 @@ QString BookDatabase::getSetting(const QString& scope, int targetId, const QStri
 
     QString result = defaultValue;
     if (sqlite3_step(stmt) == SQLITE_ROW) {
-        result = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 0));
+        result = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0)));
     }
 
     sqlite3_finalize(stmt);
@@ -677,10 +677,10 @@ std::optional<BookDatabase::DocumentMergeEntry> BookDatabase::getDocumentMerge(i
         DocumentMergeEntry entry;
         entry.id = sqlite3_column_int(stmt, 0);
         entry.documentId = sqlite3_column_int(stmt, 1);
-        entry.sourceDocumentIds = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
-        entry.prompt = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
-        entry.model = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
-        entry.timestamp = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 5));
+        entry.sourceDocumentIds = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2)));
+        entry.prompt = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3)));
+        entry.model = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 4)));
+        entry.timestamp = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 5)));
         entry.versionHistoryId = sqlite3_column_int(stmt, 6);
 
         sqlite3_finalize(stmt);
@@ -738,9 +738,9 @@ QList<BookDatabase::DocumentHistoryEntry> BookDatabase::getDocumentHistory(int d
     while (sqlite3_step(stmt) == SQLITE_ROW) {
         DocumentHistoryEntry item;
         item.id = sqlite3_column_int(stmt, 0);
-        item.actionType = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 1));
-        item.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
-        item.timestamp = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
+        item.actionType = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1)));
+        item.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2)));
+        item.timestamp = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3)));
         items.append(item);
     }
 
@@ -871,9 +871,9 @@ QList<MessageNode> BookDatabase::getMessages() const {
         node.id = sqlite3_column_int(stmt, 0);
         node.parentId = sqlite3_column_int(stmt, 1);
         node.folderId = sqlite3_column_int(stmt, 2);
-        node.role = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
-        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
-        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 5));
+        node.role = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3)));
+        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 4)));
+        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 5)));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         node.isExpanded = sqlite3_column_int(stmt, 6) != 0;
         nodes.append(node);
@@ -942,9 +942,9 @@ std::optional<DocumentNode> BookDatabase::getDocument(int id) const {
         node.isFolder = false;
         node.id = sqlite3_column_int(stmt, 0);
         node.folderId = sqlite3_column_int(stmt, 1);
-        node.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
-        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
-        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
+        node.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2)));
+        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3)));
+        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 4)));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         node.parentId = sqlite3_column_int(stmt, 5);
 
@@ -981,9 +981,9 @@ QList<DocumentNode> BookDatabase::getDocuments(int folderId) const {
         DocumentNode node;
         node.id = sqlite3_column_int(stmt, 0);
         node.folderId = sqlite3_column_int(stmt, 1);
-        node.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
-        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
-        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
+        node.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2)));
+        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3)));
+        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 4)));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         node.parentId = sqlite3_column_int(stmt, 5);
 
@@ -1071,9 +1071,9 @@ QList<NoteNode> BookDatabase::getNotes(int folderId) const {
         NoteNode node;
         node.id = sqlite3_column_int(stmt, 0);
         node.folderId = sqlite3_column_int(stmt, 1);
-        node.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
-        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
-        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
+        node.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2)));
+        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3)));
+        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 4)));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         nodes.append(node);
     }
@@ -1150,9 +1150,9 @@ QList<DocumentNode> BookDatabase::getTemplates(int folderId) const {
         DocumentNode node;
         node.id = sqlite3_column_int(stmt, 0);
         node.folderId = sqlite3_column_int(stmt, 1);
-        node.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
-        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
-        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
+        node.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2)));
+        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3)));
+        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 4)));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         node.isFolder = false;
         nodes.append(node);
@@ -1222,12 +1222,12 @@ QList<DocumentNode> BookDatabase::getDrafts(int folderId) const {
         DocumentNode node;
         node.id = sqlite3_column_int(stmt, 0);
         node.folderId = sqlite3_column_int(stmt, 1);
-        node.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
-        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
-        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
+        node.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2)));
+        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3)));
+        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 4)));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         node.parentId = sqlite3_column_int(stmt, 5);
-        node.targetType = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 6));
+        node.targetType = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 6)));
         node.isFolder = false;
         nodes.append(node);
     }
@@ -1340,9 +1340,9 @@ QList<FolderNode> BookDatabase::getFolders(const QString& type) const {
         FolderNode node;
         node.id = sqlite3_column_int(stmt, 0);
         node.parentId = sqlite3_column_int(stmt, 1);
-        node.name = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
-        node.type = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
-        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
+        node.name = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2)));
+        node.type = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3)));
+        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 4)));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         node.position = sqlite3_column_int(stmt, 5);
         node.isExpanded = sqlite3_column_int(stmt, 6) != 0;
@@ -1417,7 +1417,7 @@ BookDatabase::QueueStats BookDatabase::getQueueStats() const {
     if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return stats;
 
     while (sqlite3_step(stmt) == SQLITE_ROW) {
-        QString state = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 0));
+        QString state = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0)));
         int count = sqlite3_column_int(stmt, 1);
 
         if (state == "pending") {
@@ -1471,15 +1471,15 @@ QList<QueueItem> BookDatabase::getQueue() const {
         QueueItem item;
         item.id = sqlite3_column_int(stmt, 0);
         item.messageId = sqlite3_column_int(stmt, 1);
-        item.model = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
-        item.prompt = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
+        item.model = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2)));
+        item.prompt = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3)));
         item.processingId = sqlite3_column_int(stmt, 4);
         const unsigned char* errorText = sqlite3_column_text(stmt, 5);
         if (errorText) item.lastError = QString::fromUtf8(reinterpret_cast<const char*>(errorText));
         item.priority = sqlite3_column_int(stmt, 6);
         item.timestamp = QDateTime::fromString(
             QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 7)), Qt::ISODate);
-        item.targetType = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 8));
+        item.targetType = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 8)));
         if (item.targetType.isEmpty()) item.targetType = "message";
         const unsigned char* stateText = sqlite3_column_text(stmt, 9);
         if (stateText) item.state = QString::fromUtf8(reinterpret_cast<const char*>(stateText));
@@ -1589,8 +1589,8 @@ QList<Notification> BookDatabase::getNotifications(bool includeDismissed) const 
         Notification n;
         n.id = sqlite3_column_int(stmt, 0);
         n.targetId = sqlite3_column_int(stmt, 1);
-        n.targetType = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
-        n.type = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
+        n.targetType = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2)));
+        n.type = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3)));
         n.isDismissed = sqlite3_column_int(stmt, 4) != 0;
         n.timestamp = QDateTime::fromString(
             QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 5)), Qt::ISODate);
@@ -1719,9 +1719,9 @@ QList<CommentNode> BookDatabase::getComments(const QString& entityType, int enti
     while (sqlite3_step(stmt) == SQLITE_ROW) {
         CommentNode item;
         item.id = sqlite3_column_int(stmt, 0);
-        item.entityType = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 1));
+        item.entityType = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1)));
         item.entityId = sqlite3_column_int(stmt, 2);
-        item.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
+        item.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3)));
         item.timestamp = QDateTime::fromString(
             QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4)), Qt::ISODate);
         items.append(item);
@@ -1761,19 +1761,19 @@ ChatNode BookDatabase::getChat(int messageId) const {
 
         if (sqlite3_step(stmt) == SQLITE_ROW) {
             if (sqlite3_column_text(stmt, 0))
-                chat.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 0));
+                chat.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0)));
             if (sqlite3_column_text(stmt, 1))
-                chat.systemPrompt = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 1));
+                chat.systemPrompt = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1)));
             if (sqlite3_column_text(stmt, 2))
-                chat.sendBehavior = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
+                chat.sendBehavior = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2)));
             if (sqlite3_column_text(stmt, 3))
-                chat.model = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
+                chat.model = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3)));
             if (sqlite3_column_text(stmt, 4))
-                chat.multiLine = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
+                chat.multiLine = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 4)));
             if (sqlite3_column_text(stmt, 5))
-                chat.draftPrompt = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 5));
+                chat.draftPrompt = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 5)));
             if (sqlite3_column_text(stmt, 6))
-                chat.userNote = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 6));
+                chat.userNote = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 6)));
             chat.version = sqlite3_column_int(stmt, 7);
         }
         sqlite3_finalize(stmt);

--- a/src/BookDatabase.cpp
+++ b/src/BookDatabase.cpp
@@ -948,7 +948,7 @@ std::optional<DocumentNode> BookDatabase::getDocument(int id) const {
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         node.parentId = sqlite3_column_int(stmt, 5);
 
-        const char* metadataText = reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 6);
+        const char* metadataText = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 6));
         if (metadataText) {
             node.metadata = QString::fromUtf8(metadataText);
         }
@@ -987,7 +987,7 @@ QList<DocumentNode> BookDatabase::getDocuments(int folderId) const {
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         node.parentId = sqlite3_column_int(stmt, 5);
 
-        const char* metadataText = reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 6);
+        const char* metadataText = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 6));
         if (metadataText) {
             node.metadata = QString::fromUtf8(metadataText);
         }
@@ -1478,7 +1478,7 @@ QList<QueueItem> BookDatabase::getQueue() const {
         if (errorText) item.lastError = QString::fromUtf8(reinterpret_cast<const char*>(errorText));
         item.priority = sqlite3_column_int(stmt, 6);
         item.timestamp = QDateTime::fromString(
-            QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 7)), Qt::ISODate);
+            QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 7))), Qt::ISODate);
         item.targetType = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 8)));
         if (item.targetType.isEmpty()) item.targetType = "message";
         const unsigned char* stateText = sqlite3_column_text(stmt, 9);
@@ -1593,7 +1593,7 @@ QList<Notification> BookDatabase::getNotifications(bool includeDismissed) const 
         n.type = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3)));
         n.isDismissed = sqlite3_column_int(stmt, 4) != 0;
         n.timestamp = QDateTime::fromString(
-            QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 5)), Qt::ISODate);
+            QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 5))), Qt::ISODate);
         notifications.append(n);
     }
     sqlite3_finalize(stmt);
@@ -1723,7 +1723,7 @@ QList<CommentNode> BookDatabase::getComments(const QString& entityType, int enti
         item.entityId = sqlite3_column_int(stmt, 2);
         item.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 3)));
         item.timestamp = QDateTime::fromString(
-            QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4)), Qt::ISODate);
+            QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 4))), Qt::ISODate);
         items.append(item);
     }
 

--- a/src/BookDatabase.cpp
+++ b/src/BookDatabase.cpp
@@ -24,16 +24,16 @@ BookDatabase::~BookDatabase() { close(); }
 bool BookDatabase::open(const QString& password) {
     if (m_isOpen) return true;
 
-    int rc = sqlite3_open(m_filepath.toUtf8().constData(), (sqlite3**)&m_db);
+    int rc = sqlite3_open(m_filepath.toUtf8().constData(), reinterpret_cast<sqlite3**>(&m_db));
     if (rc != SQLITE_OK) {
-        qWarning() << "Cannot open database: " << sqlite3_errmsg((sqlite3*)m_db);
+        qWarning() << "Cannot open database: " << sqlite3_errmsg(reinterpret_cast<sqlite3*>(m_db));
         return false;
     }
 
     if (!password.isEmpty()) {
         QString keyPragma = QString("PRAGMA key = '%1';").arg(password);
         char* errMsg = nullptr;
-        rc = sqlite3_exec((sqlite3*)m_db, keyPragma.toUtf8().constData(), nullptr, nullptr, &errMsg);
+        rc = sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), keyPragma.toUtf8().constData(), nullptr, nullptr, &errMsg);
         if (rc != SQLITE_OK) {
             qWarning() << "Failed to set key: " << errMsg;
             sqlite3_free(errMsg);
@@ -44,7 +44,8 @@ bool BookDatabase::open(const QString& password) {
 
     // Verify key works
     char* errMsg = nullptr;
-    rc = sqlite3_exec((sqlite3*)m_db, "SELECT count(*) FROM sqlite_master;", nullptr, nullptr, &errMsg);
+    rc = sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "SELECT count(*) FROM sqlite_master;", nullptr, nullptr,
+                      &errMsg);
     if (rc != SQLITE_OK) {
         qWarning() << "Invalid password or corrupted database: " << errMsg;
         sqlite3_free(errMsg);
@@ -64,11 +65,10 @@ void BookDatabase::cleanupDeadProcessingItems() {
     if (!m_isOpen) return;
 
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db,
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db),
                            "SELECT id, processing_id, last_error FROM queue WHERE processing_id > 0 OR state = "
                            "'processing' OR (last_error IS NOT NULL AND last_error != '' AND state != 'error');",
-                           -1,
-                           &stmt, nullptr) == SQLITE_OK) {
+                           -1, &stmt, nullptr) == SQLITE_OK) {
         struct ItemToReset {
             int id;
             QString error;
@@ -78,7 +78,7 @@ void BookDatabase::cleanupDeadProcessingItems() {
             int id = sqlite3_column_int(stmt, 0);
             int pid = sqlite3_column_int(stmt, 1);
             const unsigned char* errText = sqlite3_column_text(stmt, 2);
-            QString lastError = errText ? QString::fromUtf8((const char*)errText) : QString();
+            QString lastError = errText ? QString::fromUtf8(reinterpret_cast<const char*>(errText)) : QString();
 
             if (pid <= 0) {
                 itemsToReset.append({id, lastError});
@@ -120,7 +120,7 @@ void BookDatabase::cleanupDeadProcessingItems() {
 
 void BookDatabase::close() {
     if (m_db) {
-        sqlite3_close((sqlite3*)m_db);
+        sqlite3_close(reinterpret_cast<sqlite3*>(m_db));
         m_db = nullptr;
         m_isOpen = false;
     }
@@ -137,7 +137,7 @@ bool BookDatabase::initSchema() {
     int userVersion = 0;
 
     // Get existing PRAGMA version for legacy support
-    if (sqlite3_prepare_v2((sqlite3*)m_db, "PRAGMA user_version;", -1, &stmt, nullptr) == SQLITE_OK) {
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version;", -1, &stmt, nullptr) == SQLITE_OK) {
         if (sqlite3_step(stmt) == SQLITE_ROW) {
             userVersion = sqlite3_column_int(stmt, 0);
         }
@@ -145,7 +145,7 @@ bool BookDatabase::initSchema() {
     }
 
     bool hasSchemaTable = false;
-    if (sqlite3_prepare_v2((sqlite3*)m_db,
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db),
                            "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_version';", -1, &stmt,
                            nullptr) == SQLITE_OK) {
         if (sqlite3_step(stmt) == SQLITE_ROW) {
@@ -158,15 +158,15 @@ bool BookDatabase::initSchema() {
         const char* createSchemaTable =
             "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY, applied_at DATETIME DEFAULT "
             "CURRENT_TIMESTAMP);";
-        sqlite3_exec((sqlite3*)m_db, createSchemaTable, nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), createSchemaTable, nullptr, nullptr, nullptr);
         // Sync PRAGMA version to table if table was just created
         if (userVersion > 0) {
             QString syncSql = QString("INSERT OR REPLACE INTO schema_version (version) VALUES (%1);").arg(userVersion);
-            sqlite3_exec((sqlite3*)m_db, syncSql.toUtf8().constData(), nullptr, nullptr, nullptr);
+            sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), syncSql.toUtf8().constData(), nullptr, nullptr, nullptr);
         }
     } else {
-        if (sqlite3_prepare_v2((sqlite3*)m_db, "SELECT MAX(version) FROM schema_version;", -1, &stmt, nullptr) ==
-            SQLITE_OK) {
+        if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), "SELECT MAX(version) FROM schema_version;", -1, &stmt,
+                               nullptr) == SQLITE_OK) {
             if (sqlite3_step(stmt) == SQLITE_ROW) {
                 int tableVersion = sqlite3_column_int(stmt, 0);
                 if (tableVersion > userVersion) userVersion = tableVersion;
@@ -231,26 +231,26 @@ bool BookDatabase::initSchema() {
             "INSERT INTO schema_version (version) VALUES (1);";
 
         char* errMsg = nullptr;
-        int rc = sqlite3_exec((sqlite3*)m_db, sql, nullptr, nullptr, &errMsg);
+        int rc = sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), sql, nullptr, nullptr, &errMsg);
         if (rc != SQLITE_OK) {
             qWarning() << "SQL error during schema init: " << errMsg;
             sqlite3_free(errMsg);
             return false;
         }
 
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 1;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 1;", nullptr, nullptr, nullptr);
         userVersion = 1;
     }
 
     if (userVersion < 2) {
         // upgrade to version 2 - Ensure settings table exists (redundant but safe)
-        sqlite3_exec((sqlite3*)m_db,
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db),
                      "CREATE TABLE IF NOT EXISTS settings (scope TEXT, target_id INTEGER, key TEXT, value TEXT, "
                      "PRIMARY KEY(scope, target_id, key));",
                      nullptr, nullptr, nullptr);
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (2);", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 2;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (2);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 2;", nullptr, nullptr, nullptr);
         userVersion = 2;
     }
 
@@ -264,26 +264,26 @@ bool BookDatabase::initSchema() {
             "CREATE TABLE IF NOT EXISTS folders (id INTEGER PRIMARY KEY AUTOINCREMENT, parent_id INTEGER DEFAULT 0, "
             "name TEXT, type TEXT, timestamp DATETIME DEFAULT CURRENT_TIMESTAMP, position INTEGER DEFAULT 0);";
 
-        sqlite3_exec((sqlite3*)m_db, sql, nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), sql, nullptr, nullptr, nullptr);
 
         // Add folder_id columns if they don't exist
-        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE documents ADD COLUMN folder_id INTEGER DEFAULT 0;", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE notes ADD COLUMN folder_id INTEGER DEFAULT 0;", nullptr, nullptr,
-                     nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "ALTER TABLE documents ADD COLUMN folder_id INTEGER DEFAULT 0;",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "ALTER TABLE notes ADD COLUMN folder_id INTEGER DEFAULT 0;",
+                     nullptr, nullptr, nullptr);
 
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (3);", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 3;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (3);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 3;", nullptr, nullptr, nullptr);
         userVersion = 3;
     }
 
     if (userVersion < 4) {
-        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE messages ADD COLUMN folder_id INTEGER DEFAULT 0;", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (4);", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 4;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "ALTER TABLE messages ADD COLUMN folder_id INTEGER DEFAULT 0;",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (4);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 4;", nullptr, nullptr, nullptr);
         userVersion = 4;
     }
 
@@ -305,19 +305,20 @@ bool BookDatabase::initSchema() {
             "is_dismissed BOOLEAN DEFAULT 0, "
             "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"
             ");";
-        sqlite3_exec((sqlite3*)m_db, sql, nullptr, nullptr, nullptr);
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (5);", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 5;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), sql, nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (5);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 5;", nullptr, nullptr, nullptr);
         userVersion = 5;
     }
 
     if (userVersion < 6) {
         // Clean up old completed jobs since they are now memory-only
-        sqlite3_exec((sqlite3*)m_db, "DELETE FROM queue WHERE status = 'completed';", nullptr, nullptr, nullptr);
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (6);", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 6;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "DELETE FROM queue WHERE status = 'completed';", nullptr,
+                     nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (6);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 6;", nullptr, nullptr, nullptr);
         userVersion = 6;
     }
 
@@ -330,37 +331,37 @@ bool BookDatabase::initSchema() {
             "content TEXT, "
             "created_at DATETIME DEFAULT CURRENT_TIMESTAMP"
             ");";
-        sqlite3_exec((sqlite3*)m_db, sql, nullptr, nullptr, nullptr);
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (7);", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 7;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), sql, nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (7);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 7;", nullptr, nullptr, nullptr);
         userVersion = 7;
     }
 
     if (userVersion < 8) {
-        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE documents ADD COLUMN parent_id INTEGER DEFAULT 0;", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (8);", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 8;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "ALTER TABLE documents ADD COLUMN parent_id INTEGER DEFAULT 0;",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (8);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 8;", nullptr, nullptr, nullptr);
         userVersion = 8;
     }
 
     if (userVersion < 9) {
-        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE queue ADD COLUMN target_type TEXT DEFAULT 'message';", nullptr,
-                     nullptr, nullptr);
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (9);", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 9;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db),
+                     "ALTER TABLE queue ADD COLUMN target_type TEXT DEFAULT 'message';", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (9);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 9;", nullptr, nullptr, nullptr);
         userVersion = 9;
     }
 
     if (userVersion < 10) {
-        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE queue ADD COLUMN processing_pid INTEGER DEFAULT 0;", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (10);", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 10;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "ALTER TABLE queue ADD COLUMN processing_pid INTEGER DEFAULT 0;",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (10);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 10;", nullptr, nullptr, nullptr);
         userVersion = 10;
     }
 
@@ -381,11 +382,11 @@ bool BookDatabase::initSchema() {
             "SELECT id, message_id, model, prompt, processing_pid, priority, created_at, target_type FROM queue;"
             "DROP TABLE queue;"
             "ALTER TABLE queue_new RENAME TO queue;";
-        sqlite3_exec((sqlite3*)m_db, sql, nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), sql, nullptr, nullptr, nullptr);
 
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (11);", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 11;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (11);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 11;", nullptr, nullptr, nullptr);
         userVersion = 11;
     }
 
@@ -402,16 +403,17 @@ bool BookDatabase::initSchema() {
             "userNote TEXT, "
             "version INTEGER DEFAULT 0"
             ");";
-        sqlite3_exec((sqlite3*)m_db, sql, nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), sql, nullptr, nullptr, nullptr);
 
-        sqlite3_stmt* stmt;
-        if (sqlite3_prepare_v2((sqlite3*)m_db, "SELECT DISTINCT target_id FROM settings WHERE scope='chat';", -1, &stmt,
+        sqlite3_stmt* inner_stmt = nullptr;
+        if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db),
+                               "SELECT DISTINCT target_id FROM settings WHERE scope='chat';", -1, &inner_stmt,
                                nullptr) == SQLITE_OK) {
             QList<int> messageIds;
-            while (sqlite3_step(stmt) == SQLITE_ROW) {
-                messageIds.append(sqlite3_column_int(stmt, 0));
+            while (sqlite3_step(inner_stmt) == SQLITE_ROW) {
+                messageIds.append(sqlite3_column_int(inner_stmt, 0));
             }
-            sqlite3_finalize(stmt);
+            sqlite3_finalize(inner_stmt);
 
             for (int id : messageIds) {
                 ChatNode c;
@@ -428,10 +430,11 @@ bool BookDatabase::initSchema() {
             }
         }
 
-        sqlite3_exec((sqlite3*)m_db, "DELETE FROM settings WHERE scope='chat';", nullptr, nullptr, nullptr);
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (12);", nullptr, nullptr,
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "DELETE FROM settings WHERE scope='chat';", nullptr, nullptr,
                      nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 12;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (12);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 12;", nullptr, nullptr, nullptr);
         userVersion = 12;
     }
 
@@ -444,67 +447,77 @@ bool BookDatabase::initSchema() {
             "content TEXT, "
             "timestamp DATETIME DEFAULT CURRENT_TIMESTAMP"
             ");";
-        sqlite3_exec((sqlite3*)m_db, sql_history, nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), sql_history, nullptr, nullptr, nullptr);
 
         const char* sql_alter_state = "ALTER TABLE queue ADD COLUMN state TEXT DEFAULT 'pending';";
-        sqlite3_exec((sqlite3*)m_db, sql_alter_state, nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), sql_alter_state, nullptr, nullptr, nullptr);
 
         const char* sql_alter_response = "ALTER TABLE queue ADD COLUMN response TEXT DEFAULT '';";
-        sqlite3_exec((sqlite3*)m_db, sql_alter_response, nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), sql_alter_response, nullptr, nullptr, nullptr);
 
         const char* sql_alter_parent = "ALTER TABLE queue ADD COLUMN parent_id INTEGER DEFAULT 0;";
-        sqlite3_exec((sqlite3*)m_db, sql_alter_parent, nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), sql_alter_parent, nullptr, nullptr, nullptr);
 
-        sqlite3_exec((sqlite3*)m_db, "UPDATE queue SET state = 'processing' WHERE processing_id > 0;", nullptr, nullptr,
-                     nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "UPDATE queue SET state = 'processing' WHERE processing_id > 0;",
+                     nullptr, nullptr, nullptr);
 
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (13);", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 13;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (13);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 13;", nullptr, nullptr, nullptr);
         userVersion = 13;
     }
 
     if (userVersion < 14) {
         const char* sql_alter_target = "ALTER TABLE queue ADD COLUMN target_action TEXT DEFAULT '';";
-        sqlite3_exec((sqlite3*)m_db, sql_alter_target, nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), sql_alter_target, nullptr, nullptr, nullptr);
 
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (14);", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 14;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (14);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 14;", nullptr, nullptr, nullptr);
         userVersion = 14;
     }
 
     if (userVersion < 15) {
-        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE notifications RENAME COLUMN message_id TO target_id;", nullptr, nullptr, nullptr);
-        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE notifications ADD COLUMN target_type TEXT DEFAULT 'message';", nullptr, nullptr, nullptr);
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (15);", nullptr, nullptr, nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 15;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db),
+                     "ALTER TABLE notifications RENAME COLUMN message_id TO target_id;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db),
+                     "ALTER TABLE notifications ADD COLUMN target_type TEXT DEFAULT 'message';", nullptr, nullptr,
+                     nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (15);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 15;", nullptr, nullptr, nullptr);
         userVersion = 15;
     }
 
     if (userVersion < 16) {
-        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE drafts ADD COLUMN parent_id INTEGER DEFAULT 0;", nullptr, nullptr, nullptr);
-        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE drafts ADD COLUMN target_type TEXT DEFAULT 'document';", nullptr, nullptr, nullptr);
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (16);", nullptr, nullptr, nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 16;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "ALTER TABLE drafts ADD COLUMN parent_id INTEGER DEFAULT 0;",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db),
+                     "ALTER TABLE drafts ADD COLUMN target_type TEXT DEFAULT 'document';", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (16);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 16;", nullptr, nullptr, nullptr);
         userVersion = 16;
     }
 
     if (userVersion < 17) {
-        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE folders ADD COLUMN is_expanded BOOLEAN DEFAULT 0;", nullptr, nullptr, nullptr);
-        sqlite3_exec((sqlite3*)m_db, "ALTER TABLE messages ADD COLUMN is_expanded BOOLEAN DEFAULT 0;", nullptr, nullptr, nullptr);
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (17);", nullptr, nullptr, nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 17;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "ALTER TABLE folders ADD COLUMN is_expanded BOOLEAN DEFAULT 0;",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "ALTER TABLE messages ADD COLUMN is_expanded BOOLEAN DEFAULT 0;",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (17);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 17;", nullptr, nullptr, nullptr);
         userVersion = 17;
     }
 
     if (userVersion < 18) {
         const char* sql_alter_documents = "ALTER TABLE documents ADD COLUMN metadata TEXT DEFAULT '';";
-        sqlite3_exec((sqlite3*)m_db, sql_alter_documents, nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), sql_alter_documents, nullptr, nullptr, nullptr);
 
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (18);", nullptr, nullptr,
-                     nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 18;", nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (18);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 18;", nullptr, nullptr, nullptr);
         userVersion = 18;
     }
 
@@ -519,11 +532,11 @@ bool BookDatabase::initSchema() {
             "timestamp DATETIME DEFAULT CURRENT_TIMESTAMP, "
             "version_history_id INTEGER DEFAULT 0"
             ");";
-        sqlite3_exec((sqlite3*)m_db, sql_merges, nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), sql_merges, nullptr, nullptr, nullptr);
 
-        sqlite3_exec((sqlite3*)m_db, "INSERT OR REPLACE INTO schema_version (version) VALUES (19);", nullptr, nullptr, nullptr);
-        sqlite3_exec((sqlite3*)m_db, "PRAGMA user_version = 19;", nullptr, nullptr, nullptr);
-        userVersion = 19;
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "INSERT OR REPLACE INTO schema_version (version) VALUES (19);",
+                     nullptr, nullptr, nullptr);
+        sqlite3_exec(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version = 19;", nullptr, nullptr, nullptr);
     }
 
     return true;
@@ -534,7 +547,7 @@ void BookDatabase::setSetting(const QString& scope, int targetId, const QString&
 
     const char* sql = "INSERT OR REPLACE INTO settings (scope, target_id, key, value) VALUES (?, ?, ?, ?);";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return;
 
     sqlite3_bind_text(stmt, 1, scope.toUtf8().constData(), -1, SQLITE_TRANSIENT);
@@ -552,7 +565,7 @@ QString BookDatabase::getSetting(const QString& scope, int targetId, const QStri
 
     const char* sql = "SELECT value FROM settings WHERE scope = ? AND target_id = ? AND key = ?;";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return defaultValue;
 
     sqlite3_bind_text(stmt, 1, scope.toUtf8().constData(), -1, SQLITE_TRANSIENT);
@@ -561,7 +574,7 @@ QString BookDatabase::getSetting(const QString& scope, int targetId, const QStri
 
     QString result = defaultValue;
     if (sqlite3_step(stmt) == SQLITE_ROW) {
-        result = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 0));
+        result = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 0));
     }
 
     sqlite3_finalize(stmt);
@@ -578,7 +591,8 @@ bool BookDatabase::moveItem(const QString& table, int id, int newFolderId) {
 
     QString sql = QString("UPDATE %1 SET folder_id = ? WHERE id = ?;").arg(safeTable);
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql.toUtf8().constData(), -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql.toUtf8().constData(), -1, &stmt, nullptr) != SQLITE_OK)
+        return false;
 
     sqlite3_bind_int(stmt, 1, newFolderId);
     sqlite3_bind_int(stmt, 2, id);
@@ -592,7 +606,7 @@ bool BookDatabase::moveFolder(int id, int newParentId) {
     if (!m_isOpen) return false;
     const char* sql = "UPDATE folders SET parent_id = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
 
     sqlite3_bind_int(stmt, 1, newParentId);
     sqlite3_bind_int(stmt, 2, id);
@@ -607,7 +621,7 @@ int BookDatabase::addMessage(int parentId, const QString& content, const QString
 
     const char* sql = "INSERT INTO messages (parent_id, folder_id, role, content) VALUES (?, ?, ?, ?);";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return -1;
 
     sqlite3_bind_int(stmt, 1, parentId);
@@ -621,16 +635,19 @@ int BookDatabase::addMessage(int parentId, const QString& content, const QString
         return -1;
     }
 
-    int id = sqlite3_last_insert_rowid((sqlite3*)m_db);
+    int id = sqlite3_last_insert_rowid(reinterpret_cast<sqlite3*>(m_db));
     sqlite3_finalize(stmt);
     return id;
 }
 
-int BookDatabase::addDocumentMerge(int documentId, const QString& sourceDocumentIds, const QString& prompt, const QString& model, int versionHistoryId) {
+int BookDatabase::addDocumentMerge(int documentId, const QString& sourceDocumentIds, const QString& prompt,
+                                   const QString& model, int versionHistoryId) {
     if (!m_isOpen) return -1;
-    const char* sql = "INSERT INTO document_merges (document_id, source_document_ids, prompt, model, version_history_id) VALUES (?, ?, ?, ?, ?);";
+    const char* sql =
+        "INSERT INTO document_merges (document_id, source_document_ids, prompt, model, version_history_id) VALUES (?, "
+        "?, ?, ?, ?);";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return -1;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return -1;
 
     sqlite3_bind_int(stmt, 1, documentId);
     sqlite3_bind_text(stmt, 2, sourceDocumentIds.toUtf8().constData(), -1, SQLITE_TRANSIENT);
@@ -639,7 +656,7 @@ int BookDatabase::addDocumentMerge(int documentId, const QString& sourceDocument
     sqlite3_bind_int(stmt, 5, versionHistoryId);
 
     int rc = sqlite3_step(stmt);
-    int id = (rc == SQLITE_DONE) ? sqlite3_last_insert_rowid((sqlite3*)m_db) : -1;
+    int id = (rc == SQLITE_DONE) ? sqlite3_last_insert_rowid(reinterpret_cast<sqlite3*>(m_db)) : -1;
     sqlite3_finalize(stmt);
     return id;
 }
@@ -647,9 +664,11 @@ int BookDatabase::addDocumentMerge(int documentId, const QString& sourceDocument
 std::optional<BookDatabase::DocumentMergeEntry> BookDatabase::getDocumentMerge(int documentId) const {
     if (!m_isOpen) return std::nullopt;
 
-    QString sqlStr = "SELECT id, document_id, source_document_ids, prompt, model, timestamp, version_history_id FROM document_merges WHERE document_id = ? ORDER BY timestamp DESC LIMIT 1;";
+    QString sqlStr =
+        "SELECT id, document_id, source_document_ids, prompt, model, timestamp, version_history_id FROM "
+        "document_merges WHERE document_id = ? ORDER BY timestamp DESC LIMIT 1;";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sqlStr.toUtf8().constData(), -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sqlStr.toUtf8().constData(), -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return std::nullopt;
 
     sqlite3_bind_int(stmt, 1, documentId);
@@ -658,10 +677,10 @@ std::optional<BookDatabase::DocumentMergeEntry> BookDatabase::getDocumentMerge(i
         DocumentMergeEntry entry;
         entry.id = sqlite3_column_int(stmt, 0);
         entry.documentId = sqlite3_column_int(stmt, 1);
-        entry.sourceDocumentIds = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
-        entry.prompt = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
-        entry.model = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
-        entry.timestamp = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 5));
+        entry.sourceDocumentIds = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
+        entry.prompt = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
+        entry.model = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
+        entry.timestamp = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 5));
         entry.versionHistoryId = sqlite3_column_int(stmt, 6);
 
         sqlite3_finalize(stmt);
@@ -675,7 +694,7 @@ bool BookDatabase::updateDocumentMergeVersion(int mergeId, int versionHistoryId)
     if (!m_isOpen) return false;
     const char* sql = "UPDATE document_merges SET version_history_id = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
     sqlite3_bind_int(stmt, 1, versionHistoryId);
     sqlite3_bind_int(stmt, 2, mergeId);
     int rc = sqlite3_step(stmt);
@@ -692,14 +711,14 @@ int BookDatabase::addDocumentHistoryReturningId(int documentId, const QString& a
 
     const char* sql = "INSERT INTO document_history (document_id, action_type, content) VALUES (?, ?, ?);";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return -1;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return -1;
 
     sqlite3_bind_int(stmt, 1, documentId);
     sqlite3_bind_text(stmt, 2, actionType.toUtf8().constData(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 3, content.toUtf8().constData(), -1, SQLITE_TRANSIENT);
 
     int rc = sqlite3_step(stmt);
-    int id = (rc == SQLITE_DONE) ? sqlite3_last_insert_rowid((sqlite3*)m_db) : -1;
+    int id = (rc == SQLITE_DONE) ? sqlite3_last_insert_rowid(reinterpret_cast<sqlite3*>(m_db)) : -1;
     sqlite3_finalize(stmt);
     return id;
 }
@@ -712,16 +731,16 @@ QList<BookDatabase::DocumentHistoryEntry> BookDatabase::getDocumentHistory(int d
         "SELECT id, action_type, content, timestamp FROM document_history WHERE document_id = ? ORDER BY timestamp "
         "DESC;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return items;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return items;
 
     sqlite3_bind_int(stmt, 1, documentId);
 
     while (sqlite3_step(stmt) == SQLITE_ROW) {
         DocumentHistoryEntry item;
         item.id = sqlite3_column_int(stmt, 0);
-        item.actionType = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 1));
-        item.content = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
-        item.timestamp = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
+        item.actionType = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 1));
+        item.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
+        item.timestamp = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
         items.append(item);
     }
 
@@ -734,7 +753,7 @@ bool BookDatabase::updateMessage(int id, const QString& newContent) {
 
     const char* sql = "UPDATE messages SET content = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return false;
 
     sqlite3_bind_text(stmt, 1, newContent.toUtf8().constData(), -1, SQLITE_TRANSIENT);
@@ -751,7 +770,7 @@ bool BookDatabase::deleteMessage(int id) {
     // Recursively delete children? For now just delete this one.
     const char* sql = "DELETE FROM messages WHERE id = ?;";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return false;
 
     sqlite3_bind_int(stmt, 1, id);
@@ -767,7 +786,7 @@ int BookDatabase::getRootMessageId(int messageId) const {
     int currentId = messageId;
     const char* sql = "SELECT parent_id FROM messages WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) {
         return currentId;
     }
 
@@ -794,7 +813,7 @@ QString BookDatabase::getInheritedSetting(int messageId, const QString& key) con
     int currentId = messageId;
     const char* sql = "SELECT parent_id FROM messages WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) {
         return QString();
     }
 
@@ -841,9 +860,10 @@ QList<MessageNode> BookDatabase::getMessages() const {
     QList<MessageNode> nodes;
     if (!m_isOpen) return nodes;
 
-    const char* sql = "SELECT id, parent_id, folder_id, role, content, timestamp, is_expanded FROM messages ORDER BY id;";
+    const char* sql =
+        "SELECT id, parent_id, folder_id, role, content, timestamp, is_expanded FROM messages ORDER BY id;";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return nodes;
 
     while (sqlite3_step(stmt) == SQLITE_ROW) {
@@ -851,9 +871,9 @@ QList<MessageNode> BookDatabase::getMessages() const {
         node.id = sqlite3_column_int(stmt, 0);
         node.parentId = sqlite3_column_int(stmt, 1);
         node.folderId = sqlite3_column_int(stmt, 2);
-        node.role = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
-        node.content = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
-        QString ts = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 5));
+        node.role = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
+        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
+        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 5));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         node.isExpanded = sqlite3_column_int(stmt, 6) != 0;
         nodes.append(node);
@@ -862,12 +882,13 @@ QList<MessageNode> BookDatabase::getMessages() const {
     return nodes;
 }
 
-int BookDatabase::addDocument(int folderId, const QString& title, const QString& content, int parentId, const QString& metadata) {
+int BookDatabase::addDocument(int folderId, const QString& title, const QString& content, int parentId,
+                              const QString& metadata) {
     if (!m_isOpen) return -1;
 
     const char* sql = "INSERT INTO documents (folder_id, title, content, parent_id, metadata) VALUES (?, ?, ?, ?, ?);";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return -1;
 
     sqlite3_bind_int(stmt, 1, folderId);
@@ -882,7 +903,7 @@ int BookDatabase::addDocument(int folderId, const QString& title, const QString&
         return -1;
     }
 
-    int id = sqlite3_last_insert_rowid((sqlite3*)m_db);
+    int id = sqlite3_last_insert_rowid(reinterpret_cast<sqlite3*>(m_db));
     sqlite3_finalize(stmt);
     return id;
 }
@@ -892,7 +913,7 @@ bool BookDatabase::updateDocument(int id, const QString& newTitle, const QString
 
     const char* sql = "UPDATE documents SET title = ?, content = ?, metadata = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return false;
 
     sqlite3_bind_text(stmt, 1, newTitle.toUtf8().constData(), -1, SQLITE_TRANSIENT);
@@ -908,24 +929,26 @@ bool BookDatabase::updateDocument(int id, const QString& newTitle, const QString
 std::optional<DocumentNode> BookDatabase::getDocument(int id) const {
     if (!m_isOpen) return std::nullopt;
 
-    QString sqlStr = "SELECT id, folder_id, title, content, timestamp, parent_id, metadata FROM documents WHERE id = ?;";
+    QString sqlStr =
+        "SELECT id, folder_id, title, content, timestamp, parent_id, metadata FROM documents WHERE id = ?;";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sqlStr.toUtf8().constData(), -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sqlStr.toUtf8().constData(), -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return std::nullopt;
 
     sqlite3_bind_int(stmt, 1, id);
 
     if (sqlite3_step(stmt) == SQLITE_ROW) {
         DocumentNode node;
+        node.isFolder = false;
         node.id = sqlite3_column_int(stmt, 0);
         node.folderId = sqlite3_column_int(stmt, 1);
-        node.title = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
-        node.content = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
-        QString ts = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
+        node.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
+        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
+        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         node.parentId = sqlite3_column_int(stmt, 5);
 
-        const char* metadataText = (const char*)sqlite3_column_text(stmt, 6);
+        const char* metadataText = reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 6);
         if (metadataText) {
             node.metadata = QString::fromUtf8(metadataText);
         }
@@ -949,7 +972,7 @@ QList<DocumentNode> BookDatabase::getDocuments(int folderId) const {
     sqlStr += " ORDER BY timestamp ASC;";
 
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sqlStr.toUtf8().constData(), -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sqlStr.toUtf8().constData(), -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return nodes;
 
     if (folderId != -1) sqlite3_bind_int(stmt, 1, folderId);
@@ -958,13 +981,13 @@ QList<DocumentNode> BookDatabase::getDocuments(int folderId) const {
         DocumentNode node;
         node.id = sqlite3_column_int(stmt, 0);
         node.folderId = sqlite3_column_int(stmt, 1);
-        node.title = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
-        node.content = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
-        QString ts = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
+        node.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
+        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
+        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         node.parentId = sqlite3_column_int(stmt, 5);
 
-        const char* metadataText = (const char*)sqlite3_column_text(stmt, 6);
+        const char* metadataText = reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 6);
         if (metadataText) {
             node.metadata = QString::fromUtf8(metadataText);
         }
@@ -983,7 +1006,7 @@ bool BookDatabase::deleteDocument(int id) {
     if (!m_isOpen) return false;
     const char* sql = "DELETE FROM documents WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
     sqlite3_bind_int(stmt, 1, id);
     int rc = sqlite3_step(stmt);
     sqlite3_finalize(stmt);
@@ -995,7 +1018,7 @@ int BookDatabase::addNote(int folderId, const QString& title, const QString& con
 
     const char* sql = "INSERT INTO notes (folder_id, title, content) VALUES (?, ?, ?);";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return -1;
 
     sqlite3_bind_int(stmt, 1, folderId);
@@ -1008,7 +1031,7 @@ int BookDatabase::addNote(int folderId, const QString& title, const QString& con
         return -1;
     }
 
-    int id = sqlite3_last_insert_rowid((sqlite3*)m_db);
+    int id = sqlite3_last_insert_rowid(reinterpret_cast<sqlite3*>(m_db));
     sqlite3_finalize(stmt);
     return id;
 }
@@ -1018,7 +1041,7 @@ bool BookDatabase::updateNote(int id, const QString& newTitle, const QString& ne
 
     const char* sql = "UPDATE notes SET title = ?, content = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return false;
 
     sqlite3_bind_text(stmt, 1, newTitle.toUtf8().constData(), -1, SQLITE_TRANSIENT);
@@ -1039,7 +1062,7 @@ QList<NoteNode> BookDatabase::getNotes(int folderId) const {
     sqlStr += " ORDER BY id;";
 
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sqlStr.toUtf8().constData(), -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sqlStr.toUtf8().constData(), -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return nodes;
 
     if (folderId != -1) sqlite3_bind_int(stmt, 1, folderId);
@@ -1048,9 +1071,9 @@ QList<NoteNode> BookDatabase::getNotes(int folderId) const {
         NoteNode node;
         node.id = sqlite3_column_int(stmt, 0);
         node.folderId = sqlite3_column_int(stmt, 1);
-        node.title = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
-        node.content = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
-        QString ts = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
+        node.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
+        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
+        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         nodes.append(node);
     }
@@ -1062,7 +1085,7 @@ bool BookDatabase::deleteNote(int id) {
     if (!m_isOpen) return false;
     const char* sql = "DELETE FROM notes WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
     sqlite3_bind_int(stmt, 1, id);
     int rc = sqlite3_step(stmt);
     sqlite3_finalize(stmt);
@@ -1074,7 +1097,7 @@ int BookDatabase::addTemplate(int folderId, const QString& title, const QString&
 
     const char* sql = "INSERT INTO templates (folder_id, title, content) VALUES (?, ?, ?);";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return -1;
 
     sqlite3_bind_int(stmt, 1, folderId);
@@ -1087,7 +1110,7 @@ int BookDatabase::addTemplate(int folderId, const QString& title, const QString&
         return -1;
     }
 
-    int id = sqlite3_last_insert_rowid((sqlite3*)m_db);
+    int id = sqlite3_last_insert_rowid(reinterpret_cast<sqlite3*>(m_db));
     sqlite3_finalize(stmt);
     return id;
 }
@@ -1097,7 +1120,7 @@ bool BookDatabase::updateTemplate(int id, const QString& newTitle, const QString
 
     const char* sql = "UPDATE templates SET title = ?, content = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return false;
 
     sqlite3_bind_text(stmt, 1, newTitle.toUtf8().constData(), -1, SQLITE_TRANSIENT);
@@ -1118,7 +1141,7 @@ QList<DocumentNode> BookDatabase::getTemplates(int folderId) const {
     sqlStr += " ORDER BY timestamp ASC;";
 
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sqlStr.toUtf8().constData(), -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sqlStr.toUtf8().constData(), -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return nodes;
 
     if (folderId != -1) sqlite3_bind_int(stmt, 1, folderId);
@@ -1127,9 +1150,9 @@ QList<DocumentNode> BookDatabase::getTemplates(int folderId) const {
         DocumentNode node;
         node.id = sqlite3_column_int(stmt, 0);
         node.folderId = sqlite3_column_int(stmt, 1);
-        node.title = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
-        node.content = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
-        QString ts = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
+        node.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
+        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
+        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         node.isFolder = false;
         nodes.append(node);
@@ -1138,12 +1161,13 @@ QList<DocumentNode> BookDatabase::getTemplates(int folderId) const {
     return nodes;
 }
 
-int BookDatabase::addDraft(int folderId, const QString& title, const QString& content, int parentId, const QString& targetType) {
+int BookDatabase::addDraft(int folderId, const QString& title, const QString& content, int parentId,
+                           const QString& targetType) {
     if (!m_isOpen) return -1;
 
     const char* sql = "INSERT INTO drafts (folder_id, title, content, parent_id, target_type) VALUES (?, ?, ?, ?, ?);";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return -1;
 
     sqlite3_bind_int(stmt, 1, folderId);
@@ -1158,7 +1182,7 @@ int BookDatabase::addDraft(int folderId, const QString& title, const QString& co
         return -1;
     }
 
-    int id = sqlite3_last_insert_rowid((sqlite3*)m_db);
+    int id = sqlite3_last_insert_rowid(reinterpret_cast<sqlite3*>(m_db));
     sqlite3_finalize(stmt);
     return id;
 }
@@ -1168,7 +1192,7 @@ bool BookDatabase::updateDraft(int id, const QString& newTitle, const QString& n
 
     const char* sql = "UPDATE drafts SET title = ?, content = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return false;
 
     sqlite3_bind_text(stmt, 1, newTitle.toUtf8().constData(), -1, SQLITE_TRANSIENT);
@@ -1189,7 +1213,7 @@ QList<DocumentNode> BookDatabase::getDrafts(int folderId) const {
     sqlStr += " ORDER BY timestamp ASC;";
 
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sqlStr.toUtf8().constData(), -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sqlStr.toUtf8().constData(), -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return nodes;
 
     if (folderId != -1) sqlite3_bind_int(stmt, 1, folderId);
@@ -1198,12 +1222,12 @@ QList<DocumentNode> BookDatabase::getDrafts(int folderId) const {
         DocumentNode node;
         node.id = sqlite3_column_int(stmt, 0);
         node.folderId = sqlite3_column_int(stmt, 1);
-        node.title = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
-        node.content = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
-        QString ts = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
+        node.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
+        node.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
+        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         node.parentId = sqlite3_column_int(stmt, 5);
-        node.targetType = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 6));
+        node.targetType = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 6));
         node.isFolder = false;
         nodes.append(node);
     }
@@ -1215,7 +1239,7 @@ bool BookDatabase::deleteDraft(int id) {
     if (!m_isOpen) return false;
     const char* sql = "DELETE FROM drafts WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
     sqlite3_bind_int(stmt, 1, id);
     int rc = sqlite3_step(stmt);
     sqlite3_finalize(stmt);
@@ -1227,7 +1251,7 @@ int BookDatabase::addFolder(int parentId, const QString& name, const QString& ty
 
     const char* sql = "INSERT INTO folders (parent_id, name, type) VALUES (?, ?, ?);";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return -1;
 
     sqlite3_bind_int(stmt, 1, parentId);
@@ -1240,7 +1264,7 @@ int BookDatabase::addFolder(int parentId, const QString& name, const QString& ty
         return -1;
     }
 
-    int id = sqlite3_last_insert_rowid((sqlite3*)m_db);
+    int id = sqlite3_last_insert_rowid(reinterpret_cast<sqlite3*>(m_db));
     sqlite3_finalize(stmt);
     return id;
 }
@@ -1250,7 +1274,7 @@ bool BookDatabase::updateFolder(int id, const QString& newName) {
 
     const char* sql = "UPDATE folders SET name = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return false;
 
     sqlite3_bind_text(stmt, 1, newName.toUtf8().constData(), -1, SQLITE_TRANSIENT);
@@ -1266,7 +1290,7 @@ bool BookDatabase::deleteFolder(int id) {
 
     const char* sql = "DELETE FROM folders WHERE id = ?;";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return false;
 
     sqlite3_bind_int(stmt, 1, id);
@@ -1280,7 +1304,7 @@ void BookDatabase::setFolderExpanded(int id, bool expanded) {
     if (!m_isOpen) return;
     const char* sql = "UPDATE folders SET is_expanded = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return;
     sqlite3_bind_int(stmt, 1, expanded ? 1 : 0);
     sqlite3_bind_int(stmt, 2, id);
     sqlite3_step(stmt);
@@ -1291,7 +1315,7 @@ void BookDatabase::setMessageExpanded(int id, bool expanded) {
     if (!m_isOpen) return;
     const char* sql = "UPDATE messages SET is_expanded = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return;
     sqlite3_bind_int(stmt, 1, expanded ? 1 : 0);
     sqlite3_bind_int(stmt, 2, id);
     sqlite3_step(stmt);
@@ -1303,10 +1327,11 @@ QList<FolderNode> BookDatabase::getFolders(const QString& type) const {
     if (!m_isOpen) return folderNodes;
 
     const char* sql =
-        "SELECT id, parent_id, name, type, timestamp, position, is_expanded FROM folders WHERE type = ? ORDER BY position ASC, name "
+        "SELECT id, parent_id, name, type, timestamp, position, is_expanded FROM folders WHERE type = ? ORDER BY "
+        "position ASC, name "
         "ASC;";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return folderNodes;
 
     sqlite3_bind_text(stmt, 1, type.toUtf8().constData(), -1, SQLITE_TRANSIENT);
@@ -1315,9 +1340,9 @@ QList<FolderNode> BookDatabase::getFolders(const QString& type) const {
         FolderNode node;
         node.id = sqlite3_column_int(stmt, 0);
         node.parentId = sqlite3_column_int(stmt, 1);
-        node.name = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
-        node.type = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
-        QString ts = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
+        node.name = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
+        node.type = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
+        QString ts = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
         node.timestamp = QDateTime::fromString(ts, Qt::ISODate);
         node.position = sqlite3_column_int(stmt, 5);
         node.isExpanded = sqlite3_column_int(stmt, 6) != 0;
@@ -1335,7 +1360,7 @@ int BookDatabase::enqueuePrompt(int messageId, const QString& model, const QStri
         "INSERT INTO queue (message_id, model, prompt, priority, target_type, state, parent_id, target_action) VALUES "
         "(?, ?, ?, ?, ?, 'pending', ?, ?);";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return -1;
 
     sqlite3_bind_int(stmt, 1, messageId);
@@ -1352,7 +1377,7 @@ int BookDatabase::enqueuePrompt(int messageId, const QString& model, const QStri
         return -1;
     }
 
-    int id = sqlite3_last_insert_rowid((sqlite3*)m_db);
+    int id = sqlite3_last_insert_rowid(reinterpret_cast<sqlite3*>(m_db));
     sqlite3_finalize(stmt);
     return id;
 }
@@ -1370,7 +1395,9 @@ bool BookDatabase::updateQueueItemState(int id, const QString& state, const QStr
     sqlStr += " WHERE id = ?;";
 
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sqlStr.toUtf8().constData(), -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sqlStr.toUtf8().constData(), -1, &stmt, nullptr) !=
+        SQLITE_OK)
+        return false;
 
     sqlite3_bind_text(stmt, 1, state.toUtf8().constData(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 2, response.toUtf8().constData(), -1, SQLITE_TRANSIENT);
@@ -1387,10 +1414,10 @@ BookDatabase::QueueStats BookDatabase::getQueueStats() const {
 
     const char* sql = "SELECT state, COUNT(*) FROM queue GROUP BY state;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return stats;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return stats;
 
     while (sqlite3_step(stmt) == SQLITE_ROW) {
-        QString state = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 0));
+        QString state = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 0));
         int count = sqlite3_column_int(stmt, 1);
 
         if (state == "pending") {
@@ -1410,9 +1437,11 @@ BookDatabase::QueueStats BookDatabase::getQueueStats() const {
 
 bool BookDatabase::isGenerating(int targetId, const QString& targetType, const QString& targetAction) const {
     if (!m_isOpen) return false;
-    const char* sql = "SELECT COUNT(*) FROM queue WHERE message_id = ? AND target_type = ? AND target_action = ? AND state IN ('pending', 'processing');";
+    const char* sql =
+        "SELECT COUNT(*) FROM queue WHERE message_id = ? AND target_type = ? AND target_action = ? AND state IN "
+        "('pending', 'processing');";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
 
     sqlite3_bind_int(stmt, 1, targetId);
     sqlite3_bind_text(stmt, 2, targetType.toUtf8().constData(), -1, SQLITE_TRANSIENT);
@@ -1436,29 +1465,29 @@ QList<QueueItem> BookDatabase::getQueue() const {
         "DESC, "
         "created_at DESC;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return items;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return items;
 
     while (sqlite3_step(stmt) == SQLITE_ROW) {
         QueueItem item;
         item.id = sqlite3_column_int(stmt, 0);
         item.messageId = sqlite3_column_int(stmt, 1);
-        item.model = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
-        item.prompt = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
+        item.model = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
+        item.prompt = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
         item.processingId = sqlite3_column_int(stmt, 4);
         const unsigned char* errorText = sqlite3_column_text(stmt, 5);
-        if (errorText) item.lastError = QString::fromUtf8((const char*)errorText);
+        if (errorText) item.lastError = QString::fromUtf8(reinterpret_cast<const char*>(errorText));
         item.priority = sqlite3_column_int(stmt, 6);
-        item.timestamp =
-            QDateTime::fromString(QString::fromUtf8((const char*)sqlite3_column_text(stmt, 7)), Qt::ISODate);
-        item.targetType = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 8));
+        item.timestamp = QDateTime::fromString(
+            QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 7)), Qt::ISODate);
+        item.targetType = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 8));
         if (item.targetType.isEmpty()) item.targetType = "message";
         const unsigned char* stateText = sqlite3_column_text(stmt, 9);
-        if (stateText) item.state = QString::fromUtf8((const char*)stateText);
+        if (stateText) item.state = QString::fromUtf8(reinterpret_cast<const char*>(stateText));
         const unsigned char* responseText = sqlite3_column_text(stmt, 10);
-        if (responseText) item.response = QString::fromUtf8((const char*)responseText);
+        if (responseText) item.response = QString::fromUtf8(reinterpret_cast<const char*>(responseText));
         item.parentId = sqlite3_column_int(stmt, 11);
         const unsigned char* actionText = sqlite3_column_text(stmt, 12);
-        if (actionText) item.targetAction = QString::fromUtf8((const char*)actionText);
+        if (actionText) item.targetAction = QString::fromUtf8(reinterpret_cast<const char*>(actionText));
 
         items.append(item);
     }
@@ -1470,7 +1499,7 @@ bool BookDatabase::updateQueueProcessingId(int id, int processingId) {
     if (!m_isOpen) return false;
     const char* sql = "UPDATE queue SET processing_id = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
     sqlite3_bind_int(stmt, 1, processingId);
     sqlite3_bind_int(stmt, 2, id);
     int rc = sqlite3_step(stmt);
@@ -1482,7 +1511,7 @@ bool BookDatabase::updateQueueError(int id, const QString& error) {
     if (!m_isOpen) return false;
     const char* sql = "UPDATE queue SET last_error = ?, processing_id = 0, state = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
 
     QString state = error.isEmpty() ? "pending" : "error";
 
@@ -1498,7 +1527,7 @@ bool BookDatabase::updateQueueItemPrompt(int id, const QString& prompt) {
     if (!m_isOpen) return false;
     const char* sql = "UPDATE queue SET prompt = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
     sqlite3_bind_text(stmt, 1, prompt.toUtf8().constData(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_int(stmt, 2, id);
     int rc = sqlite3_step(stmt);
@@ -1506,12 +1535,11 @@ bool BookDatabase::updateQueueItemPrompt(int id, const QString& prompt) {
     return rc == SQLITE_DONE;
 }
 
-
 bool BookDatabase::updateQueueItemModel(int id, const QString& model) {
     if (!m_isOpen) return false;
     const char* sql = "UPDATE queue SET model = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
     sqlite3_bind_text(stmt, 1, model.toUtf8().constData(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_int(stmt, 2, id);
     int rc = sqlite3_step(stmt);
@@ -1523,7 +1551,7 @@ bool BookDatabase::deleteQueueItem(int id) {
     if (!m_isOpen) return false;
     const char* sql = "DELETE FROM queue WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
     sqlite3_bind_int(stmt, 1, id);
     int rc = sqlite3_step(stmt);
     sqlite3_finalize(stmt);
@@ -1534,7 +1562,7 @@ int BookDatabase::addNotification(int targetId, const QString& targetType, const
     if (!m_isOpen) return -1;
     const char* sql = "INSERT INTO notifications (target_id, target_type, type) VALUES (?, ?, ?);";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return -1;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return -1;
     sqlite3_bind_int(stmt, 1, targetId);
     sqlite3_bind_text(stmt, 2, targetType.toUtf8().constData(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 3, type.toUtf8().constData(), -1, SQLITE_TRANSIENT);
@@ -1543,7 +1571,7 @@ int BookDatabase::addNotification(int targetId, const QString& targetType, const
         sqlite3_finalize(stmt);
         return -1;
     }
-    int id = sqlite3_last_insert_rowid((sqlite3*)m_db);
+    int id = sqlite3_last_insert_rowid(reinterpret_cast<sqlite3*>(m_db));
     sqlite3_finalize(stmt);
     return id;
 }
@@ -1555,16 +1583,17 @@ QList<Notification> BookDatabase::getNotifications(bool includeDismissed) const 
     if (!includeDismissed) sql += " WHERE is_dismissed = 0";
     sql += " ORDER BY created_at DESC;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql.toUtf8().constData(), -1, &stmt, nullptr) != SQLITE_OK)
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql.toUtf8().constData(), -1, &stmt, nullptr) != SQLITE_OK)
         return notifications;
     while (sqlite3_step(stmt) == SQLITE_ROW) {
         Notification n;
         n.id = sqlite3_column_int(stmt, 0);
         n.targetId = sqlite3_column_int(stmt, 1);
-        n.targetType = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
-        n.type = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
+        n.targetType = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
+        n.type = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
         n.isDismissed = sqlite3_column_int(stmt, 4) != 0;
-        n.timestamp = QDateTime::fromString(QString::fromUtf8((const char*)sqlite3_column_text(stmt, 5)), Qt::ISODate);
+        n.timestamp = QDateTime::fromString(
+            QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 5)), Qt::ISODate);
         notifications.append(n);
     }
     sqlite3_finalize(stmt);
@@ -1575,7 +1604,7 @@ bool BookDatabase::dismissNotification(int id) {
     if (!m_isOpen) return false;
     const char* sql = "UPDATE notifications SET is_dismissed = 1 WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
     sqlite3_bind_int(stmt, 1, id);
     int rc = sqlite3_step(stmt);
     sqlite3_finalize(stmt);
@@ -1586,7 +1615,7 @@ bool BookDatabase::dismissNotificationByTarget(int targetId, const QString& targ
     if (!m_isOpen) return false;
     const char* sql = "UPDATE notifications SET is_dismissed = 1 WHERE target_id = ? AND target_type = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
     sqlite3_bind_int(stmt, 1, targetId);
     sqlite3_bind_text(stmt, 2, targetType.toUtf8().constData(), -1, SQLITE_TRANSIENT);
     int rc = sqlite3_step(stmt);
@@ -1598,7 +1627,7 @@ bool BookDatabase::dismissNotificationByTargetAndType(int targetId, const QStrin
     if (!m_isOpen) return false;
     const char* sql = "UPDATE notifications SET is_dismissed = 1 WHERE target_id = ? AND target_type = ? AND type = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
     sqlite3_bind_int(stmt, 1, targetId);
     sqlite3_bind_text(stmt, 2, targetType.toUtf8().constData(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 3, type.toUtf8().constData(), -1, SQLITE_TRANSIENT);
@@ -1613,7 +1642,7 @@ QString BookDatabase::getDatabaseDebugInfo() const {
     QString info;
     int userVersion = 0;
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, "PRAGMA user_version;", -1, &stmt, nullptr) == SQLITE_OK) {
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), "PRAGMA user_version;", -1, &stmt, nullptr) == SQLITE_OK) {
         if (sqlite3_step(stmt) == SQLITE_ROW) {
             userVersion = sqlite3_column_int(stmt, 0);
         }
@@ -1622,11 +1651,11 @@ QString BookDatabase::getDatabaseDebugInfo() const {
     info += QString("Schema Version: %1\n\n").arg(userVersion);
 
     info += "Tables:\n";
-    if (sqlite3_prepare_v2((sqlite3*)m_db, "SELECT name, sql FROM sqlite_master WHERE type='table';", -1, &stmt,
-                           nullptr) == SQLITE_OK) {
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), "SELECT name, sql FROM sqlite_master WHERE type='table';",
+                           -1, &stmt, nullptr) == SQLITE_OK) {
         while (sqlite3_step(stmt) == SQLITE_ROW) {
             const unsigned char* namePtr = sqlite3_column_text(stmt, 0);
-            QString name = namePtr ? QString::fromUtf8((const char*)namePtr) : "";
+            QString name = namePtr ? QString::fromUtf8(reinterpret_cast<const char*>(namePtr)) : "";
             info += QString("- %1\n").arg(name);
         }
         sqlite3_finalize(stmt);
@@ -1640,7 +1669,7 @@ int BookDatabase::addComment(const QString& entityType, int entityId, const QStr
 
     const char* sql = "INSERT INTO comments (entity_type, entity_id, content) VALUES (?, ?, ?);";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return -1;
 
     sqlite3_bind_text(stmt, 1, entityType.toUtf8().constData(), -1, SQLITE_TRANSIENT);
@@ -1653,7 +1682,7 @@ int BookDatabase::addComment(const QString& entityType, int entityId, const QStr
         return -1;
     }
 
-    int id = sqlite3_last_insert_rowid((sqlite3*)m_db);
+    int id = sqlite3_last_insert_rowid(reinterpret_cast<sqlite3*>(m_db));
     sqlite3_finalize(stmt);
     return id;
 }
@@ -1663,7 +1692,7 @@ bool BookDatabase::updateComment(int id, const QString& newContent) {
 
     const char* sql = "UPDATE comments SET content = ? WHERE id = ?;";
     sqlite3_stmt* stmt;
-    int rc = sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr);
+    int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return false;
 
     sqlite3_bind_text(stmt, 1, newContent.toUtf8().constData(), -1, SQLITE_TRANSIENT);
@@ -1682,7 +1711,7 @@ QList<CommentNode> BookDatabase::getComments(const QString& entityType, int enti
         "SELECT id, entity_type, entity_id, content, created_at FROM comments WHERE entity_type = ? AND entity_id = ? "
         "ORDER BY created_at ASC;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return items;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return items;
 
     sqlite3_bind_text(stmt, 1, entityType.toUtf8().constData(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_int(stmt, 2, entityId);
@@ -1690,11 +1719,11 @@ QList<CommentNode> BookDatabase::getComments(const QString& entityType, int enti
     while (sqlite3_step(stmt) == SQLITE_ROW) {
         CommentNode item;
         item.id = sqlite3_column_int(stmt, 0);
-        item.entityType = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 1));
+        item.entityType = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 1));
         item.entityId = sqlite3_column_int(stmt, 2);
-        item.content = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
-        item.timestamp =
-            QDateTime::fromString(QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4)), Qt::ISODate);
+        item.content = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
+        item.timestamp = QDateTime::fromString(
+            QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4)), Qt::ISODate);
         items.append(item);
     }
 
@@ -1706,7 +1735,7 @@ bool BookDatabase::deleteComment(int id) {
     if (!m_isOpen) return false;
     const char* sql = "DELETE FROM comments WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
     sqlite3_bind_int(stmt, 1, id);
     int rc = sqlite3_step(stmt);
     sqlite3_finalize(stmt);
@@ -1727,22 +1756,24 @@ ChatNode BookDatabase::getChat(int messageId) const {
         "SELECT title, systemPrompt, sendBehavior, model, multiLine, draftPrompt, userNote, version FROM chats WHERE "
         "message_id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) == SQLITE_OK) {
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) == SQLITE_OK) {
         sqlite3_bind_int(stmt, 1, messageId);
 
         if (sqlite3_step(stmt) == SQLITE_ROW) {
-            if (sqlite3_column_text(stmt, 0)) chat.title = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 0));
+            if (sqlite3_column_text(stmt, 0))
+                chat.title = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 0));
             if (sqlite3_column_text(stmt, 1))
-                chat.systemPrompt = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 1));
+                chat.systemPrompt = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 1));
             if (sqlite3_column_text(stmt, 2))
-                chat.sendBehavior = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 2));
-            if (sqlite3_column_text(stmt, 3)) chat.model = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 3));
+                chat.sendBehavior = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 2));
+            if (sqlite3_column_text(stmt, 3))
+                chat.model = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 3));
             if (sqlite3_column_text(stmt, 4))
-                chat.multiLine = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 4));
+                chat.multiLine = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 4));
             if (sqlite3_column_text(stmt, 5))
-                chat.draftPrompt = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 5));
+                chat.draftPrompt = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 5));
             if (sqlite3_column_text(stmt, 6))
-                chat.userNote = QString::fromUtf8((const char*)sqlite3_column_text(stmt, 6));
+                chat.userNote = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_column_text)(stmt, 6));
             chat.version = sqlite3_column_int(stmt, 7);
         }
         sqlite3_finalize(stmt);
@@ -1757,7 +1788,7 @@ bool BookDatabase::updateChat(const ChatNode& chat) {
         "INSERT OR REPLACE INTO chats (message_id, title, systemPrompt, sendBehavior, model, multiLine, draftPrompt, "
         "userNote, version) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) {
         return false;
     }
 
@@ -1782,7 +1813,7 @@ QSet<int> BookDatabase::getAllChatIds() const {
     if (!m_isOpen) return ids;
     const char* sql = "SELECT message_id FROM chats;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) == SQLITE_OK) {
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) == SQLITE_OK) {
         while (sqlite3_step(stmt) == SQLITE_ROW) {
             ids.insert(sqlite3_column_int(stmt, 0));
         }
@@ -1795,7 +1826,7 @@ bool BookDatabase::deleteTemplate(int id) {
     if (!m_isOpen) return false;
     const char* sql = "DELETE FROM templates WHERE id = ?;";
     sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2((sqlite3*)m_db, sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
+    if (sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr) != SQLITE_OK) return false;
     sqlite3_bind_int(stmt, 1, id);
     int rc = sqlite3_step(stmt);
     sqlite3_finalize(stmt);

--- a/src/BookDatabase.h
+++ b/src/BookDatabase.h
@@ -26,7 +26,7 @@ struct DocumentNode {
     QDateTime timestamp;
     bool isFolder;  // Deprecated, but keeping for compatibility during migration if needed
     QString metadata;
-    QString targetType; // Optional, e.g., 'document', 'note', 'template'
+    QString targetType;  // Optional, e.g., 'document', 'note', 'template'
 };
 
 struct ChatNode {
@@ -86,15 +86,15 @@ struct CommentNode {
 struct Notification {
     int id;
     int targetId;
-    QString targetType; // "document", "message"
-    QString type;  // "responded_to", "error"
+    QString targetType;  // "document", "message"
+    QString type;        // "responded_to", "error"
     bool isDismissed;
     QDateTime timestamp;
 };
 
 class BookDatabase {
    public:
-    BookDatabase(const QString& filepath);
+    explicit BookDatabase(const QString& filepath);
     ~BookDatabase();
 
     bool open(const QString& password);
@@ -124,7 +124,8 @@ class BookDatabase {
                        const QString& defaultValue = QString()) const;
 
     // Documents
-    int addDocument(int folderId, const QString& title, const QString& content, int parentId = 0, const QString& metadata = "");
+    int addDocument(int folderId, const QString& title, const QString& content, int parentId = 0,
+                    const QString& metadata = "");
     bool updateDocument(int id, const QString& newTitle, const QString& newContent, const QString& metadata = "");
     QList<DocumentNode> getDocuments(int folderId = -1) const;  // -1 for all, 0 for root
     std::optional<DocumentNode> getDocument(int id) const;
@@ -144,13 +145,14 @@ class BookDatabase {
     struct DocumentMergeEntry {
         int id;
         int documentId;
-        QString sourceDocumentIds; // comma separated or JSON array
+        QString sourceDocumentIds;  // comma separated or JSON array
         QString prompt;
         QString model;
         QString timestamp;
         int versionHistoryId;
     };
-    int addDocumentMerge(int documentId, const QString& sourceDocumentIds, const QString& prompt, const QString& model, int versionHistoryId = 0);
+    int addDocumentMerge(int documentId, const QString& sourceDocumentIds, const QString& prompt, const QString& model,
+                         int versionHistoryId = 0);
     std::optional<DocumentMergeEntry> getDocumentMerge(int documentId) const;
     bool updateDocumentMergeVersion(int mergeId, int versionHistoryId);
 
@@ -161,7 +163,8 @@ class BookDatabase {
     bool deleteTemplate(int id);
 
     // Drafts
-    int addDraft(int folderId, const QString& title, const QString& content, int parentId = 0, const QString& targetType = "document");
+    int addDraft(int folderId, const QString& title, const QString& content, int parentId = 0,
+                 const QString& targetType = "document");
     bool updateDraft(int id, const QString& newTitle, const QString& newContent);
     QList<DocumentNode> getDrafts(int folderId = -1) const;
     bool deleteDraft(int id);

--- a/src/DocumentEditWindow.cpp
+++ b/src/DocumentEditWindow.cpp
@@ -2,6 +2,8 @@
 
 #include <sqlite3.h>
 
+#include <KActionCollection>
+#include <KStandardAction>
 #include <KToolBar>
 #include <QAction>
 #include <QCloseEvent>
@@ -19,8 +21,6 @@
 #include <QStatusBar>
 #include <QTextEdit>
 #include <QVBoxLayout>
-#include <KActionCollection>
-#include <KStandardAction>
 
 DocumentEditWindow::DocumentEditWindow(std::shared_ptr<BookDatabase> db, int documentId, const QString& title,
                                        const QString& targetType, QWidget* parent)
@@ -74,7 +74,7 @@ void DocumentEditWindow::setupWindow() {
     QAction* replaceOriginalAction = nullptr;
     QAction* viewOriginalAction = nullptr;
     if (m_targetType == "draft") {
-        saveAsDraftAction->setVisible(false); // Hide "Save as Draft" if it is already a draft.
+        saveAsDraftAction->setVisible(false);  // Hide "Save as Draft" if it is already a draft.
 
         replaceOriginalAction = new QAction(QIcon::fromTheme("document-export"), tr("Replace Original Document"), this);
         actionCollection()->addAction(QStringLiteral("replace_original"), replaceOriginalAction);
@@ -99,8 +99,10 @@ void DocumentEditWindow::setupWindow() {
 
             QDateTime originalTimestamp;
             QList<DocumentNode> originals;
-            if (targetType == "document") originals = m_db->getDocuments(-1);
-            else if (targetType == "template") originals = m_db->getTemplates(-1);
+            if (targetType == "document")
+                originals = m_db->getDocuments(-1);
+            else if (targetType == "template")
+                originals = m_db->getTemplates(-1);
             else if (targetType == "note") {
                 auto notes = m_db->getNotes(-1);
                 for (const auto& n : notes) {
@@ -122,24 +124,28 @@ void DocumentEditWindow::setupWindow() {
             if (originalTimestamp > m_openTimestamp) {
                 QMessageBox msgBox(this);
                 msgBox.setWindowTitle(tr("Conflict Detected"));
-                msgBox.setText(tr("Warning: The original document has drifted (been modified) since this draft was created/opened.\nWhat would you like to do?"));
+                msgBox.setText(
+                    tr("Warning: The original document has drifted (been modified) since this draft was "
+                       "created/opened.\nWhat would you like to do?"));
 
                 QPushButton* viewDiffBtn = msgBox.addButton(tr("View Differences"), QMessageBox::ActionRole);
                 QPushButton* continueBtn = msgBox.addButton(tr("Continue & Replace"), QMessageBox::AcceptRole);
                 QPushButton* forkBtn = msgBox.addButton(tr("Create New Forked Document"), QMessageBox::AcceptRole);
-                QPushButton* deleteDraftBtn = msgBox.addButton(tr("Delete Draft & Cancel"), QMessageBox::DestructiveRole);
+                QPushButton* deleteDraftBtn =
+                    msgBox.addButton(tr("Delete Draft & Cancel"), QMessageBox::DestructiveRole);
                 QPushButton* cancelBtn = msgBox.addButton(tr("Cancel"), QMessageBox::RejectRole);
 
                 msgBox.exec();
 
                 if (msgBox.clickedButton() == viewDiffBtn) {
-                    emit jumpToDocumentRequested(parentId); // Jump to original document
-                    return; // abort replacement for now
+                    emit jumpToDocumentRequested(parentId);  // Jump to original document
+                    return;                                  // abort replacement for now
                 } else if (msgBox.clickedButton() == continueBtn) {
                     // fallthrough to regular replace logic
                 } else if (msgBox.clickedButton() == forkBtn) {
                     bool ok;
-                    QString newTitle = QInputDialog::getText(this, tr("Create Fork"), tr("New Title:"), QLineEdit::Normal, m_title + " (Fork)", &ok);
+                    QString newTitle = QInputDialog::getText(this, tr("Create Fork"), tr("New Title:"),
+                                                             QLineEdit::Normal, m_title + " (Fork)", &ok);
                     if (ok && !newTitle.isEmpty()) {
                         int folderId = 0;
                         for (const auto& doc : originals) {
@@ -173,7 +179,7 @@ void DocumentEditWindow::setupWindow() {
                     close();
                     return;
                 } else {
-                    return; // Cancel
+                    return;  // Cancel
                 }
             }
 
@@ -190,7 +196,7 @@ void DocumentEditWindow::setupWindow() {
 
             // Delete the draft after replacing
             m_db->deleteDraft(m_documentId);
-            emit documentModified(m_documentId); // Trigger a refresh
+            emit documentModified(m_documentId);  // Trigger a refresh
             close();
         });
 
@@ -215,7 +221,7 @@ void DocumentEditWindow::setupWindow() {
                 return;
             }
 
-            emit jumpToDocumentRequested(parentId); // Signal MainWindow to jump there, need to update param
+            emit jumpToDocumentRequested(parentId);  // Signal MainWindow to jump there, need to update param
         });
     }
 
@@ -248,7 +254,7 @@ void DocumentEditWindow::setupWindow() {
                         m_db->updateComment(commentId, desc);
                     }
                 }
-                emit documentModified(m_documentId); // Force UI refresh
+                emit documentModified(m_documentId);  // Force UI refresh
             }
         });
     }
@@ -275,11 +281,12 @@ void DocumentEditWindow::setupWindow() {
             if (!m_db || !m_db->isOpen()) return;
 
             QMessageBox::StandardButton reply;
-            reply = QMessageBox::question(this, tr("Dismiss Draft"), tr("Are you sure you want to dismiss this draft permanently?"),
-                                          QMessageBox::Yes|QMessageBox::No);
+            reply = QMessageBox::question(this, tr("Dismiss Draft"),
+                                          tr("Are you sure you want to dismiss this draft permanently?"),
+                                          QMessageBox::Yes | QMessageBox::No);
             if (reply == QMessageBox::Yes) {
                 m_db->deleteDraft(m_documentId);
-                m_initialContent = m_editor->toPlainText(); // Prevent save prompt
+                m_initialContent = m_editor->toPlainText();  // Prevent save prompt
                 emit documentModified(m_documentId);
                 close();
             }
@@ -307,14 +314,12 @@ void DocumentEditWindow::onContentChanged() {
     updateStatusBar();
 }
 
-void DocumentEditWindow::setInitialContent(const QString& content) {
-    m_editor->setPlainText(content);
-}
+void DocumentEditWindow::setInitialContent(const QString& content) { m_editor->setPlainText(content); }
 
 void DocumentEditWindow::updateStatusBar() {
     if (m_targetType == "draft") {
         m_statusLabel->setText(tr("Viewing Draft"));
-        m_statusLabel->setStyleSheet("color: #FF8C00; font-weight: bold;"); // Dark Orange
+        m_statusLabel->setStyleSheet("color: #FF8C00; font-weight: bold;");  // Dark Orange
         return;
     }
 
@@ -335,9 +340,12 @@ void DocumentEditWindow::loadDocument() {
     if (!m_db || !m_db->isOpen()) return;
 
     QList<DocumentNode> docs;
-    if (m_targetType == "document") docs = m_db->getDocuments();
-    else if (m_targetType == "draft") docs = m_db->getDrafts();
-    else if (m_targetType == "template") docs = m_db->getTemplates();
+    if (m_targetType == "document")
+        docs = m_db->getDocuments();
+    else if (m_targetType == "draft")
+        docs = m_db->getDrafts();
+    else if (m_targetType == "template")
+        docs = m_db->getTemplates();
     else if (m_targetType == "note") {
         auto notes = m_db->getNotes();
         for (const auto& n : notes) {
@@ -370,9 +378,12 @@ QDateTime DocumentEditWindow::getLatestDbTimestamp() const {
 
     QDateTime latest;
     QList<DocumentNode> docs;
-    if (m_targetType == "document") docs = m_db->getDocuments();
-    else if (m_targetType == "draft") docs = m_db->getDrafts();
-    else if (m_targetType == "template") docs = m_db->getTemplates();
+    if (m_targetType == "document")
+        docs = m_db->getDocuments();
+    else if (m_targetType == "draft")
+        docs = m_db->getDrafts();
+    else if (m_targetType == "template")
+        docs = m_db->getTemplates();
     else if (m_targetType == "note") {
         auto notes = m_db->getNotes();
         for (const auto& n : notes) {
@@ -410,9 +421,7 @@ QDateTime DocumentEditWindow::getLatestDbTimestamp() const {
     return latest;
 }
 
-void DocumentEditWindow::onJumpClicked() {
-    emit jumpToDocumentRequested(m_documentId);
-}
+void DocumentEditWindow::onJumpClicked() { emit jumpToDocumentRequested(m_documentId); }
 
 void DocumentEditWindow::onSaveClicked() {
     if (saveToDb()) {
@@ -460,14 +469,14 @@ void DocumentEditWindow::onSaveAsTemplateClicked() {
 
 void DocumentEditWindow::onSaveAsDraftClicked() {
     bool ok;
-    QString newTitle = QInputDialog::getText(this, tr("Save As Draft"), tr("Draft Title:"), QLineEdit::Normal,
-                                             m_title, &ok);
+    QString newTitle =
+        QInputDialog::getText(this, tr("Save As Draft"), tr("Draft Title:"), QLineEdit::Normal, m_title, &ok);
     if (ok && !newTitle.isEmpty()) {
         int newId = saveToDraft(newTitle);
         if (newId > 0) {
             m_statusLabel->setText(tr("Saved to drafts"));
             emit newDocumentCreated(newId);
-            close(); // Close active window since it was saved as draft
+            close();  // Close active window since it was saved as draft
         }
     }
 }
@@ -490,9 +499,12 @@ int DocumentEditWindow::forkDocument(const QString& newTitle) {
     if (!m_db || !m_db->isOpen()) return 0;
 
     QList<DocumentNode> docs;
-    if (m_targetType == "document") docs = m_db->getDocuments();
-    else if (m_targetType == "draft") docs = m_db->getDrafts();
-    else if (m_targetType == "template") docs = m_db->getTemplates();
+    if (m_targetType == "document")
+        docs = m_db->getDocuments();
+    else if (m_targetType == "draft")
+        docs = m_db->getDrafts();
+    else if (m_targetType == "template")
+        docs = m_db->getTemplates();
     else if (m_targetType == "note") {
         auto notes = m_db->getNotes();
         int folderId = 0;
@@ -527,9 +539,12 @@ int DocumentEditWindow::saveToDraft(const QString& newTitle) {
     if (!m_db || !m_db->isOpen()) return 0;
 
     QList<DocumentNode> docs;
-    if (m_targetType == "document") docs = m_db->getDocuments();
-    else if (m_targetType == "draft") docs = m_db->getDrafts();
-    else if (m_targetType == "template") docs = m_db->getTemplates();
+    if (m_targetType == "document")
+        docs = m_db->getDocuments();
+    else if (m_targetType == "draft")
+        docs = m_db->getDrafts();
+    else if (m_targetType == "template")
+        docs = m_db->getTemplates();
     else if (m_targetType == "note") {
         auto notes = m_db->getNotes();
         int folderId = 0;
@@ -633,8 +648,10 @@ void DocumentEditWindow::closeEvent(QCloseEvent* event) {
             if (originalId > 0) {
                 // Fetch the original's current timestamp
                 QList<DocumentNode> originals;
-                if (targetType == "document") originals = m_db->getDocuments(-1);
-                else if (targetType == "template") originals = m_db->getTemplates(-1);
+                if (targetType == "document")
+                    originals = m_db->getDocuments(-1);
+                else if (targetType == "template")
+                    originals = m_db->getTemplates(-1);
 
                 for (const auto& doc : originals) {
                     if (doc.id == originalId) {
@@ -652,7 +669,9 @@ void DocumentEditWindow::closeEvent(QCloseEvent* event) {
                 // It's a best-effort check given the schema.
 
                 if (originalTimestamp > m_openTimestamp) {
-                    msgBox.setText(tr("Warning: The original document has been modified since you started editing this draft.\nWould you still like to Save this draft, Discard your current edits, or Cancel?"));
+                    msgBox.setText(
+                        tr("Warning: The original document has been modified since you started editing this "
+                           "draft.\nWould you still like to Save this draft, Discard your current edits, or Cancel?"));
                     QPushButton* saveBtn = msgBox.addButton(tr("Save Draft"), QMessageBox::AcceptRole);
                     QPushButton* discardBtn = msgBox.addButton(tr("Discard Edits"), QMessageBox::DestructiveRole);
                     QPushButton* cancelBtn = msgBox.addButton(tr("Cancel"), QMessageBox::RejectRole);

--- a/src/DocumentTemplatesEditorWidget.cpp
+++ b/src/DocumentTemplatesEditorWidget.cpp
@@ -51,7 +51,9 @@ class EditDocumentTemplateDialog : public QDialog {
         connect(saveBtn, &QPushButton::clicked, this, &QDialog::accept);
     }
 
-    DocumentTemplate getTemplate() const { return {m_idEdit->text(), m_nameEdit->text(), m_contentEdit->toPlainText(), ""}; }
+    DocumentTemplate getTemplate() const {
+        return {m_idEdit->text(), m_nameEdit->text(), m_contentEdit->toPlainText(), ""};
+    }
 
    private:
     QLineEdit* m_idEdit;
@@ -95,7 +97,7 @@ DocumentTemplatesEditorWidget::DocumentTemplatesEditorWidget(const QString& leve
 }
 
 void DocumentTemplatesEditorWidget::setTemplates(const QList<DocumentTemplate>& editableTpls,
-                                             const QList<DocumentTemplate>& inheritedTpls) {
+                                                 const QList<DocumentTemplate>& inheritedTpls) {
     m_table->setRowCount(0);
 
     for (const DocumentTemplate& tpl : editableTpls) {
@@ -145,7 +147,7 @@ QList<DocumentTemplate> DocumentTemplatesEditorWidget::getTemplates() const {
     for (int i = 0; i < m_table->rowCount(); ++i) {
         if (m_table->item(i, 2)->text() == m_level) {
             tpls.append({m_table->item(i, 0)->data(Qt::UserRole).toString(), m_table->item(i, 0)->text(),
-                        m_table->item(i, 0)->data(Qt::UserRole + 1).toString(), m_level});
+                         m_table->item(i, 0)->data(Qt::UserRole + 1).toString(), m_level});
         }
     }
     return tpls;

--- a/src/DocumentTemplatesManager.cpp
+++ b/src/DocumentTemplatesManager.cpp
@@ -1,9 +1,11 @@
 #include "DocumentTemplatesManager.h"
+
 #include <QCoreApplication>
 
 QList<DocumentTemplate> DocumentTemplatesManager::getBuiltInTemplates() {
     QList<DocumentTemplate> templates;
-    templates.append({"builtin:empty", QCoreApplication::translate("DocumentTemplatesManager", "Empty Document"), "", "built-in"});
+    templates.append(
+        {"builtin:empty", QCoreApplication::translate("DocumentTemplatesManager", "Empty Document"), "", "built-in"});
     return templates;
 }
 
@@ -31,7 +33,7 @@ void DocumentTemplatesManager::setGlobalTemplates(const QList<DocumentTemplate>&
     settings.setValue("globalDocumentTemplates", list);
 }
 
-QList<DocumentTemplate> DocumentTemplatesManager::getDatabaseTemplates(BookDatabase* db) {
+QList<DocumentTemplate> DocumentTemplatesManager::getDatabaseTemplates(const BookDatabase* db) {
     QList<DocumentTemplate> templates;
     if (!db) return templates;
     QList<DocumentNode> dbTpls = db->getTemplates(-1);
@@ -41,7 +43,7 @@ QList<DocumentTemplate> DocumentTemplatesManager::getDatabaseTemplates(BookDatab
     return templates;
 }
 
-QList<DocumentTemplate> DocumentTemplatesManager::getMergedTemplates(BookDatabase* db) {
+QList<DocumentTemplate> DocumentTemplatesManager::getMergedTemplates(const BookDatabase* db) {
     QList<DocumentTemplate> templates = getBuiltInTemplates();
     templates.append(getGlobalTemplates());
     if (db) {

--- a/src/DocumentTemplatesManager.h
+++ b/src/DocumentTemplatesManager.h
@@ -20,9 +20,9 @@ class DocumentTemplatesManager {
     static QList<DocumentTemplate> getGlobalTemplates();
     static void setGlobalTemplates(const QList<DocumentTemplate>& templates);
 
-    static QList<DocumentTemplate> getDatabaseTemplates(BookDatabase* db);
+    static QList<DocumentTemplate> getDatabaseTemplates(const BookDatabase* db);
 
-    static QList<DocumentTemplate> getMergedTemplates(BookDatabase* db);
+    static QList<DocumentTemplate> getMergedTemplates(const BookDatabase* db);
 };
 
 #endif  // DOCUMENTTEMPLATESMANAGER_H

--- a/src/DraftSelectionDialog.cpp
+++ b/src/DraftSelectionDialog.cpp
@@ -12,8 +12,14 @@
 #include <QVBoxLayout>
 
 DraftSelectionDialog::DraftSelectionDialog(std::shared_ptr<BookDatabase> db, int documentId,
-                                           const QList<DocumentNode>& drafts, const QString& targetType, QWidget* parent)
-    : QDialog(parent), m_db(db), m_documentId(documentId), m_drafts(drafts), m_targetType(targetType), m_draftSelected(false) {
+                                           const QList<DocumentNode>& drafts, const QString& targetType,
+                                           QWidget* parent)
+    : QDialog(parent),
+      m_db(db),
+      m_documentId(documentId),
+      m_drafts(drafts),
+      m_targetType(targetType),
+      m_draftSelected(false) {
     setWindowTitle(tr("Drafts Available"));
     resize(800, 600);
 
@@ -70,7 +76,8 @@ DraftSelectionDialog::DraftSelectionDialog(std::shared_ptr<BookDatabase> db, int
     connect(navigateOrigBtn, &QPushButton::clicked, this, [this]() {
         // Find the original document ID
         if (m_db && m_db->isOpen() && m_drafts.size() > 0) {
-            // Signal navigation externally (MainWindow handles the jump logic best). We'll set m_draftSelected to false and a specific exit code.
+            // Signal navigation externally (MainWindow handles the jump logic best). We'll set m_draftSelected to false
+            // and a specific exit code.
             done(QDialog::Accepted + 10);
         }
     });
@@ -113,9 +120,7 @@ void DraftSelectionDialog::refreshDraftsList() {
     }
 }
 
-void DraftSelectionDialog::onSelectionChanged() {
-    onPreview();
-}
+void DraftSelectionDialog::onSelectionChanged() { onPreview(); }
 
 void DraftSelectionDialog::onIgnoreDrafts() {
     // If we just want to ignore drafts, we accept the dialog without selecting a draft content
@@ -226,7 +231,7 @@ void DraftSelectionDialog::onShowDifferences() {
 
     QWidget* col1 = new QWidget(innerSplitter);
     QVBoxLayout* lay1 = new QVBoxLayout(col1);
-    lay1->setContentsMargins(0,0,0,0);
+    lay1->setContentsMargins(0, 0, 0, 0);
     lay1->addWidget(new QLabel(tr("Original (Forked From)")));
     QTextEdit* text1 = new QTextEdit(col1);
     text1->setPlainText(originalContent);
@@ -235,7 +240,7 @@ void DraftSelectionDialog::onShowDifferences() {
 
     QWidget* col2 = new QWidget(innerSplitter);
     QVBoxLayout* lay2 = new QVBoxLayout(col2);
-    lay2->setContentsMargins(0,0,0,0);
+    lay2->setContentsMargins(0, 0, 0, 0);
     lay2->addWidget(new QLabel(tr("Current Document")));
     QTextEdit* text2 = new QTextEdit(col2);
     text2->setPlainText(currentContent);
@@ -244,7 +249,7 @@ void DraftSelectionDialog::onShowDifferences() {
 
     QWidget* col3 = new QWidget(innerSplitter);
     QVBoxLayout* lay3 = new QVBoxLayout(col3);
-    lay3->setContentsMargins(0,0,0,0);
+    lay3->setContentsMargins(0, 0, 0, 0);
     lay3->addWidget(new QLabel(tr("Selected Draft")));
     QTextEdit* text3 = new QTextEdit(col3);
     text3->setPlainText(draftContent);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -49,14 +49,14 @@
 #include "AIOperationsDialog.h"
 #include "AiActionDialog.h"
 #include "ChatSettingsDialog.h"
-#include "MergeDocumentsDialog.h"
 #include "DatabaseSettingsDialog.h"
 #include "DocumentEditWindow.h"
 #include "DocumentHistoryDialog.h"
 #include "DocumentReviewDialog.h"
-#include "DraftSelectionDialog.h"
-#include "ModelSelectionDialog.h"
 #include "DocumentTemplatesManager.h"
+#include "DraftSelectionDialog.h"
+#include "MergeDocumentsDialog.h"
+#include "ModelSelectionDialog.h"
 #include "NewDocumentDialog.h"
 #include "NotificationDelegate.h"
 #include "QueueManager.h"
@@ -1461,8 +1461,10 @@ void MainWindow::updateInputBehavior() {
                 } else if (!m_availableModels.isEmpty()) {
                     m_selectedModels = QStringList() << m_availableModels.first();
                 }
-                if (modelLabel && !m_selectedModels.isEmpty()) modelLabel->setText(tr("Model: %1 (System Selected)").arg(m_selectedModels.first()));
-                if (modelSelectButton && !m_selectedModels.isEmpty()) modelSelectButton->setText(m_selectedModels.first());
+                if (modelLabel && !m_selectedModels.isEmpty())
+                    modelLabel->setText(tr("Model: %1 (System Selected)").arg(m_selectedModels.first()));
+                if (modelSelectButton && !m_selectedModels.isEmpty())
+                    modelSelectButton->setText(m_selectedModels.first());
             }
         }
 
@@ -1720,7 +1722,8 @@ void MainWindow::showItemContextMenu(QStandardItem* item, const QPoint& globalPo
                         } else if (!m_availableModels.isEmpty()) {
                             m_selectedModels = QStringList() << m_availableModels.first();
                         }
-                        if (!m_selectedModels.isEmpty()) modelLabel->setText(tr("Model: %1 (System Selected)").arg(m_selectedModels.first()));
+                        if (!m_selectedModels.isEmpty())
+                            modelLabel->setText(tr("Model: %1 (System Selected)").arg(m_selectedModels.first()));
                     }
                     if (currentLastNodeId != 0 && mainContentStack->currentWidget() == chatWindowView) {
                         updateLinearChatView(currentLastNodeId, currentDb->getMessages());
@@ -1920,7 +1923,8 @@ void MainWindow::showItemContextMenu(QStandardItem* item, const QPoint& globalPo
             if (hasMerge || hasPrompt) {
                 regenerateMergeAction = menu.addAction(QIcon::fromTheme("view-refresh"), "Regenerate");
                 if (hasMerge) {
-                    viewMergeSourcesAction = menu.addAction(QIcon::fromTheme("document-multiple"), "View Merge Sources");
+                    viewMergeSourcesAction =
+                        menu.addAction(QIcon::fromTheme("document-multiple"), "View Merge Sources");
                 }
             }
         }
@@ -1984,8 +1988,9 @@ void MainWindow::showItemContextMenu(QStandardItem* item, const QPoint& globalPo
                         QStandardItem* originalItem = findItemInTree(d.parentId, d.targetType);
                         if (originalItem) {
                             openBooksTree->setCurrentIndex(originalItem->index());
-                            openBooksTree->selectionModel()->select(originalItem->index(),
-                                                                    QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Current);
+                            openBooksTree->selectionModel()->select(
+                                originalItem->index(),
+                                QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Current);
                             openBooksTree->scrollTo(originalItem->index());
                             onOpenBooksTreeDoubleClicked(originalItem->index());
                         } else {
@@ -2198,7 +2203,8 @@ void MainWindow::onMergeDocumentsSelected() {
         int targetDocId = dlg.getTargetDocumentId();
         QList<int> docsToDelete = dlg.getDocumentsToDelete();
 
-        processMergeGeneration(finalPrompt, rawPrompt, selectedModels, sourceDocumentIds, baseTitle, targetFolderId, targetDocId, docsToDelete);
+        processMergeGeneration(finalPrompt, rawPrompt, selectedModels, sourceDocumentIds, baseTitle, targetFolderId,
+                               targetDocId, docsToDelete);
     }
 }
 
@@ -2432,7 +2438,8 @@ void MainWindow::addPhantomItem(QStandardItem* folderItem, const QString& type) 
     folderItem->appendRow(phantomItem);
 
     openBooksTree->setExpanded(folderItem->index(), true);
-    openBooksTree->selectionModel()->select(phantomItem->index(), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Current);
+    openBooksTree->selectionModel()->select(phantomItem->index(),
+                                            QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Current);
 }
 
 /** * @brief Executes logic for loadSession. This function manages component initialization and handles state
@@ -3294,7 +3301,6 @@ void MainWindow::onSendMessage() {
         currentDb->updateChat(cn);
 
         QueueManager::instance().enqueuePrompt(aiId, model, text);
-
     }
 
     // Refresh tree if needed
@@ -3452,7 +3458,8 @@ void MainWindow::updateGenerationUI() {
     if (QueueManager::instance().isProcessing() && currentDb) {
         auto items = QueueManager::instance().currentProcessingItems();
         for (const auto& mergedItem : items) {
-            if (mergedItem.db == currentDb && mergedItem.item.targetType == "message" && mergedItem.item.messageId == currentLastNodeId) {
+            if (mergedItem.db == currentDb && mergedItem.item.targetType == "message" &&
+                mergedItem.item.messageId == currentLastNodeId) {
                 isGeneratingCurrentChat = true;
                 break;
             }
@@ -3472,9 +3479,10 @@ void MainWindow::onCancelActiveGeneration() {
     if (QueueManager::instance().isProcessing() && currentDb) {
         auto items = QueueManager::instance().currentProcessingItems();
         for (const auto& mergedItem : items) {
-            if (mergedItem.db == currentDb && mergedItem.item.targetType == "message" && mergedItem.item.messageId == currentLastNodeId) {
+            if (mergedItem.db == currentDb && mergedItem.item.targetType == "message" &&
+                mergedItem.item.messageId == currentLastNodeId) {
                 QueueManager::instance().cancelItem(currentDb, mergedItem.item.id);
-                break; // Assuming only one active generation per chat node
+                break;  // Assuming only one active generation per chat node
             }
         }
         updateGenerationUI();
@@ -3507,9 +3515,8 @@ void MainWindow::onProcessingFinished(std::shared_ptr<BookDatabase> db, int mess
 
     if (currentDb == db) {
         if (targetType == "document" && currentDocumentId == messageId) {
-            statusBar->showMessage(success ? tr("AI document generation complete.")
-                                           : tr("Error generating document changes."),
-                                   3000);
+            statusBar->showMessage(
+                success ? tr("AI document generation complete.") : tr("Error generating document changes."), 3000);
         } else if (targetType == "message" && currentLastNodeId == messageId) {
             statusBar->showMessage(success ? tr("Response complete.") : tr("Error in response."), 3000);
             updateGenerationUI();
@@ -4006,8 +4013,8 @@ void MainWindow::onOpenBooksSelectionChanged(const QItemSelection& selected, con
                 connect(editWin, &DocumentEditWindow::jumpToDocumentRequested, this, [this, type](int docId) {
                     QStandardItem* item = findItemInTree(docId, type);
                     if (item) {
-                        openBooksTree->selectionModel()->select(item->index(),
-                                                                QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Current);
+                        openBooksTree->selectionModel()->select(
+                            item->index(), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Current);
                         openBooksTree->scrollTo(item->index());
                     }
                     this->raise();
@@ -4244,7 +4251,7 @@ void MainWindow::showOpenBookContextMenu(const QPoint& pos) {
         if (selectedAction == mergeAction) {
             onMergeDocumentsSelected();
         }
-        return; // Don't show regular single-item context menu
+        return;  // Don't show regular single-item context menu
     }
 
     QModelIndex index = openBooksTree->indexAt(pos);
@@ -4541,7 +4548,8 @@ void MainWindow::updateNotificationStatus() {
                 targetTitle = tr("Unknown");
             }
 
-            QString menuText = QString("[%1] %2: %3 '%4' (%5)").arg(bookName, typeStr, displayTargetType, targetTitle, QString::number(n.targetId));
+            QString menuText = QString("[%1] %2: %3 '%4' (%5)")
+                                   .arg(bookName, typeStr, displayTargetType, targetTitle, QString::number(n.targetId));
             QAction* action = notificationMenu->addAction(menuText);
             snapshot.append({db, n.id, action->text()});
             connect(action, &QAction::triggered, this, [this, db, n, bookName, displayTargetType, targetTitle]() {
@@ -4579,8 +4587,9 @@ void MainWindow::updateNotificationStatus() {
                     dialog.setWindowTitle(tr("Error: Modify and Retry"));
                     QVBoxLayout* layout = new QVBoxLayout(&dialog);
 
-                    QLabel* summary = new QLabel(QString("<b>Book:</b> %1<br><b>%2:</b> %3 (%4)")
-                                                     .arg(bookName, displayTargetType, targetTitle, QString::number(n.targetId)));
+                    QLabel* summary =
+                        new QLabel(QString("<b>Book:</b> %1<br><b>%2:</b> %3 (%4)")
+                                       .arg(bookName, displayTargetType, targetTitle, QString::number(n.targetId)));
                     summary->setWordWrap(true);
                     layout->addWidget(summary);
 
@@ -4659,9 +4668,9 @@ void MainWindow::updateNotificationStatus() {
                     QVBoxLayout* layout = new QVBoxLayout(&dialog);
 
                     QString typeStr = (n.type == "finished_generation") ? tr("Finished Generation") : tr("Finished");
-                    QLabel* summary =
-                        new QLabel(QString("<b>Book:</b> %1<br><b>Status:</b> %2<br><b>%3:</b> %4 (%5)")
-                                       .arg(bookName, typeStr, displayTargetType, targetTitle, QString::number(n.targetId)));
+                    QLabel* summary = new QLabel(
+                        QString("<b>Book:</b> %1<br><b>Status:</b> %2<br><b>%3:</b> %4 (%5)")
+                            .arg(bookName, typeStr, displayTargetType, targetTitle, QString::number(n.targetId)));
                     summary->setWordWrap(true);
                     layout->addWidget(summary);
 
@@ -5200,7 +5209,8 @@ void MainWindow::onDocumentAIOperations() {
                 }
                 docMeta["prompt"] = prompt;
                 docMeta["raw_prompt"] = promptTpl;
-                currentDb->updateDocument(currentDocumentId, docOpt->title, docOpt->content, QString::fromUtf8(QJsonDocument(docMeta).toJson(QJsonDocument::Compact)));
+                currentDb->updateDocument(currentDocumentId, docOpt->title, docOpt->content,
+                                          QString::fromUtf8(QJsonDocument(docMeta).toJson(QJsonDocument::Compact)));
             }
             QueueManager::instance().enqueuePrompt(currentDocumentId, model, prompt, 0, "document", 0, "");
         }
@@ -5255,7 +5265,7 @@ void MainWindow::onRegenerateMerge() {
 
     QString currentBaseTitle = doc.title;
     if (currentBaseTitle.endsWith(" (Models)")) {
-        currentBaseTitle.chop(9); // length of " (Models)"
+        currentBaseTitle.chop(9);  // length of " (Models)"
     }
     dlg.setTitle(currentBaseTitle);
 
@@ -5275,20 +5285,25 @@ void MainWindow::onRegenerateMerge() {
         int targetDocId = dlg.getTargetDocumentId();
         QList<int> docsToDelete = dlg.getDocumentsToDelete();
 
-        if (targetDocId == -1) { // Replace existing merged document
+        if (targetDocId == -1) {  // Replace existing merged document
             targetDocId = currentDocumentId;
         } else {
-            // Since we are creating a new document or replacing a source document, we should delete the current old merged document
+            // Since we are creating a new document or replacing a source document, we should delete the current old
+            // merged document
             if (!docsToDelete.contains(currentDocumentId)) {
                 docsToDelete.append(currentDocumentId);
             }
         }
 
-        processMergeGeneration(finalPrompt, newRawPrompt, selectedModels, sourceIds, baseTitle, doc.parentId, targetDocId, docsToDelete);
+        processMergeGeneration(finalPrompt, newRawPrompt, selectedModels, sourceIds, baseTitle, doc.parentId,
+                               targetDocId, docsToDelete);
     }
 }
 
-void MainWindow::processMergeGeneration(const QString& finalPrompt, const QString& rawPrompt, const QStringList& selectedModels, const QList<int>& sourceDocumentIds, const QString& baseTitle, int targetFolderId, int existingDocId, const QList<int>& docsToDelete) {
+void MainWindow::processMergeGeneration(const QString& finalPrompt, const QString& rawPrompt,
+                                        const QStringList& selectedModels, const QList<int>& sourceDocumentIds,
+                                        const QString& baseTitle, int targetFolderId, int existingDocId,
+                                        const QList<int>& docsToDelete) {
     if (!currentDb || selectedModels.isEmpty() || finalPrompt.isEmpty()) return;
 
     // Build metadata
@@ -5337,7 +5352,8 @@ void MainWindow::processMergeGeneration(const QString& finalPrompt, const QStrin
             // Set generating text and metadata
             currentDb->updateDocument(existingDocId, docOpt->title, GENERATING_MERGE_TEXT, metaStr);
 
-            if (documentEditorView && mainContentStack->currentWidget() == docContainer && currentDocumentId == existingDocId) {
+            if (documentEditorView && mainContentStack->currentWidget() == docContainer &&
+                currentDocumentId == existingDocId) {
                 documentEditorView->blockSignals(true);
                 documentEditorView->setPlainText(GENERATING_MERGE_TEXT);
                 documentEditorView->blockSignals(false);
@@ -5353,7 +5369,9 @@ void MainWindow::processMergeGeneration(const QString& finalPrompt, const QStrin
         if (selectedModels.size() > 1) {
             targetFolderId = currentDb->addFolder(targetFolderId, baseTitle + " (Models)", "docs_folder");
         }
-        int newDocId = currentDb->addDocument(targetFolderId, selectedModels.size() > 1 ? baseTitle + " - " + firstModel : baseTitle, GENERATING_MERGE_TEXT, 0, metaStr);
+        int newDocId = currentDb->addDocument(targetFolderId,
+                                              selectedModels.size() > 1 ? baseTitle + " - " + firstModel : baseTitle,
+                                              GENERATING_MERGE_TEXT, 0, metaStr);
         currentDb->addDocumentMerge(newDocId, sourceIdsStr, finalPrompt, firstModel, 0);
         currentDb->enqueuePrompt(newDocId, firstModel, finalPrompt, 0, "document", 0, "replace_direct");
     }
@@ -5361,7 +5379,8 @@ void MainWindow::processMergeGeneration(const QString& finalPrompt, const QStrin
     // If there are additional models selected, create new documents for them
     for (int i = 1; i < selectedModels.size(); ++i) {
         QString model = selectedModels[i];
-        int newDocId = currentDb->addDocument(targetFolderId, baseTitle + " - " + model, GENERATING_MERGE_TEXT, 0, metaStr);
+        int newDocId =
+            currentDb->addDocument(targetFolderId, baseTitle + " - " + model, GENERATING_MERGE_TEXT, 0, metaStr);
         currentDb->addDocumentMerge(newDocId, sourceIdsStr, finalPrompt, model, 0);
         currentDb->enqueuePrompt(newDocId, model, finalPrompt, 0, "document", 0, "replace_direct");
     }
@@ -5552,12 +5571,14 @@ void MainWindow::handleNewDocumentCreation(int defaultFolderId) {
                 for (const QString& model : models) {
                     QString docTitle = title + " (" + model + ")";
                     newDocId = currentDb->addDocument(newFolderId, docTitle, GENERATING_MERGE_TEXT, 0, metaStr);
-                    if (newDocId != -1) currentDb->enqueuePrompt(newDocId, model, prompt, 0, "document", 0, "replace_direct");
+                    if (newDocId != -1)
+                        currentDb->enqueuePrompt(newDocId, model, prompt, 0, "document", 0, "replace_direct");
                 }
             } else {
                 QString model = models.isEmpty() ? "" : models.first();
                 newDocId = currentDb->addDocument(folderId, title, GENERATING_MERGE_TEXT, 0, metaStr);
-                if (newDocId != -1) currentDb->enqueuePrompt(newDocId, model, prompt, 0, "document", 0, "replace_direct");
+                if (newDocId != -1)
+                    currentDb->enqueuePrompt(newDocId, model, prompt, 0, "document", 0, "replace_direct");
                 shouldNavigate = true;
             }
             loadDocumentsAndNotes();
@@ -5760,11 +5781,12 @@ void MainWindow::onEditDocument() {
                 return;
             } else if (res == QDialog::Accepted + 10) {
                 // Navigate to original
-                QStandardItem* originalItem = findItemInTree(associatedDrafts.first().parentId, associatedDrafts.first().targetType);
+                QStandardItem* originalItem =
+                    findItemInTree(associatedDrafts.first().parentId, associatedDrafts.first().targetType);
                 if (originalItem) {
                     openBooksTree->setCurrentIndex(originalItem->index());
-                    openBooksTree->selectionModel()->select(originalItem->index(),
-                                                            QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Current);
+                    openBooksTree->selectionModel()->select(
+                        originalItem->index(), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Current);
                     openBooksTree->scrollTo(originalItem->index());
                     onOpenBooksTreeDoubleClicked(originalItem->index());
                 } else {

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -109,7 +109,9 @@ class MainWindow : public KXmlGuiWindow {
     void showOpenBookContextMenu(const QPoint& pos);
     void showVfsContextMenu(const QPoint& pos);
     void onMergeDocumentsSelected();
-    void processMergeGeneration(const QString& finalPrompt, const QString& rawPrompt, const QStringList& selectedModels, const QList<int>& sourceDocumentIds, const QString& baseTitle, int targetFolderId, int existingDocId = 0, const QList<int>& docsToDelete = QList<int>());
+    void processMergeGeneration(const QString& finalPrompt, const QString& rawPrompt, const QStringList& selectedModels,
+                                const QList<int>& sourceDocumentIds, const QString& baseTitle, int targetFolderId,
+                                int existingDocId = 0, const QList<int>& docsToDelete = QList<int>());
     void showInputSettingsMenu();
     void showChatSettingsDialog(int messageId);
     void updateInputBehavior();
@@ -150,7 +152,8 @@ class MainWindow : public KXmlGuiWindow {
                              BookDatabase* db);
     void populateMessageForks(QStandardItem* parentItem, int parentId, const QList<MessageNode>& allMessages);
     void populateDocumentFolders(QStandardItem* parentItem, int folderId, const QString& type, BookDatabase* db);
-    void populateDraftsFolders(QStandardItem* parentItem, int folderId, const QString& underlyingType, BookDatabase* db);
+    void populateDraftsFolders(QStandardItem* parentItem, int folderId, const QString& underlyingType,
+                               BookDatabase* db);
     void addPhantomItem(QStandardItem* folderItem, const QString& type);
     void updateLinearChatView(int tailNodeId, const QList<MessageNode>& allMessages);
     void getPathToRoot(int nodeId, const QList<MessageNode>& allMessages, QList<MessageNode>& path);

--- a/src/MergeDocumentsDialog.cpp
+++ b/src/MergeDocumentsDialog.cpp
@@ -1,25 +1,30 @@
 #include "MergeDocumentsDialog.h"
 
-#include <QDialogButtonBox>
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QVBoxLayout>
-#include <QRegularExpression>
-#include <QFormLayout>
-#include <QLineEdit>
-#include <QPushButton>
-#include <QMessageBox>
-#include <QSettings>
 #include <QCheckBox>
-
-#include <QUuid>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QHBoxLayout>
 #include <QInputDialog>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QRegularExpression>
+#include <QSettings>
+#include <QUuid>
+#include <QVBoxLayout>
 
 #include "ModelSelectionDialog.h"
 #include "TemplateParser.h"
 
-MergeDocumentsDialog::MergeDocumentsDialog(BookDatabase* db, const QList<int>& documentIds, const QList<OllamaModelInfo>& modelInfos, const QStringList& fallbackModels, QWidget* parent)
-    : QDialog(parent), m_db(db), m_documentIds(documentIds), m_modelInfos(modelInfos), m_fallbackModels(fallbackModels) {
+MergeDocumentsDialog::MergeDocumentsDialog(BookDatabase* db, const QList<int>& documentIds,
+                                           const QList<OllamaModelInfo>& modelInfos, const QStringList& fallbackModels,
+                                           QWidget* parent)
+    : QDialog(parent),
+      m_db(db),
+      m_documentIds(documentIds),
+      m_modelInfos(modelInfos),
+      m_fallbackModels(fallbackModels) {
     setWindowTitle(tr("Merge Documents with AI"));
     setMinimumWidth(600);
     setMinimumHeight(500);
@@ -84,9 +89,7 @@ MergeDocumentsDialog::MergeDocumentsDialog(BookDatabase* db, const QList<int>& d
     titleLayout->addWidget(m_titleEdit);
     layout->addLayout(titleLayout);
 
-    connect(m_titleEdit, &QLineEdit::textEdited, this, [this](const QString&) {
-        m_titleManuallyEdited = true;
-    });
+    connect(m_titleEdit, &QLineEdit::textEdited, this, [this](const QString&) { m_titleManuallyEdited = true; });
 
     // Templates selection
     QHBoxLayout* topLayout = new QHBoxLayout();
@@ -118,7 +121,8 @@ MergeDocumentsDialog::MergeDocumentsDialog(BookDatabase* db, const QList<int>& d
     connect(helpBtn, &QPushButton::clicked, this, &MergeDocumentsDialog::onHelpClicked);
 
     m_instructionEdit = new QTextEdit(this);
-    m_instructionEdit->setPlaceholderText(tr("Use {foreach contexts}...{between}...{end} and {input \"label\"} placeholders..."));
+    m_instructionEdit->setPlaceholderText(
+        tr("Use {foreach contexts}...{between}...{end} and {input \"label\"} placeholders..."));
     m_instructionEdit->setAcceptRichText(false);
     layout->addWidget(m_instructionEdit);
 
@@ -126,7 +130,8 @@ MergeDocumentsDialog::MergeDocumentsDialog(BookDatabase* db, const QList<int>& d
     m_dynamicInputsLayout = new QFormLayout();
     layout->addLayout(m_dynamicInputsLayout);
 
-    QCheckBox* parseTemplateCheck = new QCheckBox(tr("Parse as Template (Uncheck if regenerating previously outputted prompt to prevent double parsing)"), this);
+    QCheckBox* parseTemplateCheck = new QCheckBox(
+        tr("Parse as Template (Uncheck if regenerating previously outputted prompt to prevent double parsing)"), this);
     parseTemplateCheck->setChecked(true);
     m_parseTemplate = true;
     layout->addWidget(parseTemplateCheck);
@@ -173,13 +178,16 @@ MergeDocumentsDialog::MergeDocumentsDialog(BookDatabase* db, const QList<int>& d
 
     loadTemplates();
 
-    connect(m_templateCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &MergeDocumentsDialog::onTemplateChanged);
+    connect(m_templateCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &MergeDocumentsDialog::onTemplateChanged);
     connect(m_instructionEdit, &QTextEdit::textChanged, this, &MergeDocumentsDialog::updateDynamicInputs);
 
     if (m_templateCombo->count() > 0) {
         onTemplateChanged(0);
     } else {
-        m_instructionEdit->setPlainText(tr("Merge the following documents into one coherent document:\n\n{foreach contexts}\nDocument:\n{context}\n{between}\n---\n{end}"));
+        m_instructionEdit->setPlainText(
+            tr("Merge the following documents into one coherent document:\n\n{foreach "
+               "contexts}\nDocument:\n{context}\n{between}\n---\n{end}"));
     }
 }
 
@@ -197,29 +205,33 @@ void MergeDocumentsDialog::loadTemplates() {
 }
 
 void MergeDocumentsDialog::onHelpClicked() {
-    QString helpText = tr(
-        "<b>Template Language Help</b><br><br>"
-        "You can configure how the selected documents are merged using template tags.<br><br>"
-        "<b><code>{foreach contexts} ... {end}</code></b><br>"
-        "Loops over every selected document. Inside this block, use <b><code>{context}</code></b> to output the document's content.<br><br>"
-        "<b><code>{between}</code></b><br>"
-        "Placed inside a <code>{foreach}</code> block to separate documents. Text after <code>{between}</code> is only inserted between documents, not at the very end.<br><br>"
-        "<b>Example:</b><br>"
-        "<code>{foreach contexts}</code><br>"
-        "<code>Doc: {context}</code><br>"
-        "<code>{between}</code><br>"
-        "<code>---</code><br>"
-        "<code>{end}</code><br><br>"
-        "<b>Dynamic Inputs:</b><br>"
-        "You can also use <code>{input \"Label\"}</code> or <code>{textarea \"Label\"}</code> to create custom input fields that will be requested before merging."
-    );
+    QString helpText =
+        tr("<b>Template Language Help</b><br><br>"
+           "You can configure how the selected documents are merged using template tags.<br><br>"
+           "<b><code>{foreach contexts} ... {end}</code></b><br>"
+           "Loops over every selected document. Inside this block, use <b><code>{context}</code></b> to output the "
+           "document's content.<br><br>"
+           "<b><code>{between}</code></b><br>"
+           "Placed inside a <code>{foreach}</code> block to separate documents. Text after <code>{between}</code> is "
+           "only inserted between documents, not at the very end.<br><br>"
+           "<b>Example:</b><br>"
+           "<code>{foreach contexts}</code><br>"
+           "<code>Doc: {context}</code><br>"
+           "<code>{between}</code><br>"
+           "<code>---</code><br>"
+           "<code>{end}</code><br><br>"
+           "<b>Dynamic Inputs:</b><br>"
+           "You can also use <code>{input \"Label\"}</code> or <code>{textarea \"Label\"}</code> to create custom "
+           "input fields that will be requested before merging.");
     QMessageBox::information(this, tr("Template Help"), helpText);
 }
 
 void MergeDocumentsDialog::onTemplateChanged(int index) {
     QString templateName;
     if (index == 0) {
-        m_instructionEdit->setPlainText(tr("Merge the following documents into one coherent document:\n\n{foreach contexts}\nDocument:\n{context}\n{between}\n---\n{end}"));
+        m_instructionEdit->setPlainText(
+            tr("Merge the following documents into one coherent document:\n\n{foreach "
+               "contexts}\nDocument:\n{context}\n{between}\n---\n{end}"));
         templateName = tr("Default Merge");
     } else if (index > 0 && index - 1 < m_templates.size()) {
         m_instructionEdit->setPlainText(m_templates[index - 1].prompt);
@@ -236,17 +248,11 @@ void MergeDocumentsDialog::onTemplateChanged(int index) {
     }
 }
 
-QString MergeDocumentsDialog::getFinalPrompt() const {
-    return m_finalPrompt;
-}
+QString MergeDocumentsDialog::getFinalPrompt() const { return m_finalPrompt; }
 
-QStringList MergeDocumentsDialog::getSelectedModels() const {
-    return m_selectedModels;
-}
+QStringList MergeDocumentsDialog::getSelectedModels() const { return m_selectedModels; }
 
-QString MergeDocumentsDialog::getRawPrompt() const {
-    return m_instructionEdit->toPlainText();
-}
+QString MergeDocumentsDialog::getRawPrompt() const { return m_instructionEdit->toPlainText(); }
 
 void MergeDocumentsDialog::setInitialPrompt(const QString& prompt) {
     if (!prompt.isEmpty()) {
@@ -300,9 +306,9 @@ void MergeDocumentsDialog::setIsRegenerating(bool isRegenerating) {
 int MergeDocumentsDialog::getTargetDocumentId() const {
     int actionData = m_mainActionCombo->currentData().toInt();
     if (actionData == 0) {
-        return 0; // New Document
+        return 0;  // New Document
     } else if (actionData == -1) {
-        return -1; // Replace Existing (resolved in MainWindow)
+        return -1;  // Replace Existing (resolved in MainWindow)
     } else if (actionData == 1) {
         return m_replaceTargetCombo->currentData().toInt();
     }
@@ -322,9 +328,7 @@ QList<int> MergeDocumentsDialog::getDocumentsToDelete() const {
     return result;
 }
 
-QString MergeDocumentsDialog::getTitle() const {
-    return m_titleEdit->text();
-}
+QString MergeDocumentsDialog::getTitle() const { return m_titleEdit->text(); }
 
 void MergeDocumentsDialog::setTitle(const QString& title) {
     m_titleEdit->setText(title);
@@ -381,16 +385,16 @@ void MergeDocumentsDialog::onPreviewClicked() {
     QMessageBox::information(this, tr("Prompt Preview"), prompt);
 }
 
-void MergeDocumentsDialog::onParseTemplateToggled(int state) {
-    m_parseTemplate = (state == Qt::Checked);
-}
+void MergeDocumentsDialog::onParseTemplateToggled(int state) { m_parseTemplate = (state == Qt::Checked); }
 
 void MergeDocumentsDialog::onSaveTemplateClicked() {
     bool ok;
     QString name = QInputDialog::getText(this, tr("Save Template"), tr("Template Name:"), QLineEdit::Normal, "", &ok);
     if (!ok || name.isEmpty()) return;
 
-    QMessageBox::StandardButton reply = QMessageBox::question(this, tr("Save Location"), tr("Save this template globally so it is available in all books?"), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+    QMessageBox::StandardButton reply = QMessageBox::question(
+        this, tr("Save Location"), tr("Save this template globally so it is available in all books?"),
+        QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
     if (reply == QMessageBox::Cancel) return;
 
     AIOperation op;

--- a/src/MergeDocumentsDialog.h
+++ b/src/MergeDocumentsDialog.h
@@ -3,14 +3,15 @@
 
 #include <QComboBox>
 #include <QDialog>
+#include <QLineEdit>
 #include <QList>
 #include <QString>
 #include <QTextEdit>
-#include <QLineEdit>
 #include <memory>
-#include "BookDatabase.h"
+
 #include "AIOperationsManager.h"
-#include "AiActionDialog.h" // For AiDynamicInputInfo
+#include "AiActionDialog.h"  // For AiDynamicInputInfo
+#include "BookDatabase.h"
 #include "OllamaModelInfo.h"
 
 class QFormLayout;
@@ -21,7 +22,9 @@ class QCheckBox;
 class MergeDocumentsDialog : public QDialog {
     Q_OBJECT
    public:
-    explicit MergeDocumentsDialog(BookDatabase* db, const QList<int>& documentIds, const QList<OllamaModelInfo>& modelInfos, const QStringList& fallbackModels, QWidget* parent = nullptr);
+    explicit MergeDocumentsDialog(BookDatabase* db, const QList<int>& documentIds,
+                                  const QList<OllamaModelInfo>& modelInfos, const QStringList& fallbackModels,
+                                  QWidget* parent = nullptr);
 
     QString getFinalPrompt() const;
     QStringList getSelectedModels() const;
@@ -82,4 +85,4 @@ class MergeDocumentsDialog : public QDialog {
     bool m_isRegenerating = false;
 };
 
-#endif // MERGEDOCUMENTSDIALOG_H
+#endif  // MERGEDOCUMENTSDIALOG_H

--- a/src/ModelExplorer.cpp
+++ b/src/ModelExplorer.cpp
@@ -4,19 +4,20 @@
 #include <QDesktopServices>
 #include <QHeaderView>
 #include <QIcon>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QMenu>
 #include <QMessageBox>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QRegularExpression>
 #include <QSettings>
 #include <QUrl>
 #include <QUrlQuery>
-#include <QNetworkRequest>
-#include <QNetworkReply>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonArray>
-#include <QRegularExpression>
 
-ModelExplorer::ModelExplorer(OllamaClient* client, bool isOllama, QWidget* parent) : QDialog(parent), m_client(client), m_isOllama(isOllama), m_networkManager(new QNetworkAccessManager(this)) {
+ModelExplorer::ModelExplorer(OllamaClient* client, bool isOllama, QWidget* parent)
+    : QDialog(parent), m_client(client), m_isOllama(isOllama), m_networkManager(new QNetworkAccessManager(this)) {
     setWindowTitle("Model Explorer");
     resize(800, 600);
 
@@ -91,7 +92,9 @@ void ModelExplorer::setupDownloadTab() {
         externalSearchLayout->addWidget(searchHfButton);
         layout->addLayout(externalSearchLayout);
 
-        QLabel* hfNoteLabel = new QLabel("Note: Downloading Hugging Face models may require configuring Ollama's HF connection (e.g., via HF CLI).", this);
+        QLabel* hfNoteLabel = new QLabel(
+            "Note: Downloading Hugging Face models may require configuring Ollama's HF connection (e.g., via HF CLI).",
+            this);
         hfNoteLabel->setStyleSheet("color: gray; font-style: italic; font-size: 10px;");
         layout->addWidget(hfNoteLabel);
 
@@ -137,7 +140,7 @@ void ModelExplorer::setupOnlineSearchTab() {
     layout->addWidget(m_searchResultsTable);
 
     m_loadMoreButton = new QPushButton("Load More", this);
-    m_loadMoreButton->hide(); // Hidden initially
+    m_loadMoreButton->hide();  // Hidden initially
     layout->addWidget(m_loadMoreButton);
 
     QPushButton* downloadSelectedBtn = new QPushButton("Download Selected", this);
@@ -222,12 +225,13 @@ void ModelExplorer::onLoadMoreClicked() {
             if (doc.isArray()) {
                 QJsonArray arr = doc.array();
                 if (arr.isEmpty()) {
-                    m_loadMoreButton->hide(); // No more results
+                    m_loadMoreButton->hide();  // No more results
                 } else {
                     for (const QJsonValue& val : arr) {
                         QJsonObject obj = val.toObject();
                         QString name = obj["id"].toString();
-                        QString desc = "Downloads: " + QString::number(obj["downloads"].toInt()) + ", Pipeline: " + obj["pipeline_tag"].toString();
+                        QString desc = "Downloads: " + QString::number(obj["downloads"].toInt()) +
+                                       ", Pipeline: " + obj["pipeline_tag"].toString();
                         int row = m_searchResultsTable->rowCount();
                         m_searchResultsTable->insertRow(row);
                         m_searchResultsTable->setItem(row, 0, new QTableWidgetItem(name));
@@ -301,7 +305,8 @@ void ModelExplorer::onOnlineSearchClicked() {
                     for (const QJsonValue& val : arr) {
                         QJsonObject obj = val.toObject();
                         QString name = obj["id"].toString();
-                        QString desc = "Downloads: " + QString::number(obj["downloads"].toInt()) + ", Pipeline: " + obj["pipeline_tag"].toString();
+                        QString desc = "Downloads: " + QString::number(obj["downloads"].toInt()) +
+                                       ", Pipeline: " + obj["pipeline_tag"].toString();
                         int row = m_searchResultsTable->rowCount();
                         m_searchResultsTable->insertRow(row);
                         m_searchResultsTable->setItem(row, 0, new QTableWidgetItem(name));
@@ -331,7 +336,7 @@ void ModelExplorer::onDownloadFromSearchClicked() {
     }
 
     m_downloadNameField->setText(name);
-    m_tabWidget->setCurrentIndex(1); // Switch back to Download Models tab
+    m_tabWidget->setCurrentIndex(1);  // Switch back to Download Models tab
     onDownloadModelClicked();
 }
 

--- a/src/ModelExplorer.h
+++ b/src/ModelExplorer.h
@@ -1,19 +1,18 @@
 #ifndef MODELEXPLORER_H
 #define MODELEXPLORER_H
 
+#include <QComboBox>
 #include <QDialog>
 #include <QHBoxLayout>
 #include <QLabel>
-#include <QComboBox>
 #include <QLineEdit>
 #include <QListWidget>
+#include <QNetworkAccessManager>
 #include <QProgressBar>
 #include <QPushButton>
 #include <QTabWidget>
 #include <QTableWidget>
 #include <QVBoxLayout>
-
-#include <QNetworkAccessManager>
 
 #include "OllamaClient.h"
 #include "OllamaModelInfo.h"

--- a/src/OllamaModelInfo.h
+++ b/src/OllamaModelInfo.h
@@ -11,4 +11,4 @@ struct OllamaModelInfo {
     QString quantizationLevel;
 };
 
-#endif // OLLAMAMODELINFO_H
+#endif  // OLLAMAMODELINFO_H

--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -12,7 +12,8 @@ QueueManager& QueueManager::instance() {
     return instance;
 }
 
-QueueManager::QueueManager(QObject* parent) : QObject(parent), m_timer(new QTimer(this)), m_isPaused(false), m_probeTimer(new QTimer(this)) {
+QueueManager::QueueManager(QObject* parent)
+    : QObject(parent), m_timer(new QTimer(this)), m_isPaused(false), m_probeTimer(new QTimer(this)) {
     connect(m_timer, &QTimer::timeout, this, &QueueManager::checkQueue);
     m_timer->start(1000);  // Check every second
 
@@ -57,7 +58,8 @@ void QueueManager::retryItem(std::shared_ptr<BookDatabase> db, int queueId) {
     }
 }
 
-void QueueManager::modifyItem(std::shared_ptr<BookDatabase> db, int queueId, const QString& newPrompt, const QString& newModel) {
+void QueueManager::modifyItem(std::shared_ptr<BookDatabase> db, int queueId, const QString& newPrompt,
+                              const QString& newModel) {
     if (db) {
         db->updateQueueItemPrompt(queueId, newPrompt);
         if (!newModel.isEmpty()) db->updateQueueItemModel(queueId, newModel);
@@ -414,10 +416,9 @@ void QueueManager::processNext() {
                     auto act = m_activeItems[procId];
                     if (act.db && act.db->isOpen()) {
                         if (errorCode == QNetworkReply::ConnectionRefusedError ||
-                            errorCode == QNetworkReply::HostNotFoundError ||
-                            errorCode == QNetworkReply::TimeoutError) {
+                            errorCode == QNetworkReply::HostNotFoundError || errorCode == QNetworkReply::TimeoutError) {
                             act.db->updateQueueItemState(act.item.id, "pending");
-                            act.db->updateQueueError(act.item.id, ""); // also resets processing_id to 0
+                            act.db->updateQueueError(act.item.id, "");  // also resets processing_id to 0
                         } else {
                             act.db->updateQueueError(act.item.id, error);
                             act.db->addNotification(act.item.messageId, act.item.targetType, "error");
@@ -499,10 +500,9 @@ void QueueManager::processNext() {
                     auto act = m_activeItems[procId];
                     if (act.db && act.db->isOpen()) {
                         if (errorCode == QNetworkReply::ConnectionRefusedError ||
-                            errorCode == QNetworkReply::HostNotFoundError ||
-                            errorCode == QNetworkReply::TimeoutError) {
+                            errorCode == QNetworkReply::HostNotFoundError || errorCode == QNetworkReply::TimeoutError) {
                             act.db->updateQueueItemState(act.item.id, "pending");
-                            act.db->updateQueueError(act.item.id, ""); // also resets processing_id to 0
+                            act.db->updateQueueError(act.item.id, "");  // also resets processing_id to 0
                         } else {
                             act.db->updateQueueError(act.item.id, error);
                             act.db->addNotification(act.item.messageId, act.item.targetType, "error");

--- a/src/QueueManager.h
+++ b/src/QueueManager.h
@@ -43,7 +43,8 @@ class QueueManager : public QObject {
 
     void cancelItem(std::shared_ptr<BookDatabase> db, int queueId);
     void retryItem(std::shared_ptr<BookDatabase> db, int queueId);
-    void modifyItem(std::shared_ptr<BookDatabase> db, int queueId, const QString& newPrompt, const QString& newModel = QString());
+    void modifyItem(std::shared_ptr<BookDatabase> db, int queueId, const QString& newPrompt,
+                    const QString& newModel = QString());
 
     void clearCompleted();
     void pauseQueue();
@@ -77,12 +78,12 @@ class QueueManager : public QObject {
     OllamaClient* m_client = nullptr;
     QTimer* m_timer;
 
-    QMap<int, MergedQueueItem> m_activeItems; // Map processingId to QueueItem
+    QMap<int, MergedQueueItem> m_activeItems;  // Map processingId to QueueItem
     int m_maxConcurrent = 1;
     bool m_isPaused = false;
     QString m_lastProcessedModel;
 
-    int m_nextProcessingId = 1; // Counter to track unique processing IDs
+    int m_nextProcessingId = 1;  // Counter to track unique processing IDs
     bool m_isEndpointUp = true;
     QTimer* m_probeTimer;
 

--- a/src/QueueWindow.cpp
+++ b/src/QueueWindow.cpp
@@ -2,12 +2,12 @@
 
 #include <QApplication>
 #include <QFileInfo>
+#include <QFormLayout>
 #include <QHeaderView>
 #include <QInputDialog>
 #include <QMenu>
 #include <QMessageBox>
 #include <QTextEdit>
-#include <QFormLayout>
 
 QueueWindow::QueueWindow(QWidget* parent) : QWidget(parent, Qt::Window) {
     setWindowTitle("LLM Request Queue");
@@ -38,9 +38,7 @@ QueueWindow::QueueWindow(QWidget* parent) : QWidget(parent, Qt::Window) {
     connect(m_clearBtn, &QPushButton::clicked, this, &QueueWindow::onClearCompleted);
     connect(m_queueList, &QListWidget::itemSelectionChanged, this, &QueueWindow::updateButtons);
 
-    connect(m_queueList, &QListWidget::itemDoubleClicked, this, [this](QListWidgetItem*) {
-        onJumpItem();
-    });
+    connect(m_queueList, &QListWidget::itemDoubleClicked, this, [this](QListWidgetItem*) { onJumpItem(); });
 
     connect(pauseBtn, &QPushButton::clicked, this, [this, pauseBtn]() {
         if (QueueManager::instance().isPaused()) {
@@ -328,8 +326,7 @@ void QueueWindow::onJumpItem() {
                     if (mainWin) {
                         QMetaObject::invokeMethod(mainWin, "onQueueItemClicked",
                                                   Q_ARG(std::shared_ptr<BookDatabase>, db),
-                                                  Q_ARG(int, mi.item.messageId),
-                                                  Q_ARG(QString, mi.item.targetType));
+                                                  Q_ARG(int, mi.item.messageId), Q_ARG(QString, mi.item.targetType));
                     }
                     break;
                 }

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -173,7 +173,8 @@ SettingsDialog::SettingsDialog(QWidget* parent) : QDialog(parent) {
 
     m_connectionsTable = new QTableWidget(this);
     m_connectionsTable->setColumnCount(5);
-    m_connectionsTable->setHorizontalHeaderLabels({tr("Name"), tr("Backend"), tr("URL"), tr("Auth Key"), tr("Max Concurrent")});
+    m_connectionsTable->setHorizontalHeaderLabels(
+        {tr("Name"), tr("Backend"), tr("URL"), tr("Auth Key"), tr("Max Concurrent")});
     m_connectionsTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
     m_connectionsTable->setSelectionBehavior(QAbstractItemView::SelectRows);
     m_connectionsTable->setEditTriggers(QAbstractItemView::NoEditTriggers);

--- a/src/TemplateParser.cpp
+++ b/src/TemplateParser.cpp
@@ -1,11 +1,13 @@
 #include "TemplateParser.h"
+
 #include <QRegularExpression>
 
 QString TemplateParser::parseMergeTemplate(QString prompt, const QList<QString>& documentContents) {
     // Process {foreach contexts} block
     // Syntax: {foreach contexts} ... {context} ... [{between} ... ] {end}
     // Note: Use a non-greedy match for the block
-    QRegularExpression foreachRe("\\{foreach contexts\\}(.*?)\\{end\\}", QRegularExpression::DotMatchesEverythingOption);
+    QRegularExpression foreachRe("\\{foreach contexts\\}(.*?)\\{end\\}",
+                                 QRegularExpression::DotMatchesEverythingOption);
 
     int offset = 0;
     while (true) {
@@ -24,7 +26,7 @@ QString TemplateParser::parseMergeTemplate(QString prompt, const QList<QString>&
 
         if (betweenIndex != -1) {
             mainPart = innerBlock.left(betweenIndex);
-            betweenPart = innerBlock.mid(betweenIndex + 9); // length of "{between}"
+            betweenPart = innerBlock.mid(betweenIndex + 9);  // length of "{between}"
         }
 
         for (int k = 0; k < documentContents.size(); ++k) {

--- a/src/TemplateParser.h
+++ b/src/TemplateParser.h
@@ -5,8 +5,8 @@
 #include <QString>
 
 class TemplateParser {
-public:
+   public:
     static QString parseMergeTemplate(QString prompt, const QList<QString>& documentContents);
 };
 
-#endif // TEMPLATEPARSER_H
+#endif  // TEMPLATEPARSER_H


### PR DESCRIPTION
Fix lint issues flagged by cppcheck and format code with clang-format -i to pass static checks.
The issues fixed:
- Add `explicit` keyword to `BookDatabase` constructor with one argument.
- Resolve variable shadowing for `stmt` by renaming the inner variable to `inner_stmt` in `BookDatabase.cpp`.
- Remove the unused assignment to `userVersion` in `BookDatabase.cpp`.
- Initialize `node.isFolder` in `BookDatabase.cpp`.
- Make the pointer parameter `BookDatabase* db` const in `DocumentTemplatesManager`.
- Fix the `cstyleCast` warnings by using `reinterpret_cast`.
- Format all source files with `clang-format -i`.

---
*PR created automatically by Jules for task [15804891937669758672](https://jules.google.com/task/15804891937669758672) started by @arran4*