### PR TITLE
feat: allow stopping active generations

### DIFF
--- a/src/OllamaClient.cpp
+++ b/src/OllamaClient.cpp
@@ -180,7 +180,7 @@ void OllamaClient::pullModel(const QString& modelName) {
  * @param onComplete Fired when the JSON EOF boolean is detected.
  * @param onError Fired on socket or HTTP error conditions.
  */
-void OllamaClient::generate(const QString& model, const QString& prompt, std::function<void(const QString&)> onChunk,
+QNetworkReply* OllamaClient::generate(const QString& model, const QString& prompt, std::function<void(const QString&)> onChunk,
                             std::function<void(const QString&)> onComplete,
                             std::function<void(QNetworkReply::NetworkError, const QString&)> onError) {
     QUrl url(m_baseUrl + "/api/generate");
@@ -256,6 +256,8 @@ void OllamaClient::generate(const QString& model, const QString& prompt, std::fu
         }
         reply->deleteLater();
     });
+
+    return reply;
 }
 
 /**
@@ -267,7 +269,7 @@ void OllamaClient::generate(const QString& model, const QString& prompt, std::fu
  * @param onComplete Fired when the JSON EOF boolean is detected.
  * @param onError Fired on socket or HTTP error conditions.
  */
-void OllamaClient::generateChat(const QString& model, const QJsonArray& messages,
+QNetworkReply* OllamaClient::generateChat(const QString& model, const QJsonArray& messages,
                                 std::function<void(const QString&)> onChunk,
                                 std::function<void(const QString&)> onComplete,
                                 std::function<void(QNetworkReply::NetworkError, const QString&)> onError) {
@@ -363,6 +365,8 @@ void OllamaClient::generateChat(const QString& model, const QJsonArray& messages
         }
         reply->deleteLater();
     });
+
+    return reply;
 }
 
 void OllamaClient::abortGenerations() {

--- a/src/OllamaClient.h
+++ b/src/OllamaClient.h
@@ -25,11 +25,11 @@ class OllamaClient : public QObject {
 
     void setSystemPrompt(const QString& prompt);
 
-    void generate(const QString& model, const QString& prompt, std::function<void(const QString&)> onChunk,
+    QNetworkReply* generate(const QString& model, const QString& prompt, std::function<void(const QString&)> onChunk,
                   std::function<void(const QString&)> onComplete,
                   std::function<void(QNetworkReply::NetworkError, const QString&)> onError);
 
-    void generateChat(const QString& model, const QJsonArray& messages, std::function<void(const QString&)> onChunk,
+    QNetworkReply* generateChat(const QString& model, const QJsonArray& messages, std::function<void(const QString&)> onChunk,
                       std::function<void(const QString&)> onComplete,
                       std::function<void(QNetworkReply::NetworkError, const QString&)> onError);
 

--- a/src/QueueManager.cpp
+++ b/src/QueueManager.cpp
@@ -188,7 +188,13 @@ void QueueManager::cancelItem(std::shared_ptr<BookDatabase> db, int queueId) {
         }
     }
     if (toRemoveId != -1) {
-        // Ideally we'd abort the network request here
+        if (m_activeNetworkRequests.contains(toRemoveId)) {
+            QNetworkReply* reply = m_activeNetworkRequests[toRemoveId];
+            if (reply) {
+                reply->abort();
+            }
+            m_activeNetworkRequests.remove(toRemoveId);
+        }
         m_activeItems.remove(toRemoveId);
     }
     emit queueChanged();
@@ -368,7 +374,7 @@ void QueueManager::processNext() {
                 messagesArray.append(msgObj);
             }
 
-            m_client->generateChat(
+            m_activeNetworkRequests[procId] = m_client->generateChat(
                 item.model, messagesArray,
                 [this, procId](const QString& chunk) {
                     if (!m_activeItems.contains(procId)) return;
@@ -408,6 +414,7 @@ void QueueManager::processNext() {
                     }
                     emit processingFinished(act.db, act.item.messageId, true, act.item.targetType);
                     m_activeItems.remove(procId);
+                    m_activeNetworkRequests.remove(procId);
                     emit queueChanged();
                     QTimer::singleShot(500, this, &QueueManager::checkQueue);
                 },
@@ -426,11 +433,12 @@ void QueueManager::processNext() {
                     }
                     emit processingFinished(act.db, act.item.messageId, false, act.item.targetType);
                     m_activeItems.remove(procId);
+                    m_activeNetworkRequests.remove(procId);
                     emit queueChanged();
                     QTimer::singleShot(500, this, &QueueManager::checkQueue);
                 });
         } else {
-            m_client->generate(
+            m_activeNetworkRequests[procId] = m_client->generate(
                 item.model, item.prompt,
                 [this, procId](const QString& chunk) {
                     if (!m_activeItems.contains(procId)) return;
@@ -492,6 +500,7 @@ void QueueManager::processNext() {
                     }
                     emit processingFinished(act.db, act.item.messageId, true, act.item.targetType);
                     m_activeItems.remove(procId);
+                    m_activeNetworkRequests.remove(procId);
                     emit queueChanged();
                     QTimer::singleShot(500, this, &QueueManager::checkQueue);
                 },
@@ -510,6 +519,7 @@ void QueueManager::processNext() {
                     }
                     emit processingFinished(act.db, act.item.messageId, false, act.item.targetType);
                     m_activeItems.remove(procId);
+                    m_activeNetworkRequests.remove(procId);
                     emit queueChanged();
                     QTimer::singleShot(500, this, &QueueManager::checkQueue);
                 });

--- a/src/QueueManager.h
+++ b/src/QueueManager.h
@@ -79,6 +79,7 @@ class QueueManager : public QObject {
     QTimer* m_timer;
 
     QMap<int, MergedQueueItem> m_activeItems;  // Map processingId to QueueItem
+    QMap<int, QNetworkReply*> m_activeNetworkRequests;  // Map processingId to QNetworkReply
     int m_maxConcurrent = 1;
     bool m_isPaused = false;
     QString m_lastProcessedModel;

--- a/src/QueueWindow.cpp
+++ b/src/QueueWindow.cpp
@@ -217,7 +217,9 @@ void QueueWindow::showContextMenu(const QPoint& pos) {
     retryAction->setEnabled(isError);
 
     menu.addSeparator();
-    menu.addAction("Delete", this, &QueueWindow::onCancelItem);
+
+    QAction* stopAction = menu.addAction("Stop/Delete", this, &QueueWindow::onCancelItem);
+    stopAction->setToolTip("Cancel if pending/processing, or delete if completed/error");
 
     menu.exec(m_queueList->mapToGlobal(pos));
 }


### PR DESCRIPTION
Adds the ability to stop an active generation in progress from both the queue and the main window preview by properly exposing and aborting the underlying `QNetworkReply`.

---
*PR created automatically by Jules for task [13959060826512872671](https://jules.google.com/task/13959060826512872671) started by @arran4*