### PR TITLE
Fix incorrect generic use of '*Generating merge...*' placeholder

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -64,9 +64,18 @@
 #include "QueueWindow.h"
 #include "WalletManager.h"
 
-static const QString GENERATING_MERGE_TEXT = QStringLiteral("*Generating merge...*");
-static const QString GENERATING_DOC_TEXT = QStringLiteral("*Generating document...*");
-static const QString REGENERATING_TEXT = QStringLiteral("*Regenerating...*");
+const QString MainWindow::GENERATING_MERGE_TEXT = QStringLiteral("*Generating merge...*");
+const QString MainWindow::GENERATING_DOC_TEXT = QStringLiteral("*Generating document...*");
+const QString MainWindow::REGENERATING_TEXT = QStringLiteral("*Regenerating...*");
+
+QString MainWindow::getGenerationPlaceholderText(int existingDocId, int numSourceDocuments) {
+    if (existingDocId > 0) {
+        return REGENERATING_TEXT;
+    } else if (numSourceDocuments <= 1) {
+        return GENERATING_DOC_TEXT;
+    }
+    return GENERATING_MERGE_TEXT;
+}
 
 CustomItemModel::CustomItemModel(QObject* parent) : QStandardItemModel(parent), m_mainWindow(nullptr) {}
 
@@ -5348,12 +5357,7 @@ void MainWindow::processMergeGeneration(const QString& finalPrompt, const QStrin
     QString firstModel = selectedModels.first();
     int currentDocIdToUpdate = existingDocId;
 
-    QString generationText = GENERATING_MERGE_TEXT;
-    if (existingDocId > 0) {
-        generationText = REGENERATING_TEXT;
-    } else if (sourceDocumentIds.size() <= 1) {
-        generationText = GENERATING_DOC_TEXT;
-    }
+    QString generationText = getGenerationPlaceholderText(existingDocId, sourceDocumentIds.size());
 
     if (existingDocId > 0) {
         auto docOpt = currentDb->getDocument(existingDocId);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -5348,6 +5348,13 @@ void MainWindow::processMergeGeneration(const QString& finalPrompt, const QStrin
     QString firstModel = selectedModels.first();
     int currentDocIdToUpdate = existingDocId;
 
+    QString generationText = GENERATING_MERGE_TEXT;
+    if (existingDocId > 0) {
+        generationText = REGENERATING_TEXT;
+    } else if (sourceDocumentIds.size() <= 1) {
+        generationText = GENERATING_DOC_TEXT;
+    }
+
     if (existingDocId > 0) {
         auto docOpt = currentDb->getDocument(existingDocId);
         if (docOpt) {
@@ -5387,7 +5394,7 @@ void MainWindow::processMergeGeneration(const QString& finalPrompt, const QStrin
         }
         int newDocId = currentDb->addDocument(targetFolderId,
                                               selectedModels.size() > 1 ? baseTitle + " - " + firstModel : baseTitle,
-                                              GENERATING_MERGE_TEXT, 0, metaStr);
+                                              generationText, 0, metaStr);
         currentDb->addDocumentMerge(newDocId, sourceIdsStr, finalPrompt, firstModel, 0);
         currentDb->enqueuePrompt(newDocId, firstModel, finalPrompt, 0, "document", 0, "replace_direct");
     }
@@ -5396,7 +5403,7 @@ void MainWindow::processMergeGeneration(const QString& finalPrompt, const QStrin
     for (int i = 1; i < selectedModels.size(); ++i) {
         QString model = selectedModels[i];
         int newDocId =
-            currentDb->addDocument(targetFolderId, baseTitle + " - " + model, GENERATING_MERGE_TEXT, 0, metaStr);
+            currentDb->addDocument(targetFolderId, baseTitle + " - " + model, generationText, 0, metaStr);
         currentDb->addDocumentMerge(newDocId, sourceIdsStr, finalPrompt, model, 0);
         currentDb->enqueuePrompt(newDocId, model, finalPrompt, 0, "document", 0, "replace_direct");
     }
@@ -5690,8 +5697,7 @@ void MainWindow::updateRegenerateButtonVisibility(const DocumentNode& doc, const
         if (hasMerge || hasPrompt) {
             if (hasMerge) showSources = true;
             bool isGenerating = currentDb->isGenerating(doc.id, "document", "replace_direct");
-            if (!isGenerating && !doc.content.contains(GENERATING_MERGE_TEXT) &&
-                !doc.content.contains(GENERATING_DOC_TEXT) && !doc.content.contains(REGENERATING_TEXT)) {
+            if (!isGenerating) {
                 showRegenerate = true;
             }
         }

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -55,6 +55,12 @@ class CustomItemModel : public QStandardItemModel {
 class MainWindow : public KXmlGuiWindow {
     Q_OBJECT
    public:
+    static const QString GENERATING_MERGE_TEXT;
+    static const QString GENERATING_DOC_TEXT;
+    static const QString REGENERATING_TEXT;
+
+    static QString getGenerationPlaceholderText(int existingDocId, int numSourceDocuments);
+
     explicit MainWindow(QWidget* parent = nullptr);
     ~MainWindow();
     void getDocumentContent(int id, const QString& type, QString& outTitle, QString& outContent);


### PR DESCRIPTION
This commit resolves the issue where the program used `*Generating merge...*` as the generic text for all AI document generation tasks, including regular single-document regenerations. It also removes a brittle string match that prevented the "Regenerate" button from appearing when an AI generation failed and left placeholder text behind.

---
*PR created automatically by Jules for task [5769859406307494008](https://jules.google.com/task/5769859406307494008) started by @arran4*