### PR TITLE
⚡ perf: Delay unnecessary wallet password loading on open books

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2212,8 +2212,6 @@ void MainWindow::onBookSelected(const QModelIndex& index) {
     QString fileName = bookList->item(index.row())->text();
     QString filePath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/" + fileName;
 
-    QString password = WalletManager::loadPassword(fileName);
-
     if (m_openDatabases.contains(fileName)) {
         currentDb = m_openDatabases[fileName];
         QueueManager::instance().setActiveDatabase(currentDb);
@@ -2226,6 +2224,7 @@ void MainWindow::onBookSelected(const QModelIndex& index) {
         }
         return;
     } else {
+        QString password = WalletManager::loadPassword(fileName);
         auto db = std::make_shared<BookDatabase>(filePath);
         if (!db->open(password)) {
             PasswordDialog dialog("Unlock Book", "Enter password for " + fileName + ":", this);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2223,30 +2223,30 @@ void MainWindow::onBookSelected(const QModelIndex& index) {
             }
         }
         return;
-    } else {
-        QString password = WalletManager::loadPassword(fileName);
-        auto db = std::make_shared<BookDatabase>(filePath);
-        if (!db->open(password)) {
-            PasswordDialog dialog("Unlock Book", "Enter password for " + fileName + ":", this);
-            if (dialog.exec() == QDialog::Accepted) {
-                password = dialog.password();
-                if (db->open(password)) {
-                    if (!password.isEmpty() && dialog.saveToWallet()) {
-                        WalletManager::savePassword(fileName, password);
-                    }
-                } else {
-                    QMessageBox::warning(this, "Error", "Could not open book.");
-                    return;
+    }
+
+    QString password = WalletManager::loadPassword(fileName);
+    auto db = std::make_shared<BookDatabase>(filePath);
+    if (!db->open(password)) {
+        PasswordDialog dialog("Unlock Book", "Enter password for " + fileName + ":", this);
+        if (dialog.exec() == QDialog::Accepted) {
+            password = dialog.password();
+            if (db->open(password)) {
+                if (!password.isEmpty() && dialog.saveToWallet()) {
+                    WalletManager::savePassword(fileName, password);
                 }
             } else {
                 QMessageBox::warning(this, "Error", "Could not open book.");
                 return;
             }
+        } else {
+            QMessageBox::warning(this, "Error", "Could not open book.");
+            return;
         }
-        m_openDatabases[fileName] = db;
-        currentDb = db;
-        QueueManager::instance().addDatabase(db);
     }
+    m_openDatabases[fileName] = db;
+    currentDb = db;
+    QueueManager::instance().addDatabase(db);
 
     QueueManager::instance().setActiveDatabase(currentDb);
 


### PR DESCRIPTION
💡 **What:** Moved the `WalletManager::loadPassword(fileName)` call in `MainWindow::onBookSelected` out of the unconditional scope and into the `else` block where a new `BookDatabase` instance is actually created.
🎯 **Why:** Loading a password from KWallet involves synchronous, blocking DBus/I/O operations. Doing this on every click for a database that is already loaded and decrypted introduces unnecessary UI latency and CPU/IO overhead.
📊 **Measured Improvement:** Because the local sandbox lacks KDE Framework dependencies, we cannot run a localized benchmark. However, we have eliminated a blocking OS-level inter-process communication (DBus to KWallet daemon) lookup on the hot path for switching between already-open books, resulting in a strict performance and responsiveness upgrade.

---
*PR created automatically by Jules for task [14453130813188861314](https://jules.google.com/task/14453130813188861314) started by @arran4*