### PR TITLE
feat: Enhance AI Document Operations Dialog

### DIFF
--- a/src/AIOperationsDialog.cpp
+++ b/src/AIOperationsDialog.cpp
@@ -22,6 +22,7 @@ AIOperationsDialog::AIOperationsDialog(BookDatabase* db, const QString& defaultP
                                        const QList<OllamaModelInfo>& modelInfos,
                                        const QStringList& fallbackModels, QWidget* parent)
     : QDialog(parent), m_db(db), m_modelInfos(modelInfos), m_fallbackModels(fallbackModels) {
+    Q_ASSERT(m_db != nullptr);
     setWindowTitle(tr("AI Document Operations"));
     resize(500, 400);
 
@@ -111,13 +112,7 @@ AIOperationsDialog::AIOperationsDialog(BookDatabase* db, const QString& defaultP
         }
     }
 
-    if (m_selectedModels.isEmpty()) {
-        m_selectModelsBtn->setText(tr("Select Model(s)"));
-    } else if (m_selectedModels.size() == 1) {
-        m_selectModelsBtn->setText(m_selectedModels.first());
-    } else {
-        m_selectModelsBtn->setText(tr("%1 Models Selected").arg(m_selectedModels.size()));
-    }
+    updateModelButtonText();
     connect(m_selectModelsBtn, &QPushButton::clicked, this, &AIOperationsDialog::onSelectModelsClicked);
 
 
@@ -175,17 +170,21 @@ void AIOperationsDialog::onRestoreDraftClicked() {
     }
 }
 
+void AIOperationsDialog::updateModelButtonText() {
+    if (m_selectedModels.isEmpty()) {
+        m_selectModelsBtn->setText(tr("Select Model(s)"));
+    } else if (m_selectedModels.size() == 1) {
+        m_selectModelsBtn->setText(m_selectedModels.first());
+    } else {
+        m_selectModelsBtn->setText(tr("%1 Models Selected").arg(m_selectedModels.size()));
+    }
+}
+
 void AIOperationsDialog::onSelectModelsClicked() {
     ModelSelectionDialog dlg(m_modelInfos, m_fallbackModels, this);
     if (dlg.exec() == QDialog::Accepted) {
         m_selectedModels = dlg.selectedModels();
-        if (m_selectedModels.isEmpty()) {
-            m_selectModelsBtn->setText(tr("Select Model(s)"));
-        } else if (m_selectedModels.size() == 1) {
-            m_selectModelsBtn->setText(m_selectedModels.first());
-        } else {
-            m_selectModelsBtn->setText(tr("%1 Models Selected").arg(m_selectedModels.size()));
-        }
+        updateModelButtonText();
     }
 }
 

--- a/src/AIOperationsDialog.cpp
+++ b/src/AIOperationsDialog.cpp
@@ -11,15 +11,28 @@
 #include <QSettings>
 #include <QTextEdit>
 #include <QVBoxLayout>
+#include <QSplitter>
+#include <QScrollArea>
 
 #include "AIOperationsManager.h"
+#include "ModelSelectionDialog.h"
+#include <QMessageBox>
 
-AIOperationsDialog::AIOperationsDialog(BookDatabase* db, const QString& defaultPrompt, QWidget* parent)
-    : QDialog(parent) {
+AIOperationsDialog::AIOperationsDialog(BookDatabase* db, const QString& defaultPrompt,
+                                       const QList<OllamaModelInfo>& modelInfos,
+                                       const QStringList& fallbackModels, QWidget* parent)
+    : QDialog(parent), m_db(db), m_modelInfos(modelInfos), m_fallbackModels(fallbackModels) {
     setWindowTitle(tr("AI Document Operations"));
     resize(500, 400);
 
-    QVBoxLayout* layout = new QVBoxLayout(this);
+    QVBoxLayout* mainLayout = new QVBoxLayout(this);
+
+    m_mainSplitter = new QSplitter(Qt::Vertical, this);
+
+    // Top section: Operation and Prompt Instructions
+    QWidget* topWidget = new QWidget(m_mainSplitter);
+    QVBoxLayout* topLayout = new QVBoxLayout(topWidget);
+    topLayout->setContentsMargins(0, 0, 0, 0);
 
     // Operation
     QHBoxLayout* opLayout = new QHBoxLayout();
@@ -33,17 +46,80 @@ AIOperationsDialog::AIOperationsDialog(BookDatabase* db, const QString& defaultP
     }
 
     opLayout->addWidget(m_operationCombo, 1);
-    layout->addLayout(opLayout);
+    topLayout->addLayout(opLayout);
 
     // Prompt
-    layout->addWidget(new QLabel(tr("Prompt Instructions:")));
+    QHBoxLayout* promptLabelLayout = new QHBoxLayout();
+    promptLabelLayout->addWidget(new QLabel(tr("Prompt Instructions:")));
+    promptLabelLayout->addStretch();
+
+    QPushButton* saveDraftBtn = new QPushButton(tr("Save Draft"), this);
+    QPushButton* restoreDraftBtn = new QPushButton(tr("Restore Draft"), this);
+    promptLabelLayout->addWidget(saveDraftBtn);
+    promptLabelLayout->addWidget(restoreDraftBtn);
+    topLayout->addLayout(promptLabelLayout);
+
+    connect(saveDraftBtn, &QPushButton::clicked, this, &AIOperationsDialog::onSaveDraftClicked);
+    connect(restoreDraftBtn, &QPushButton::clicked, this, &AIOperationsDialog::onRestoreDraftClicked);
+
     m_promptEdit = new QTextEdit(this);
     m_promptEdit->setPlainText(defaultPrompt);
-    layout->addWidget(m_promptEdit);
+    topLayout->addWidget(m_promptEdit);
 
-    // Dynamic Inputs
+    m_mainSplitter->addWidget(topWidget);
+
+    // Bottom section: Dynamic inputs scroll area
+    QScrollArea* scrollArea = new QScrollArea(m_mainSplitter);
+    scrollArea->setWidgetResizable(true);
+    QWidget* bottomWidget = new QWidget();
+    QVBoxLayout* bottomLayout = new QVBoxLayout(bottomWidget);
     m_dynamicInputsLayout = new QFormLayout();
-    layout->addLayout(m_dynamicInputsLayout);
+    bottomLayout->addLayout(m_dynamicInputsLayout);
+    bottomLayout->addStretch();
+    scrollArea->setWidget(bottomWidget);
+
+    m_mainSplitter->addWidget(scrollArea);
+
+    // Set stretch factors so the text edit takes most of the space initially
+    m_mainSplitter->setStretchFactor(0, 3);
+    m_mainSplitter->setStretchFactor(1, 1);
+
+    mainLayout->addWidget(m_mainSplitter);
+
+    // Models Selection
+    QHBoxLayout* modelsLayout = new QHBoxLayout();
+    modelsLayout->addWidget(new QLabel(tr("Model(s):"), this));
+    m_selectModelsBtn = new QPushButton(this);
+    modelsLayout->addWidget(m_selectModelsBtn);
+    mainLayout->addLayout(modelsLayout);
+
+    // Init models
+    QStringList availableNames;
+    for (const auto& mi : m_modelInfos) availableNames.append(mi.name);
+    if (availableNames.isEmpty()) availableNames = m_fallbackModels;
+
+    QString dbModel = m_db->getSetting("book", 0, "defaultModel", "");
+    if (!dbModel.isEmpty() && availableNames.contains(dbModel)) {
+        m_selectedModels << dbModel;
+    } else {
+        QSettings settings;
+        QString systemModel = settings.value("systemModel", "").toString();
+        if (!systemModel.isEmpty() && availableNames.contains(systemModel)) {
+            m_selectedModels << systemModel;
+        } else if (!availableNames.isEmpty()) {
+            m_selectedModels << availableNames.first();
+        }
+    }
+
+    if (m_selectedModels.isEmpty()) {
+        m_selectModelsBtn->setText(tr("Select Model(s)"));
+    } else if (m_selectedModels.size() == 1) {
+        m_selectModelsBtn->setText(m_selectedModels.first());
+    } else {
+        m_selectModelsBtn->setText(tr("%1 Models Selected").arg(m_selectedModels.size()));
+    }
+    connect(m_selectModelsBtn, &QPushButton::clicked, this, &AIOperationsDialog::onSelectModelsClicked);
+
 
     // Buttons
     QHBoxLayout* btnLayout = new QHBoxLayout();
@@ -54,7 +130,7 @@ AIOperationsDialog::AIOperationsDialog(BookDatabase* db, const QString& defaultP
     btnLayout->addStretch();
     btnLayout->addWidget(cancelBtn);
     btnLayout->addWidget(generateBtn);
-    layout->addLayout(btnLayout);
+    mainLayout->addLayout(btnLayout);
 
     connect(cancelBtn, &QPushButton::clicked, this, &QDialog::reject);
     connect(generateBtn, &QPushButton::clicked, this, &QDialog::accept);
@@ -79,6 +155,39 @@ AIOperationsDialog::~AIOperationsDialog() {}
 QString AIOperationsDialog::getOperation() const { return m_operationCombo->currentData().toString(); }
 
 QString AIOperationsDialog::getPrompt() const { return m_finalPrompt; }
+
+QStringList AIOperationsDialog::getSelectedModels() const { return m_selectedModels; }
+
+void AIOperationsDialog::onSaveDraftClicked() {
+    if (!m_db) return;
+    QString prompt = m_promptEdit->toPlainText();
+    m_db->setSetting("ai_operations", 0, "draft_prompt", prompt);
+    QMessageBox::information(this, tr("Draft Saved"), tr("Prompt instructions draft saved successfully."));
+}
+
+void AIOperationsDialog::onRestoreDraftClicked() {
+    if (!m_db) return;
+    QString prompt = m_db->getSetting("ai_operations", 0, "draft_prompt", "");
+    if (!prompt.isEmpty()) {
+        m_promptEdit->setPlainText(prompt);
+    } else {
+        QMessageBox::information(this, tr("No Draft"), tr("No saved draft found."));
+    }
+}
+
+void AIOperationsDialog::onSelectModelsClicked() {
+    ModelSelectionDialog dlg(m_modelInfos, m_fallbackModels, this);
+    if (dlg.exec() == QDialog::Accepted) {
+        m_selectedModels = dlg.selectedModels();
+        if (m_selectedModels.isEmpty()) {
+            m_selectModelsBtn->setText(tr("Select Model(s)"));
+        } else if (m_selectedModels.size() == 1) {
+            m_selectModelsBtn->setText(m_selectedModels.first());
+        } else {
+            m_selectModelsBtn->setText(tr("%1 Models Selected").arg(m_selectedModels.size()));
+        }
+    }
+}
 
 void AIOperationsDialog::setForkOnlyMode(bool enabled) {
     if (enabled) {

--- a/src/AIOperationsDialog.h
+++ b/src/AIOperationsDialog.h
@@ -63,6 +63,8 @@ class AIOperationsDialog : public QDialog {
     QPushButton* m_selectModelsBtn;
 
     QSplitter* m_mainSplitter;
+
+    void updateModelButtonText();
 };
 
 #endif  // AIOPERATIONSDIALOG_H

--- a/src/AIOperationsDialog.h
+++ b/src/AIOperationsDialog.h
@@ -4,10 +4,15 @@
 #include <QDialog>
 #include <QString>
 
+#include "OllamaModelInfo.h"
+
 class QComboBox;
+class QPushButton;
 class QTextEdit;
 class BookDatabase;
 class QFormLayout;
+class QSplitter;
+class QScrollArea;
 
 struct DynamicInputInfo {
     QString fullMatch;
@@ -24,11 +29,14 @@ struct DynamicInputInfo {
 class AIOperationsDialog : public QDialog {
     Q_OBJECT
    public:
-    explicit AIOperationsDialog(BookDatabase* db, const QString& defaultPrompt = "", QWidget* parent = nullptr);
+    explicit AIOperationsDialog(BookDatabase* db, const QString& defaultPrompt,
+                                const QList<OllamaModelInfo>& modelInfos,
+                                const QStringList& fallbackModels, QWidget* parent = nullptr);
     ~AIOperationsDialog() override;
 
     QString getOperation() const;
     QString getPrompt() const;
+    QStringList getSelectedModels() const;
 
     void setForkOnlyMode(bool enabled);
 
@@ -37,13 +45,24 @@ class AIOperationsDialog : public QDialog {
 
    private slots:
     void updateDynamicInputs();
+    void onSelectModelsClicked();
+    void onSaveDraftClicked();
+    void onRestoreDraftClicked();
 
    private:
+    BookDatabase* m_db;
+    QList<OllamaModelInfo> m_modelInfos;
+    QStringList m_fallbackModels;
+    QStringList m_selectedModels;
+
     QComboBox* m_operationCombo;
     QTextEdit* m_promptEdit;
     QFormLayout* m_dynamicInputsLayout;
     QList<DynamicInputInfo> m_currentDynamicInputs;
     QString m_finalPrompt;
+    QPushButton* m_selectModelsBtn;
+
+    QSplitter* m_mainSplitter;
 };
 
 #endif  // AIOPERATIONSDIALOG_H

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -5151,7 +5151,7 @@ void MainWindow::showDocumentAIToolsMenu() {}
 void MainWindow::onDocumentAIOperations() {
     if (m_isGenerating || !currentDb) return;
 
-    AIOperationsDialog dialog(currentDb.get(), "", this);
+    AIOperationsDialog dialog(currentDb.get(), "", m_availableModelInfos, m_availableModels, this);
     if (dialog.exec() == QDialog::Accepted) {
         QString op = dialog.getOperation();
         QString promptTpl = dialog.getPrompt();
@@ -5178,7 +5178,7 @@ void MainWindow::onDocumentAIOperations() {
         QString prompt = promptTpl;
         prompt.replace("{context}", contextText);
 
-        QStringList models = m_selectedModels;
+        QStringList models = dialog.getSelectedModels();
         if (models.isEmpty() && !m_availableModels.isEmpty()) {
             models.append(m_availableModels.first());
         }


### PR DESCRIPTION
This PR introduces several enhancements to the AI Document Operations dialog based on user feedback:
1. **Model Selection**: Users can now select the specific model(s) and endpoint they want to use for the operation directly within the dialog, rather than relying on the globally selected models.
2. **Expandable Instructions Area**: The dialog has been restructured using a `QSplitter`, dedicating a larger, resizable share of the vertical space to the "Prompt Instructions" text area. The dynamic inputs section is now enclosed in a scroll area.
3. **Draft Support**: "Save Draft" and "Restore Draft" buttons were added above the prompt text area. Drafts are safely persisted into the active `BookDatabase` via its key-value settings store.

---
*PR created automatically by Jules for task [1779826511632210806](https://jules.google.com/task/1779826511632210806) started by @arran4*