### PR TITLE
Fix New Document Dialog folder tree expansion to mirror VFS

### DIFF
--- a/src/NewDocumentDialog.cpp
+++ b/src/NewDocumentDialog.cpp
@@ -92,7 +92,7 @@ NewDocumentDialog::NewDocumentDialog(std::shared_ptr<BookDatabase> db, int defau
         populateDocuments();
     }
 
-    m_folderTree->expandAll();
+    rootItem->setExpanded(true);
     mainLayout->addWidget(m_folderTree);
 
     // Buttons
@@ -102,6 +102,9 @@ NewDocumentDialog::NewDocumentDialog(std::shared_ptr<BookDatabase> db, int defau
     connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
     connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
     connect(m_typeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &NewDocumentDialog::onTypeChanged);
+
+    // We intentionally do not connect itemExpanded / itemCollapsed to save the state,
+    // so that the user's opens and closes in this dialog do not impact the original VFS.
 }
 
 void NewDocumentDialog::populateFolders(QTreeWidgetItem* parentItem, int parentId) {
@@ -116,6 +119,9 @@ void NewDocumentDialog::populateFolders(QTreeWidgetItem* parentItem, int parentI
                 item->setSelected(true);
             }
             populateFolders(item, folder.id);
+            if (folder.isExpanded) {
+                item->setExpanded(true);
+            }
         }
     }
 }


### PR DESCRIPTION
This patch modifies `NewDocumentDialog` to initialize its folder tree mirroring the user's expanded/collapsed state from the main virtual file system (VFS). It prevents the tree from being fully expanded initially and ensures that expanding/collapsing items within the dialog does not modify the original VFS state.

---
*PR created automatically by Jules for task [3857794023140016122](https://jules.google.com/task/3857794023140016122) started by @arran4*