### PR TITLE
🧪 Add unit tests for QueueManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,3 +140,7 @@ install(FILES src/kdocumenteditwindowui.rc
 install(FILES src/com.arran4.kllamabooks.metainfo.xml
     DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo
 )
+
+add_executable(test_QueueManager tests/test_QueueManager.cpp src/QueueManager.cpp src/BookDatabase.cpp src/OllamaClient.cpp src/NotificationDelegate.cpp src/DocumentTemplatesManager.cpp src/AIOperationsManager.cpp src/TemplateParser.cpp)
+target_link_libraries(test_QueueManager Qt6::Test Qt6::Core Qt6::Widgets Qt6::Network ${SQLCIPHER_LIBRARIES})
+add_test(NAME test_QueueManager COMMAND test_QueueManager)

--- a/tests/test_QueueManager.cpp
+++ b/tests/test_QueueManager.cpp
@@ -41,9 +41,15 @@ void TestQueueManager::init() {
 }
 
 void TestQueueManager::cleanup() {
+    QueueManager& qm = QueueManager::instance();
     if (m_db) {
+        qm.removeDatabase(m_db);
         m_db->close();
     }
+    qm.setClient(nullptr);
+    qm.resumeQueue();
+    qm.setMaxConcurrent(1); // Reset to default value
+
     QFile::remove(m_testDbPath);
 }
 
@@ -83,8 +89,6 @@ void TestQueueManager::testGetQueueStats() {
 
     stats = qm.getQueueStats();
     QCOMPARE(stats.pending, 1);
-
-    qm.removeDatabase(m_db);
 }
 
 void TestQueueManager::testCheckQueueIsPaused() {
@@ -104,8 +108,13 @@ void TestQueueManager::testCheckQueueIsPaused() {
     QCOMPARE(stats.processing, 0); // No items should move to processing since queue is paused
 
     qm.resumeQueue();
-    qm.setClient(nullptr);
-    qm.removeDatabase(m_db);
+
+    // Wait for the asynchronous checkQueue to run and process the item.
+    QTest::qWait(100);
+
+    stats = qm.getQueueStats();
+    QCOMPARE(stats.pending, 0);
+    QCOMPARE(stats.processing, 1);
 }
 
 void TestQueueManager::testEndpointDownPreventsProcessing() {
@@ -131,16 +140,38 @@ void TestQueueManager::testEndpointDownPreventsProcessing() {
     emit client.connectionStatusChanged(true);
     QVERIFY(qm.isEndpointUp());
 
-    stats = qm.getQueueStats();
+    // Wait for async checkQueue to run
+    QTest::qWait(100);
 
-    qm.setClient(nullptr);
-    qm.removeDatabase(m_db);
+    stats = qm.getQueueStats();
+    QCOMPARE(stats.pending, 0);
+    QCOMPARE(stats.processing, 1);
 }
 
 void TestQueueManager::testMaxConcurrentLimits() {
     QueueManager& qm = QueueManager::instance();
-    qm.setMaxConcurrent(3);
-    QCOMPARE(qm.maxConcurrent(), 3);
+    qm.addDatabase(m_db);
+    OllamaClient client;
+    qm.setClient(&client);
+    qm.resumeQueue();
+
+    qm.setMaxConcurrent(1);
+    QCOMPARE(qm.maxConcurrent(), 1);
+
+    // Enqueue more items than the concurrent limit
+    m_db->enqueuePrompt(1, "test_model", "test_prompt_1");
+    m_db->enqueuePrompt(2, "test_model", "test_prompt_2");
+
+    QueueManager::QueueStats stats = qm.getQueueStats();
+    QCOMPARE(stats.pending, 2);
+    QCOMPARE(stats.processing, 0);
+
+    qm.checkQueue();
+
+    // After checkQueue, one item should be processing and one pending.
+    stats = qm.getQueueStats();
+    QCOMPARE(stats.pending, 1);
+    QCOMPARE(stats.processing, 1);
 }
 
 QTEST_MAIN(TestQueueManager)

--- a/tests/test_QueueManager.cpp
+++ b/tests/test_QueueManager.cpp
@@ -1,0 +1,147 @@
+#include <QtTest>
+#include <QCoreApplication>
+#include "../src/QueueManager.h"
+#include "../src/BookDatabase.h"
+#include "../src/OllamaClient.h"
+
+class TestQueueManager : public QObject {
+    Q_OBJECT
+private slots:
+    void initTestCase();
+    void cleanupTestCase();
+    void init();
+    void cleanup();
+
+    void testAddRemoveDatabase();
+    void testPauseResume();
+    void testGetQueueStats();
+    void testCheckQueueIsPaused();
+    void testEndpointDownPreventsProcessing();
+    void testMaxConcurrentLimits();
+
+private:
+    std::shared_ptr<BookDatabase> m_db;
+    QString m_testDbPath;
+};
+
+void TestQueueManager::initTestCase() {
+    QCoreApplication::setOrganizationName("arran4_test");
+    QCoreApplication::setApplicationName("kllamabooks_test");
+}
+
+void TestQueueManager::cleanupTestCase() {
+}
+
+void TestQueueManager::init() {
+    m_testDbPath = QDir::tempPath() + "/test_queue_manager.db";
+    QFile::remove(m_testDbPath);
+    m_db = std::make_shared<BookDatabase>(m_testDbPath);
+    m_db->open("test_password");
+    m_db->initSchema();
+}
+
+void TestQueueManager::cleanup() {
+    if (m_db) {
+        m_db->close();
+    }
+    QFile::remove(m_testDbPath);
+}
+
+void TestQueueManager::testAddRemoveDatabase() {
+    QueueManager& qm = QueueManager::instance();
+    int initialCount = qm.databases().count();
+
+    qm.addDatabase(m_db);
+    QCOMPARE(qm.databases().count(), initialCount + 1);
+    QVERIFY(qm.databases().contains(m_db));
+
+    qm.removeDatabase(m_db);
+    QCOMPARE(qm.databases().count(), initialCount);
+    QVERIFY(!qm.databases().contains(m_db));
+}
+
+void TestQueueManager::testPauseResume() {
+    QueueManager& qm = QueueManager::instance();
+    qm.pauseQueue();
+    QVERIFY(qm.isPaused());
+
+    qm.resumeQueue();
+    QVERIFY(!qm.isPaused());
+}
+
+void TestQueueManager::testGetQueueStats() {
+    QueueManager& qm = QueueManager::instance();
+    qm.addDatabase(m_db);
+
+    QueueManager::QueueStats stats = qm.getQueueStats();
+    QCOMPARE(stats.pending, 0);
+    QCOMPARE(stats.processing, 0);
+    QCOMPARE(stats.completed, 0);
+    QCOMPARE(stats.error, 0);
+
+    m_db->enqueuePrompt(1, "test_model", "test_prompt");
+
+    stats = qm.getQueueStats();
+    QCOMPARE(stats.pending, 1);
+
+    qm.removeDatabase(m_db);
+}
+
+void TestQueueManager::testCheckQueueIsPaused() {
+    QueueManager& qm = QueueManager::instance();
+    qm.addDatabase(m_db);
+
+    OllamaClient client;
+    qm.setClient(&client);
+
+    qm.pauseQueue();
+    m_db->enqueuePrompt(1, "test_model", "test_prompt");
+
+    qm.checkQueue();
+
+    QueueManager::QueueStats stats = qm.getQueueStats();
+    QCOMPARE(stats.pending, 1);
+    QCOMPARE(stats.processing, 0); // No items should move to processing since queue is paused
+
+    qm.resumeQueue();
+    qm.setClient(nullptr);
+    qm.removeDatabase(m_db);
+}
+
+void TestQueueManager::testEndpointDownPreventsProcessing() {
+    QueueManager& qm = QueueManager::instance();
+    qm.addDatabase(m_db);
+
+    OllamaClient client;
+    qm.setClient(&client);
+    qm.resumeQueue();
+
+    // Simulate endpoint going down
+    emit client.connectionStatusChanged(false);
+    QVERIFY(!qm.isEndpointUp());
+
+    m_db->enqueuePrompt(1, "test_model", "test_prompt");
+    qm.checkQueue();
+
+    QueueManager::QueueStats stats = qm.getQueueStats();
+    QCOMPARE(stats.pending, 1);
+    QCOMPARE(stats.processing, 0); // No items should process since endpoint is down
+
+    // Simulate endpoint coming up, checkQueue is called automatically via signal
+    emit client.connectionStatusChanged(true);
+    QVERIFY(qm.isEndpointUp());
+
+    stats = qm.getQueueStats();
+
+    qm.setClient(nullptr);
+    qm.removeDatabase(m_db);
+}
+
+void TestQueueManager::testMaxConcurrentLimits() {
+    QueueManager& qm = QueueManager::instance();
+    qm.setMaxConcurrent(3);
+    QCOMPARE(qm.maxConcurrent(), 3);
+}
+
+QTEST_MAIN(TestQueueManager)
+#include "test_QueueManager.moc"


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The QueueManager class lacked unit tests, making refactoring risky due to its complex interactions with threading, timers, and external endpoints.

📊 **Coverage:** What scenarios are now tested
- Database management: `testAddRemoveDatabase` verifies that databases can be dynamically added and removed from the active queue.
- State control: `testPauseResume` and `testCheckQueueIsPaused` ensure that the queue's processing state respects pause and resume requests without triggering side effects.
- Analytics: `testGetQueueStats` validates that correct pending, processing, and completed counts are aggregated correctly.
- Endpoint robustness: `testEndpointDownPreventsProcessing` asserts that queue items are suspended and not processed when the active endpoint (e.g. Ollama daemon) disconnects.
- Concurrency limits: `testMaxConcurrentLimits` validates that `setMaxConcurrent` successfully limits concurrent request execution.

✨ **Result:** The improvement in test coverage
We now have an automated safety net for the fundamental dispatching logic of QueueManager, ensuring greater confidence when modifying its architecture or scheduling algorithms.

---
*PR created automatically by Jules for task [6021926334189969573](https://jules.google.com/task/6021926334189969573) started by @arran4*