### PR TITLE
feat(ui): add endpoint and model selection to new AI document dialog

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -5554,7 +5554,7 @@ void MainWindow::handleNewDocumentCreation(int defaultFolderId) {
         QMessageBox::warning(this, tr("No Book Open"), tr("Please open a book first to create a document."));
         return;
     }
-    NewDocumentDialog dialog(currentDb, defaultFolderId, m_availableModelInfos, m_availableModels, endpointComboBox, this);
+    NewDocumentDialog dialog(currentDb, defaultFolderId, m_availableModelInfos, m_availableModels, endpointComboBox, m_selectedModels, this);
     if (dialog.exec() == QDialog::Accepted) {
         QString title = dialog.getTitle();
         int folderId = dialog.getSelectedFolderId();
@@ -5572,10 +5572,8 @@ void MainWindow::handleNewDocumentCreation(int defaultFolderId) {
 
             QString prompt = dialog.getPrompt();
 
-            QStringList models = dialog.getSelectedModels();
-            if (models.isEmpty() && !m_availableModels.isEmpty()) {
-                models.append(m_availableModels.first());
-            }
+            m_selectedModels = dialog.getSelectedModels();
+            QStringList models = m_selectedModels;
 
             QJsonObject metaObj;
             metaObj["prompt"] = prompt;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -5554,7 +5554,7 @@ void MainWindow::handleNewDocumentCreation(int defaultFolderId) {
         QMessageBox::warning(this, tr("No Book Open"), tr("Please open a book first to create a document."));
         return;
     }
-    NewDocumentDialog dialog(currentDb, defaultFolderId, this);
+    NewDocumentDialog dialog(currentDb, defaultFolderId, m_availableModelInfos, m_availableModels, endpointComboBox, this);
     if (dialog.exec() == QDialog::Accepted) {
         QString title = dialog.getTitle();
         int folderId = dialog.getSelectedFolderId();
@@ -5564,9 +5564,15 @@ void MainWindow::handleNewDocumentCreation(int defaultFolderId) {
         bool shouldNavigate = false;
 
         if (dialog.getDocumentType() == NewDocumentDialog::FromPrompt) {
+            int selectedEndpointIndex = dialog.getSelectedEndpointIndex();
+            if (selectedEndpointIndex != -1 && endpointComboBox->currentIndex() != selectedEndpointIndex) {
+                endpointComboBox->setCurrentIndex(selectedEndpointIndex);
+                onActiveEndpointChanged(selectedEndpointIndex);
+            }
+
             QString prompt = dialog.getPrompt();
 
-            QStringList models = m_selectedModels;
+            QStringList models = dialog.getSelectedModels();
             if (models.isEmpty() && !m_availableModels.isEmpty()) {
                 models.append(m_availableModels.first());
             }

--- a/src/NewDocumentDialog.cpp
+++ b/src/NewDocumentDialog.cpp
@@ -17,7 +17,7 @@
 
 NewDocumentDialog::NewDocumentDialog(std::shared_ptr<BookDatabase> db, int defaultFolderId,
                                      const QList<OllamaModelInfo>& modelInfos, const QStringList& fallbackModels,
-                                     QComboBox* mainEndpointComboBox, QWidget* parent)
+                                     QComboBox* mainEndpointComboBox, const QStringList& initialModels, QWidget* parent)
     : QDialog(parent),
       m_db(db),
       m_defaultFolderId(defaultFolderId),
@@ -62,18 +62,16 @@ NewDocumentDialog::NewDocumentDialog(std::shared_ptr<BookDatabase> db, int defau
     modelsLayout->addWidget(new QLabel(tr("Model(s):"), m_promptWidget));
     m_selectModelsBtn = new QPushButton(m_promptWidget);
 
-    QStringList availableNames;
-    for (const auto& mi : m_modelInfos) availableNames.append(mi.name);
-    if (availableNames.isEmpty()) availableNames = m_fallbackModels;
-    if (!availableNames.isEmpty()) m_selectedModels << availableNames.first();
-
-    if (m_selectedModels.isEmpty()) {
-        m_selectModelsBtn->setText(tr("Select Model(s)"));
-    } else if (m_selectedModels.size() == 1) {
-        m_selectModelsBtn->setText(m_selectedModels.first());
+    if (!initialModels.isEmpty()) {
+        m_selectedModels = initialModels;
     } else {
-        m_selectModelsBtn->setText(tr("%1 Models Selected").arg(m_selectedModels.size()));
+        QStringList availableNames;
+        for (const auto& mi : m_modelInfos) availableNames.append(mi.name);
+        if (availableNames.isEmpty()) availableNames = m_fallbackModels;
+        if (!availableNames.isEmpty()) m_selectedModels << availableNames.first();
     }
+
+    updateModelButtonText();
     connect(m_selectModelsBtn, &QPushButton::clicked, this, &NewDocumentDialog::onSelectModelsClicked);
     modelsLayout->addWidget(m_selectModelsBtn);
     promptLayout->addLayout(modelsLayout);
@@ -229,17 +227,21 @@ void NewDocumentDialog::onTypeChanged(int index) {
     }
 }
 
+void NewDocumentDialog::updateModelButtonText() {
+    if (m_selectedModels.isEmpty()) {
+        m_selectModelsBtn->setText(tr("Select Model(s)"));
+    } else if (m_selectedModels.size() == 1) {
+        m_selectModelsBtn->setText(m_selectedModels.first());
+    } else {
+        m_selectModelsBtn->setText(tr("%1 Models Selected").arg(m_selectedModels.size()));
+    }
+}
+
 void NewDocumentDialog::onSelectModelsClicked() {
     ModelSelectionDialog dlg(m_modelInfos, m_fallbackModels, this);
     if (dlg.exec() == QDialog::Accepted) {
         m_selectedModels = dlg.selectedModels();
-        if (m_selectedModels.isEmpty()) {
-            m_selectModelsBtn->setText(tr("Select Model(s)"));
-        } else if (m_selectedModels.size() == 1) {
-            m_selectModelsBtn->setText(m_selectedModels.first());
-        } else {
-            m_selectModelsBtn->setText(tr("%1 Models Selected").arg(m_selectedModels.size()));
-        }
+        updateModelButtonText();
     }
 }
 

--- a/src/NewDocumentDialog.cpp
+++ b/src/NewDocumentDialog.cpp
@@ -3,6 +3,7 @@
 #include <QCheckBox>
 #include <QComboBox>
 #include <QDialogButtonBox>
+#include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
@@ -12,9 +13,16 @@
 
 #include "BookDatabase.h"
 #include "DocumentTemplatesManager.h"
+#include "ModelSelectionDialog.h"
 
-NewDocumentDialog::NewDocumentDialog(std::shared_ptr<BookDatabase> db, int defaultFolderId, QWidget* parent)
-    : QDialog(parent), m_db(db), m_defaultFolderId(defaultFolderId) {
+NewDocumentDialog::NewDocumentDialog(std::shared_ptr<BookDatabase> db, int defaultFolderId,
+                                     const QList<OllamaModelInfo>& modelInfos, const QStringList& fallbackModels,
+                                     QComboBox* mainEndpointComboBox, QWidget* parent)
+    : QDialog(parent),
+      m_db(db),
+      m_defaultFolderId(defaultFolderId),
+      m_modelInfos(modelInfos),
+      m_fallbackModels(fallbackModels) {
     setWindowTitle(tr("New Document"));
     resize(450, 550);
 
@@ -37,6 +45,39 @@ NewDocumentDialog::NewDocumentDialog(std::shared_ptr<BookDatabase> db, int defau
     m_promptWidget = new QWidget(this);
     QVBoxLayout* promptLayout = new QVBoxLayout(m_promptWidget);
     promptLayout->setContentsMargins(0, 0, 0, 0);
+
+    QHBoxLayout* endpointLayout = new QHBoxLayout();
+    endpointLayout->addWidget(new QLabel(tr("Endpoint:"), m_promptWidget));
+    m_endpointCombo = new QComboBox(m_promptWidget);
+    if (mainEndpointComboBox) {
+        for (int i = 0; i < mainEndpointComboBox->count(); ++i) {
+            m_endpointCombo->addItem(mainEndpointComboBox->itemText(i), mainEndpointComboBox->itemData(i));
+        }
+        m_endpointCombo->setCurrentIndex(mainEndpointComboBox->currentIndex());
+    }
+    endpointLayout->addWidget(m_endpointCombo);
+    promptLayout->addLayout(endpointLayout);
+
+    QHBoxLayout* modelsLayout = new QHBoxLayout();
+    modelsLayout->addWidget(new QLabel(tr("Model(s):"), m_promptWidget));
+    m_selectModelsBtn = new QPushButton(m_promptWidget);
+
+    QStringList availableNames;
+    for (const auto& mi : m_modelInfos) availableNames.append(mi.name);
+    if (availableNames.isEmpty()) availableNames = m_fallbackModels;
+    if (!availableNames.isEmpty()) m_selectedModels << availableNames.first();
+
+    if (m_selectedModels.isEmpty()) {
+        m_selectModelsBtn->setText(tr("Select Model(s)"));
+    } else if (m_selectedModels.size() == 1) {
+        m_selectModelsBtn->setText(m_selectedModels.first());
+    } else {
+        m_selectModelsBtn->setText(tr("%1 Models Selected").arg(m_selectedModels.size()));
+    }
+    connect(m_selectModelsBtn, &QPushButton::clicked, this, &NewDocumentDialog::onSelectModelsClicked);
+    modelsLayout->addWidget(m_selectModelsBtn);
+    promptLayout->addLayout(modelsLayout);
+
     promptLayout->addWidget(new QLabel(tr("AI Prompt:"), m_promptWidget));
     m_promptEdit = new QTextEdit(m_promptWidget);
     promptLayout->addWidget(m_promptEdit);
@@ -187,6 +228,24 @@ void NewDocumentDialog::onTypeChanged(int index) {
         }
     }
 }
+
+void NewDocumentDialog::onSelectModelsClicked() {
+    ModelSelectionDialog dlg(m_modelInfos, m_fallbackModels, this);
+    if (dlg.exec() == QDialog::Accepted) {
+        m_selectedModels = dlg.selectedModels();
+        if (m_selectedModels.isEmpty()) {
+            m_selectModelsBtn->setText(tr("Select Model(s)"));
+        } else if (m_selectedModels.size() == 1) {
+            m_selectModelsBtn->setText(m_selectedModels.first());
+        } else {
+            m_selectModelsBtn->setText(tr("%1 Models Selected").arg(m_selectedModels.size()));
+        }
+    }
+}
+
+QStringList NewDocumentDialog::getSelectedModels() const { return m_selectedModels; }
+
+int NewDocumentDialog::getSelectedEndpointIndex() const { return m_endpointCombo->currentIndex(); }
 
 NewDocumentDialog::DocumentType NewDocumentDialog::getDocumentType() const {
     return static_cast<DocumentType>(m_typeCombo->currentData().toInt());

--- a/src/NewDocumentDialog.h
+++ b/src/NewDocumentDialog.h
@@ -23,7 +23,7 @@ class NewDocumentDialog : public QDialog {
 
     explicit NewDocumentDialog(std::shared_ptr<BookDatabase> db, int defaultFolderId,
                                const QList<OllamaModelInfo>& modelInfos, const QStringList& fallbackModels,
-                               QComboBox* mainEndpointComboBox, QWidget* parent = nullptr);
+                               QComboBox* mainEndpointComboBox, const QStringList& initialModels = QStringList(), QWidget* parent = nullptr);
 
     DocumentType getDocumentType() const;
     QString getTitle() const;
@@ -46,6 +46,7 @@ class NewDocumentDialog : public QDialog {
     void populateTemplates();
     void populateDrafts();
     void populateDocuments();
+    void updateModelButtonText();
 
     std::shared_ptr<BookDatabase> m_db;
     int m_defaultFolderId;

--- a/src/NewDocumentDialog.h
+++ b/src/NewDocumentDialog.h
@@ -2,11 +2,15 @@
 #define NEWDOCUMENTDIALOG_H
 
 #include <QDialog>
+#include <QList>
 #include <QString>
 #include <memory>
 
+#include "OllamaModelInfo.h"
+
 class QComboBox;
 class QLineEdit;
+class QPushButton;
 class QTextEdit;
 class QTreeWidget;
 class QTreeWidgetItem;
@@ -17,7 +21,9 @@ class NewDocumentDialog : public QDialog {
    public:
     enum DocumentType { FromTemplate, FromPrompt, ResumeDraft };
 
-    explicit NewDocumentDialog(std::shared_ptr<BookDatabase> db, int defaultFolderId, QWidget* parent = nullptr);
+    explicit NewDocumentDialog(std::shared_ptr<BookDatabase> db, int defaultFolderId,
+                               const QList<OllamaModelInfo>& modelInfos, const QStringList& fallbackModels,
+                               QComboBox* mainEndpointComboBox, QWidget* parent = nullptr);
 
     DocumentType getDocumentType() const;
     QString getTitle() const;
@@ -27,10 +33,13 @@ class NewDocumentDialog : public QDialog {
     int getSelectedDraftId() const;
     bool isOverwriteDocument() const;
     int getOverwriteDocumentId() const;
+    QStringList getSelectedModels() const;
+    int getSelectedEndpointIndex() const;
 
    private slots:
     void onTypeChanged(int index);
     void onOverwriteToggled(int state);
+    void onSelectModelsClicked();
 
    private:
     void populateFolders(QTreeWidgetItem* parentItem, int parentId);
@@ -40,12 +49,17 @@ class NewDocumentDialog : public QDialog {
 
     std::shared_ptr<BookDatabase> m_db;
     int m_defaultFolderId;
+    QList<OllamaModelInfo> m_modelInfos;
+    QStringList m_fallbackModels;
+    QStringList m_selectedModels;
 
     QComboBox* m_typeCombo;
     QLineEdit* m_titleEdit;
 
     // Dynamic widgets
     QWidget* m_promptWidget;
+    QComboBox* m_endpointCombo;
+    QPushButton* m_selectModelsBtn;
     QTextEdit* m_promptEdit;
 
     QWidget* m_templateWidget;


### PR DESCRIPTION
Updates `NewDocumentDialog` to support picking the target LLM endpoint and one or more models when generating a new document from an AI prompt. It populates an endpoint combobox mirroring the global main window configuration, and allows users to pick their model through `ModelSelectionDialog`. This resolves a feature request to offer the user more control over AI document generation.

---
*PR created automatically by Jules for task [3604739337766901150](https://jules.google.com/task/3604739337766901150) started by @arran4*