### PR TITLE
Format queue items as multi-line for better readability

### DIFF
--- a/src/QueueWindow.cpp
+++ b/src/QueueWindow.cpp
@@ -98,7 +98,7 @@ void QueueWindow::refresh() {
             if (targetTitle.isEmpty()) targetTitle = "Chat";
         }
 
-        QString text = QString("[%1] %2 | %3: %4 | %5 (%6)")
+        QString text = QString("[%1] %2\n%3: %4\nModel: %6\nPrompt: %5")
                            .arg(statusStr)
                            .arg(QFileInfo(mi.db->filepath()).fileName())
                            .arg(mi.item.targetType.toUpper())
@@ -107,7 +107,7 @@ void QueueWindow::refresh() {
                            .arg(mi.item.model);
 
         if (statusStr == "ERROR" && !mi.item.lastError.isEmpty()) {
-            text += QString(" - Error: %1").arg(mi.item.lastError);
+            text += QString("\nError: %1").arg(mi.item.lastError);
         }
 
         QListWidgetItem* listItem = new QListWidgetItem(text, m_queueList);


### PR DESCRIPTION
Replaced single-line queue entry formatting with a multi-line structure in `QueueWindow::refresh` to improve UX readability.

---
*PR created automatically by Jules for task [4075792769937567868](https://jules.google.com/task/4075792769937567868) started by @arran4*