### PR TITLE
Fix Flatpak build compiler flags syntax

### DIFF
--- a/packaging/flatpak/com.arran4.kllamabooks.yaml
+++ b/packaging/flatpak/com.arran4.kllamabooks.yaml
@@ -16,8 +16,8 @@ modules:
     config-opts:
       - --enable-tempstore=yes
       - --disable-tcl
-      - CFLAGS=-DSQLITE_HAS_CODEC
-      - LDFLAGS=-lcrypto
+      - CPPFLAGS=-DSQLITE_HAS_CODEC
+      - LIBS=-lcrypto
     sources:
       - type: archive
         url: https://github.com/sqlcipher/sqlcipher/archive/v4.5.5.tar.gz

--- a/packaging/flatpak/com.arran4.kllamabooks.yaml
+++ b/packaging/flatpak/com.arran4.kllamabooks.yaml
@@ -16,8 +16,8 @@ modules:
     config-opts:
       - --enable-tempstore=yes
       - --disable-tcl
-      - CFLAGS="-DSQLITE_HAS_CODEC"
-      - LDFLAGS="-lcrypto"
+      - CFLAGS=-DSQLITE_HAS_CODEC
+      - LDFLAGS=-lcrypto
     sources:
       - type: archive
         url: https://github.com/sqlcipher/sqlcipher/archive/v4.5.5.tar.gz


### PR DESCRIPTION
Removed literal double quotes surrounding the values of CFLAGS and LDFLAGS in the flatpak manifest. This fixes a compilation error during the CI build process caused by `flatpak-builder` passing the quoted strings literally to the `configure` script, which prevented `gcc` from correctly parsing the arguments.

---
*PR created automatically by Jules for task [7783353462041594388](https://jules.google.com/task/7783353462041594388) started by @arran4*