### PR TITLE
Fix flatpak build by adding tcl build dependency

### DIFF
--- a/packaging/flatpak/com.arran4.kllamabooks.yaml
+++ b/packaging/flatpak/com.arran4.kllamabooks.yaml
@@ -11,6 +11,15 @@ finish-args:
   - --share=network
   - --socket=session-bus
 modules:
+  - name: tcl
+    buildsystem: autotools
+    subdir: unix
+    cleanup:
+      - '*'
+    sources:
+      - type: archive
+        url: https://prdownloads.sourceforge.net/tcl/tcl8.6.13-src.tar.gz
+        sha256: 43a1fae7412f61ff11de2cfd05d28cfc3a73762f354a417c62370a54e2caf066
   - name: sqlcipher
     buildsystem: autotools
     config-opts:

--- a/packaging/flatpak/com.arran4.kllamabooks.yaml
+++ b/packaging/flatpak/com.arran4.kllamabooks.yaml
@@ -3,6 +3,12 @@ runtime: org.kde.Platform
 runtime-version: '6.6'
 sdk: org.kde.Sdk
 command: kllamabooks
+cleanup:
+  - /bin/tclsh*
+  - /lib/libtcl*
+  - /include/tcl*
+  - /share/man/man*/tcl*
+  - /share/man/man*/*Tcl*
 finish-args:
   - --share=ipc
   - --socket=fallback-x11
@@ -14,8 +20,6 @@ modules:
   - name: tcl
     buildsystem: autotools
     subdir: unix
-    cleanup:
-      - '*'
     sources:
       - type: archive
         url: https://prdownloads.sourceforge.net/tcl/tcl8.6.13-src.tar.gz


### PR DESCRIPTION
Fixes the flatpak build for com.arran4.kllamabooks by satisfying the build-time dependency for sqlcipher on `tclsh`.

---
*PR created automatically by Jules for task [11683257776127702438](https://jules.google.com/task/11683257776127702438) started by @arran4*