### PR TITLE
fix: Correct OVERLAY_GITHUB_TOKEN typo in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,7 +477,7 @@ jobs:
         with:
           repository: arran4/arrans_overlay
           path: arrans_overlay
-          token: ${{ secrets.OVERLAY_GITHB_TOKEN }}
+          token: ${{ secrets.OVERLAY_GITHUB_TOKEN }}
 
       - name: Set up Git
         run: |
@@ -517,7 +517,7 @@ jobs:
 
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ secrets.OVERLAY_GITHB_TOKEN }}
+          GH_TOKEN: ${{ secrets.OVERLAY_GITHUB_TOKEN }}
         run: |
           cd arrans_overlay
           VERSION="${GITHUB_REF#refs/tags/v}"


### PR DESCRIPTION
Corrects a typo in the GitHub Actions CI workflow where `OVERLAY_GITHB_TOKEN` was used instead of `OVERLAY_GITHUB_TOKEN`. This typo caused the 'actions/checkout@v4' step to fail with 'Input required and not supplied: token'.

---
*PR created automatically by Jules for task [11101154861201534479](https://jules.google.com/task/11101154861201534479) started by @arran4*