### PR TITLE
feat(queue): enforce per-source concurrency limits

### DIFF
--- a/.jules/Dockerfile
+++ b/.jules/Dockerfile
@@ -1,4 +1,4 @@
-FROM mirror.gcr.io/library/debian:trixie-slim
+FROM public.ecr.aws/docker/library/debian:trixie-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \

--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -293,11 +293,27 @@ void QueueManager::processNext() {
                   }
               });
 
-    int tasksToStart = qMin(m_maxConcurrent - m_activeItems.size(), allPending.size());
-    for (int t = 0; t < tasksToStart; ++t) {
+    int tasksToStart = m_maxConcurrent - m_activeItems.size();
+    if (tasksToStart <= 0) return;
+
+    for (int t = 0; t < allPending.size(); ++t) {
         auto nextItem = allPending[t];
         auto db = nextItem.db;
         auto item = nextItem.item;
+
+        // Check if there is an active item with the same source (db, targetType, messageId)
+        bool sourceIsActive = false;
+        for (auto it = m_activeItems.begin(); it != m_activeItems.end(); ++it) {
+            if (it.value().db == db && it.value().item.targetType == item.targetType &&
+                it.value().item.messageId == item.messageId) {
+                sourceIsActive = true;
+                break;
+            }
+        }
+
+        if (sourceIsActive) {
+            continue;
+        }
 
         int procId = m_nextProcessingId++;
         item.processingId = procId;
@@ -310,6 +326,9 @@ void QueueManager::processNext() {
 
         emit processingStarted(db, item.messageId, item.targetType);
         emit queueChanged();
+
+        tasksToStart--;
+        if (tasksToStart <= 0) break;
 
         QString sysPrompt = db->getInheritedSetting(item.messageId, "systemPrompt");
         if (sysPrompt.isEmpty()) {


### PR DESCRIPTION
This change updates `QueueManager::processNext()` to iterate over all pending jobs rather than simply slicing the top items by concurrency size. While checking pending items, it checks if any active task shares the identical `db`, `targetType`, and `messageId` source. If an active match is found, the pending job is safely skipped, allowing the queue scheduler to dispatch subsequent unaffected jobs while the identical source remains blocked until completion.

---
*PR created automatically by Jules for task [2957480488630954907](https://jules.google.com/task/2957480488630954907) started by @arran4*