### PR TITLE
feat: Add unique toolbar icons and context creation menu

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,10 @@
+1. **Update `src/MainWindow.cpp`**:
+    - Keep `newContextItemAction` without a `QMenu`. This ensures it remains a clickable item in standard menus.
+    - Create a new action `newContextItemToolbarAction` that shares the same icon, text, and trigger slot as `newContextItemAction`.
+    - Attach the `contextMenu` (containing Chat, Document, etc.) to `newContextItemToolbarAction`.
+    - Register `newContextItemToolbarAction` with `actionCollection()->addAction(QStringLiteral("new_context_item_toolbar"), newContextItemToolbarAction);`.
+2. **Update `src/kllamabooksui.rc`**:
+    - In `<Menu name="file">`, move `<Action name="new_context_item" />` to be the first item inside the `<Menu name="new_items">` (the "New" submenu). This groups all "New" actions logically and removes the confusion of having both a "New" menu and a "New Context Item" directly in File.
+    - In the `<ToolBar name="mainToolBar">`, replace `<Action name="new_context_item" />` with `<Action name="new_context_item_toolbar" />`. This gives the toolbar button the required dropdown without breaking the File menu.
+3. **Run `cppcheck`** to ensure no syntax issues.
+4. **Submit** the changes.

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -681,7 +681,7 @@ void MainWindow::setupUi() {
     actionCollection()->addAction(QStringLiteral("open_book_location"), openBookLocationAction);
     connect(openBookLocationAction, &QAction::triggered, this, &MainWindow::onOpenBookLocation);
 
-    QAction* newChatMenuAction = new QAction(QIcon::fromTheme("chat-message-new"), tr("New Chat"), this);
+    QAction* newChatMenuAction = new QAction(QIcon(":/assets/chat-new.svg"), tr("New Chat"), this);
     actionCollection()->addAction(QStringLiteral("new_chat"), newChatMenuAction);
     connect(newChatMenuAction, &QAction::triggered, this, [this]() { addPhantomItem(nullptr, "chats_folder"); });
 
@@ -689,20 +689,28 @@ void MainWindow::setupUi() {
     actionCollection()->addAction(QStringLiteral("new_document"), newDocMenuAction);
     connect(newDocMenuAction, &QAction::triggered, this, [this]() { handleNewDocumentCreation(0); });
 
-    QAction* newNoteMenuAction = new QAction(QIcon::fromTheme("document-new"), tr("New Note"), this);
+    QAction* newNoteMenuAction = new QAction(QIcon(":/assets/note-new.svg"), tr("New Note"), this);
     actionCollection()->addAction(QStringLiteral("new_note"), newNoteMenuAction);
     connect(newNoteMenuAction, &QAction::triggered, this, [this]() { addPhantomItem(nullptr, "notes_folder"); });
 
-    QAction* newTemplateMenuAction = new QAction(QIcon::fromTheme("document-new"), tr("New Template"), this);
+    QAction* newTemplateMenuAction = new QAction(QIcon(":/assets/template-new.svg"), tr("New Template"), this);
     actionCollection()->addAction(QStringLiteral("new_template"), newTemplateMenuAction);
     connect(newTemplateMenuAction, &QAction::triggered, this,
             [this]() { addPhantomItem(nullptr, "templates_folder"); });
 
-    QAction* newDraftMenuAction = new QAction(QIcon::fromTheme("document-new"), tr("New Draft"), this);
+    QAction* newDraftMenuAction = new QAction(QIcon(":/assets/draft-new.svg"), tr("New Draft"), this);
     actionCollection()->addAction(QStringLiteral("new_draft"), newDraftMenuAction);
     connect(newDraftMenuAction, &QAction::triggered, this, [this]() { addPhantomItem(nullptr, "drafts_folder"); });
 
-    QAction* newContextItemAction = new QAction(QIcon::fromTheme("document-new"), tr("New Context Item"), this);
+    QAction* newContextItemAction = new QAction(QIcon(":/assets/context-new.svg"), tr("New Context Item"), this);
+    QMenu* contextMenu = new QMenu(this);
+    contextMenu->addAction(newChatMenuAction);
+    contextMenu->addAction(newDocMenuAction);
+    contextMenu->addAction(newNoteMenuAction);
+    contextMenu->addAction(newTemplateMenuAction);
+    contextMenu->addAction(newDraftMenuAction);
+    newContextItemAction->setMenu(contextMenu);
+
     actionCollection()->addAction(QStringLiteral("new_context_item"), newContextItemAction);
     actionCollection()->setDefaultShortcut(newContextItemAction, QKeySequence::New);
     connect(newContextItemAction, &QAction::triggered, this, &MainWindow::onNewContextItemTriggered);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -703,17 +703,21 @@ void MainWindow::setupUi() {
     connect(newDraftMenuAction, &QAction::triggered, this, [this]() { addPhantomItem(nullptr, "drafts_folder"); });
 
     QAction* newContextItemAction = new QAction(QIcon(":/assets/context-new.svg"), tr("New Context Item"), this);
+    actionCollection()->addAction(QStringLiteral("new_context_item"), newContextItemAction);
+    actionCollection()->setDefaultShortcut(newContextItemAction, QKeySequence::New);
+    connect(newContextItemAction, &QAction::triggered, this, &MainWindow::onNewContextItemTriggered);
+
+    QAction* newContextItemToolbarAction = new QAction(QIcon(":/assets/context-new.svg"), tr("New Context Item"), this);
     QMenu* contextMenu = new QMenu(this);
     contextMenu->addAction(newChatMenuAction);
     contextMenu->addAction(newDocMenuAction);
     contextMenu->addAction(newNoteMenuAction);
     contextMenu->addAction(newTemplateMenuAction);
     contextMenu->addAction(newDraftMenuAction);
-    newContextItemAction->setMenu(contextMenu);
+    newContextItemToolbarAction->setMenu(contextMenu);
 
-    actionCollection()->addAction(QStringLiteral("new_context_item"), newContextItemAction);
-    actionCollection()->setDefaultShortcut(newContextItemAction, QKeySequence::New);
-    connect(newContextItemAction, &QAction::triggered, this, &MainWindow::onNewContextItemTriggered);
+    actionCollection()->addAction(QStringLiteral("new_context_item_toolbar"), newContextItemToolbarAction);
+    connect(newContextItemToolbarAction, &QAction::triggered, this, &MainWindow::onNewContextItemTriggered);
 
     QAction* createFolderMenuAction = new QAction(QIcon::fromTheme("folder-new"), tr("Create Folder"), this);
     actionCollection()->addAction(QStringLiteral("create_folder_menu"), createFolderMenuAction);

--- a/src/assets/chat-new.svg
+++ b/src/assets/chat-new.svg
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='utf-8'?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z" fill="currentColor" /></svg>

--- a/src/assets/context-new.svg
+++ b/src/assets/context-new.svg
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='utf-8'?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path d="M3 4h14v2H3V4zm0 5h14v2H3V9zm0 5h10v2H3v-2zm12-2v3h-3v2h3v3h2v-3h3v-2h-3v-3h-2z" fill="currentColor" /></svg>

--- a/src/assets/draft-new.svg
+++ b/src/assets/draft-new.svg
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='utf-8'?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z" fill="currentColor" /></svg>

--- a/src/assets/note-new.svg
+++ b/src/assets/note-new.svg
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='utf-8'?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path d="M4 4c0-1.1.9-2 2-2h12a2 2 0 0 1 2 2v16a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4zm2 0v16h12V4H6zm2 4h8v2H8V8zm0 4h8v2H8v-2zm0 4h5v2H8v-2z" fill="currentColor" /></svg>

--- a/src/assets/template-new.svg
+++ b/src/assets/template-new.svg
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='utf-8'?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm-1 1.5L18.5 9H13V3.5zM6 20V4h5v7h7v9H6zm2-4h8v2H8v-2zm0-4h8v2H8v-2z" fill="currentColor" /></svg>

--- a/src/kllamabooksui.rc
+++ b/src/kllamabooksui.rc
@@ -11,9 +11,10 @@
             <Action name="new_book" />
             <Action name="open_book" />
             <Separator />
-            <Action name="new_context_item" />
             <Menu name="new_items">
                 <text>&amp;New</text>
+                <Action name="new_context_item" />
+                <Separator />
                 <Action name="new_chat" />
                 <Action name="new_document" />
                 <Action name="new_note" />
@@ -60,7 +61,7 @@
         <Separator />
         <Action name="nav_up" />
         <Separator />
-        <Action name="new_context_item" />
+        <Action name="new_context_item_toolbar" />
         <Separator />
         <Action name="create_folder" />
         <Separator />

--- a/src/kllamabooksui.rc
+++ b/src/kllamabooksui.rc
@@ -60,7 +60,6 @@
         <Separator />
         <Action name="nav_up" />
         <Separator />
-        <Action name="new_chat" />
         <Action name="new_context_item" />
         <Separator />
         <Action name="create_folder" />

--- a/src/kllamabooksui.rc
+++ b/src/kllamabooksui.rc
@@ -61,10 +61,7 @@
         <Action name="nav_up" />
         <Separator />
         <Action name="new_chat" />
-        <Action name="new_document" />
-        <Action name="new_note" />
-        <Action name="new_template" />
-        <Action name="new_draft" />
+        <Action name="new_context_item" />
         <Separator />
         <Action name="create_folder" />
         <Separator />

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -3,6 +3,11 @@
     <qresource prefix="/">
         <file>assets/icon.png</file>
         <file>assets/icon-dotted.png</file>
+        <file>assets/chat-new.svg</file>
+        <file>assets/note-new.svg</file>
+        <file>assets/template-new.svg</file>
+        <file>assets/draft-new.svg</file>
+        <file>assets/context-new.svg</file>
         <file>kllamabooksui.rc</file>
         <file>kdocumenteditwindowui.rc</file>
         <file>kllamabooks.desktop</file>


### PR DESCRIPTION
This implements the user's request to have more unique toolbar icons, particularly for the new actions, and adding an icon to "new chat". The "new contextual" item was added to group all creation logic (Note, Template, Draft, Chat, Document) as a drop-down in the toolbar.

---
*PR created automatically by Jules for task [3676857067736628786](https://jules.google.com/task/3676857067736628786) started by @arran4*