### PR TITLE
Fix new folder expansion in tree view

### DIFF
--- a/src/BookDatabase.cpp
+++ b/src/BookDatabase.cpp
@@ -1246,10 +1246,10 @@ bool BookDatabase::deleteDraft(int id) {
     return rc == SQLITE_DONE;
 }
 
-int BookDatabase::addFolder(int parentId, const QString& name, const QString& type) {
+int BookDatabase::addFolder(int parentId, const QString& name, const QString& type, bool isExpanded) {
     if (!m_isOpen) return -1;
 
-    const char* sql = "INSERT INTO folders (parent_id, name, type) VALUES (?, ?, ?);";
+    const char* sql = "INSERT INTO folders (parent_id, name, type, is_expanded) VALUES (?, ?, ?, ?);";
     sqlite3_stmt* stmt;
     int rc = sqlite3_prepare_v2(reinterpret_cast<sqlite3*>(m_db), sql, -1, &stmt, nullptr);
     if (rc != SQLITE_OK) return -1;
@@ -1257,6 +1257,7 @@ int BookDatabase::addFolder(int parentId, const QString& name, const QString& ty
     sqlite3_bind_int(stmt, 1, parentId);
     sqlite3_bind_text(stmt, 2, name.toUtf8().constData(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 3, type.toUtf8().constData(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 4, isExpanded ? 1 : 0);
 
     rc = sqlite3_step(stmt);
     if (rc != SQLITE_DONE) {

--- a/src/BookDatabase.h
+++ b/src/BookDatabase.h
@@ -176,7 +176,7 @@ class BookDatabase {
     bool deleteNote(int id);
 
     // Folders
-    int addFolder(int parentId, const QString& name, const QString& type);
+    int addFolder(int parentId, const QString& name, const QString& type, bool isExpanded = false);
     bool updateFolder(int id, const QString& newName);
     bool deleteFolder(int id);
     void setFolderExpanded(int id, bool expanded);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -752,7 +752,8 @@ void MainWindow::setupUi() {
                 else if (type == "notes_folder")
                     fType = "notes";
 
-                currentDb->addFolder(parentId, name, fType);
+                currentDb->addFolder(parentId, name, fType, true);
+                currentDb->setFolderExpanded(parentId, true);
                 loadDocumentsAndNotes();
             }
         }
@@ -1804,7 +1805,8 @@ void MainWindow::showItemContextMenu(QStandardItem* item, const QPoint& globalPo
                 else if (type == "chats_folder")
                     fType = "chats";
 
-                currentDb->addFolder(parentId, name, fType);
+                currentDb->addFolder(parentId, name, fType, true);
+                currentDb->setFolderExpanded(parentId, true);
                 loadDocumentsAndNotes();
             }
         } else if (importAction && selectedAction == importAction) {


### PR DESCRIPTION
Fixes an issue where newly created sub-folders would not appear immediately because the parent folder was not auto-expanded.
This changes `BookDatabase::addFolder` to accept an `is_expanded` flag and manually expands the parent folder after a successful creation from the UI.

---
*PR created automatically by Jules for task [3995761740589987805](https://jules.google.com/task/3995761740589987805) started by @arran4*