### PR TITLE
fix: use pre-rendered png for desktop icon instead of missing svg

### DIFF
--- a/.jules/Dockerfile
+++ b/.jules/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie-slim
+FROM mirror.gcr.io/library/debian:trixie-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,9 +118,9 @@ add_executable(test_TemplateParser tests/test_TemplateParser.cpp src/TemplatePar
 target_link_libraries(test_TemplateParser Qt6::Test Qt6::Core)
 add_test(NAME test_TemplateParser COMMAND test_TemplateParser)
 
-install(FILES src/assets/icon.svg
-    DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps
-    RENAME kllamabooks.svg
+install(FILES src/assets/icon.png
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/512x512/apps
+    RENAME kllamabooks.png
 )
 
 install(FILES src/kllamabooks.notifyrc


### PR DESCRIPTION
Changed `CMakeLists.txt` to install `icon.png` instead of the non-existent `icon.svg` and adjusted the target installation path to `icons/hicolor/512x512/apps`.

---
*PR created automatically by Jules for task [11768473921712589614](https://jules.google.com/task/11768473921712589614) started by @arran4*