### PR TITLE
fix: resolve flatpak-builder errors in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,7 @@ jobs:
         run: flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
       - name: Build Flatpak
         run: |
-          flatpak-builder --repo=repo --force-clean --install-deps-from=flathub build-dir packaging/flatpak/com.arran4.kllamabooks.yaml
+          flatpak-builder --user --repo=repo --force-clean --install-deps-from=flathub build-dir packaging/flatpak/com.arran4.kllamabooks.yaml
           flatpak build-bundle repo kllamabooks.flatpak com.arran4.kllamabooks
 
       - uses: actions/upload-artifact@v4

--- a/packaging/flatpak/com.arran4.kllamabooks.yaml
+++ b/packaging/flatpak/com.arran4.kllamabooks.yaml
@@ -29,4 +29,4 @@ modules:
     sources:
       - type: dir
         path: ../../
-        exclude: [ "build", ".flatpak-builder", ".git" ]
+        skip: [ "build", ".flatpak-builder", ".git" ]


### PR DESCRIPTION
Resolves build failures in the Flatpak CI step. The Flatpak manifest contained an invalid `exclude` key for directory sources, which was changed to `skip`. The `flatpak-builder` command in the CI workflow now uses the `--user` flag to find user-installed remotes like Flathub.

---
*PR created automatically by Jules for task [13225519554443991473](https://jules.google.com/task/13225519554443991473) started by @arran4*