### PR TITLE
🔒 fix: enforce strict SSL/TLS configuration for network requests

### DIFF
--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -9,8 +9,6 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
-#include <QSslConfiguration>
-#include <QSslSocket>
 #include <QSpinBox>
 #include <QTabWidget>
 
@@ -83,11 +81,6 @@ void ConnectionDialog::onTestConnection() {
     urlStr += "api/tags";
 
     QNetworkRequest request((QUrl(urlStr)));
-
-    QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
-    sslConfig.setPeerVerifyMode(QSslSocket::VerifyPeer);
-    sslConfig.setProtocol(QSsl::TlsV1_2OrLater);
-    request.setSslConfiguration(sslConfig);
 
     if (!authKey.isEmpty()) {
         request.setRawHeader("Authorization", ("Bearer " + authKey).toUtf8());
@@ -356,11 +349,6 @@ void SettingsDialog::onTestConnection() {
     urlStr += "api/tags";
 
     QNetworkRequest request((QUrl(urlStr)));
-
-    QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
-    sslConfig.setPeerVerifyMode(QSslSocket::VerifyPeer);
-    sslConfig.setProtocol(QSsl::TlsV1_2OrLater);
-    request.setSslConfiguration(sslConfig);
 
     if (!authKey.isEmpty()) {
         request.setRawHeader("Authorization", ("Bearer " + authKey).toUtf8());

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -9,6 +9,8 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QSslConfiguration>
+#include <QSslSocket>
 #include <QSpinBox>
 #include <QTabWidget>
 
@@ -81,6 +83,12 @@ void ConnectionDialog::onTestConnection() {
     urlStr += "api/tags";
 
     QNetworkRequest request((QUrl(urlStr)));
+
+    QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
+    sslConfig.setPeerVerifyMode(QSslSocket::VerifyPeer);
+    sslConfig.setProtocol(QSsl::TlsV1_2OrLater);
+    request.setSslConfiguration(sslConfig);
+
     if (!authKey.isEmpty()) {
         request.setRawHeader("Authorization", ("Bearer " + authKey).toUtf8());
     }
@@ -348,6 +356,12 @@ void SettingsDialog::onTestConnection() {
     urlStr += "api/tags";
 
     QNetworkRequest request((QUrl(urlStr)));
+
+    QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
+    sslConfig.setPeerVerifyMode(QSslSocket::VerifyPeer);
+    sslConfig.setProtocol(QSsl::TlsV1_2OrLater);
+    request.setSslConfiguration(sslConfig);
+
     if (!authKey.isEmpty()) {
         request.setRawHeader("Authorization", ("Bearer " + authKey).toUtf8());
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,8 @@
 #include <KLocalizedString>
 #include <QApplication>
 #include <QCommandLineOption>
+#include <QSslConfiguration>
+#include <QSslSocket>
 #include <QCommandLineParser>
 #include <QDebug>
 #include <QDir>
@@ -25,6 +27,11 @@ int main(int argc, char *argv[]) {
     QCoreApplication::setApplicationName("kllamabooks");
     QCoreApplication::setApplicationVersion(QStringLiteral(KGHN_APP_VERSION));
     QGuiApplication::setDesktopFileName("com.arran4.kllamabooks.desktop");
+
+    QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
+    sslConfig.setPeerVerifyMode(QSslSocket::VerifyPeer);
+    sslConfig.setProtocol(QSsl::TlsV1_2OrLater);
+    QSslConfiguration::setDefaultConfiguration(sslConfig);
 
     QApplication app(argc, argv);
     QApplication::setWindowIcon(QIcon::fromTheme("kllamabooks", QIcon(":/assets/icon.png")));


### PR DESCRIPTION
🎯 **What:** The `QNetworkRequest` instances in `SettingsDialog.cpp` lacked explicit SSL/TLS configurations, relying on defaults which might allow insecure connections or insufficient certificate verification.
⚠️ **Risk:** This could lead to a man-in-the-middle (MitM) attack, especially concerning since the requests carry an 'Authorization' header with a Bearer token.
🛡️ **Solution:** Added explicit configuration to set the peer verification mode to `QSslSocket::VerifyPeer` and enforce a minimum protocol of TLS 1.2 (`QSsl::TlsV1_2OrLater`).

---
*PR created automatically by Jules for task [2970159295564342062](https://jules.google.com/task/2970159295564342062) started by @arran4*